### PR TITLE
Remove default session devise routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Deprecated
 
 ### Removed
+- Remove default devise session routes, only logout remain (@mkasztelnik)
 
 ### Fixed
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@
 
 Rails.application.routes.draw do
   devise_for :users,
-             controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
+             controllers: { omniauth_callbacks: "users/omniauth_callbacks" },
+             skip: [:sessions]
+  as :user do
+    delete "users/logout", to: "devise/sessions#destroy", as: :destroy_user_session
+  end
 
   resources :services, only: [:index, :show]
 


### PR DESCRIPTION
Since marketplace will be 100% based on external IDP (configured using omniauth) no session related URLs should be defined. Here session routes are removed, only logout option remains.