### PR TITLE
Sentry integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 - Basic application structure and configuration (@mkasztelnik)
 - Service model, simple index and show pages integrated with elasticsearch (@mkasztelnik)
+- Sentry integration (@mkasztelnik)
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,7 @@ group :test do
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+group :production do
+  gem "sentry-raven"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sentry-raven (2.7.3)
+      faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.11.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
@@ -360,6 +362,7 @@ DEPENDENCIES
   rspec-rails (~> 3.7)
   rubocop-rails
   sass-rails (~> 5.0)
+  sentry-raven
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -63,3 +63,10 @@ css/js files change) use following command:
 ```
 
 By default application should start on [http://localhost:5000]()
+
+## Sentry integration
+
+In production environment sentry integration can be turned on. To do so create
+dedicated env variable `SENTRY_DSN` with details how to connect to sentry
+server. Sentry environment can also be configured using `SENTRY_ENVIRONMENT`
+env variable (default set to `production`).

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,5 @@ require "turbolinks"
 
 class ApplicationController < ActionController::Base
   include Turbolinks::Redirection
+  include Sentryable
 end

--- a/app/controllers/concerns/sentryable.rb
+++ b/app/controllers/concerns/sentryable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Sentryable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_raven_context, if: :sentry_enabled?
+  end
+
+  private
+
+    def set_raven_context
+      if current_user
+        Raven.user_context(id: current_user.id,
+                          email: current_user.email,
+                          username: current_user.full_name)
+      end
+      Raven.extra_context(params: params.permit!.to_h, url: request.url)
+    end
+
+    def sentry_enabled?
+      Rails.env.production?
+    end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+if Rails.env.production? && ENV["SENTRY_DSN"]
+  require "raven"
+
+  Raven.configure do |config|
+    config.dsn = ENV["SENTRY_DSN"]
+    config.environments = [ENV["SENTRY_ENVIRONMENT"] || "production"]
+    config.sanitize_fields =
+      Rails.application.config.filter_parameters.map(&:to_s)
+  end
+end


### PR DESCRIPTION
Sentry integration will help us trace bugs in both production and staging environments. Sentry integration can be turned on **only** in production environemtn by setting `SENTRY_DSN` env variable with details how to connect to sentry server. Additionally `SENTRY_ENVIRONMENT` can be set to customize entvironment errors will be reported (default set to `production`).