### PR TITLE
Service categories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+   TargetRubyVersion: 2.5
+
 inherit_gem:
   rubocop-rails:
     - config/rails.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Service model, simple index and show pages integrated with elasticsearch (@mkasztelnik)
 - Sentry integration (@mkasztelnik)
 - Profile page with basic info and unauthenticated user redirection (@martaswiatkowska @jswk)
+- Service categories (@mkasztelnik)
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "turbolinks", "~> 5", require: false
 
 gem "bootsnap", ">= 1.1.0", require: false
 
+gem "ancestry"
 gem "gretel"
 gem "will_paginate", "~> 3.1.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     aes_key_wrap (1.0.1)
+    ancestry (3.0.2)
+      activerecord (>= 3.2.0)
     arel (9.0.0)
     ast (2.4.0)
     attr_required (1.0.1)
@@ -338,6 +340,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ancestry
   bootsnap (>= 1.1.0)
   byebug
   capybara

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CategoriesController < ApplicationController
+  include Service::Searchable
+
+  before_action :category
+
+  def show
+    @services = records.joins(:service_categories).
+      where(service_categories: { category_id: category_and_descendant_ids }).
+      page(params[:page])
+    @subcategories = category.children
+  end
+
+  private
+
+    def category_and_descendant_ids
+      [category] + category.descendant_ids
+    end
+
+    def category
+      @category ||= Category.find(params[:id])
+    end
+end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Service::Searchable
+  extend ActiveSupport::Concern
+
+  private
+
+    def records
+      params[:q].blank? ? Service.all : Service.where(id: search_ids)
+    end
+
+    def search_ids
+      Service.search(params[:q]).records.ids
+    end
+end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,21 +1,14 @@
 # frozen_string_literal: true
 
 class ServicesController < ApplicationController
+  include Service::Searchable
+
   def index
     @services = records.page(params[:page])
+    @subcategories = Category.roots
   end
 
   def show
     @service = Service.find(params[:id])
   end
-
-  private
-
-    def records
-      params[:q].blank? ? Service.all : Service.where(id: search_ids)
-    end
-
-    def search_ids
-      Service.search(params[:q]).records.ids
-    end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Category < ApplicationRecord
+  has_ancestry
+
+  validates :name, presence: true
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,5 +3,8 @@
 class Category < ApplicationRecord
   has_ancestry
 
+  has_many :service_categories, autosave: true, dependent: :destroy
+  has_many :services, through: :service_categories
+
   validates :name, presence: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,8 +3,28 @@
 class Category < ApplicationRecord
   has_ancestry
 
+  # This callback need to be defined byfore dependent: :destroy
+  # relation, because in this case order matter. This callback need to be
+  # invoked before destroying related service categories to find affected
+  # services.
+  before_destroy :store_affected_services
+
   has_many :service_categories, autosave: true, dependent: :destroy
   has_many :services, through: :service_categories
 
   validates :name, presence: true
+
+  after_destroy :update_main_categories!
+
+  private
+
+    def store_affected_services
+      # neet do store results in array since relation is lazy evaluated
+      @main_services = Service.joins(:service_categories).
+        where(service_categories: { category: self, main: true }).to_a
+    end
+
+    def update_main_categories!
+      @main_services.each { |s| s.set_first_category_as_main! }
+    end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,6 +6,26 @@ class Service < ApplicationRecord
   include Elasticsearch::Model
   include Elasticsearch::Model::Callbacks
 
+  has_many :service_categories, dependent: :destroy
+  has_many :categories, through: :service_categories
+
   validates :title, presence: true
   validates :description, presence: true
+
+  after_save :set_main_category, if: :main_category_missing?
+
+  def main_category
+    @main_category ||= categories.joins(:service_categories).
+                                  find_by(service_categories: { main: true })
+  end
+
+  private
+
+    def main_category_missing?
+      service_categories.where(main: true).count.zero?
+    end
+
+    def set_main_category
+      service_categories.first&.update_attributes(main: true)
+    end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,20 +12,20 @@ class Service < ApplicationRecord
   validates :title, presence: true
   validates :description, presence: true
 
-  after_save :set_main_category, if: :main_category_missing?
+  after_save :set_first_category_as_main!, if: :main_category_missing?
 
   def main_category
     @main_category ||= categories.joins(:service_categories).
                                   find_by(service_categories: { main: true })
   end
 
+  def set_first_category_as_main!
+    service_categories.first&.update_attributes(main: true)
+  end
+
   private
 
     def main_category_missing?
       service_categories.where(main: true).count.zero?
-    end
-
-    def set_main_category
-      service_categories.first&.update_attributes(main: true)
     end
 end

--- a/app/models/service_category.rb
+++ b/app/models/service_category.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ServiceCategory < ApplicationRecord
+  belongs_to :service
+  belongs_to :category
+
+  validates :service, presence: true
+  validates :category, presence: true
+
+  after_save :guarantee_only_one_main
+
+  private
+
+    def guarantee_only_one_main
+      ServiceCategory.where(service: service).
+                      where.not(id: id).
+                      update(main: false)
+    end
+end

--- a/app/views/categories/_subcategories.html.haml
+++ b/app/views/categories/_subcategories.html.haml
@@ -1,0 +1,4 @@
+- unless subcategories.empty?
+  %h5 Subcategories
+  %ul
+    = render partial: "categories/subcategory", collection: subcategories

--- a/app/views/categories/_subcategory.html.haml
+++ b/app/views/categories/_subcategory.html.haml
@@ -1,0 +1,1 @@
+%li= link_to subcategory.name, category_path(subcategory)

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,0 +1,9 @@
+- breadcrumb :category, @category
+
+.container-fluid
+  .row
+    .col-1
+      = render "subcategories", subcategories: @subcategories
+    .col-11
+      %h2= @category.name
+      = render "services/services", services: @services

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -12,7 +12,7 @@
     %ul.navbar-nav.ml-auto
       = nav_link controller: :home do
         = link_to "Getting Started", root_path, class: "nav-link"
-      = nav_link controller: :services do
+      = nav_link controller: [:services, :categories] do
         = link_to "Services", services_path, class: "nav-link"
       %li.nav-item
         = link_to "Data", root_path, class: "nav-link"

--- a/app/views/services/_left_menu.html.haml
+++ b/app/views/services/_left_menu.html.haml
@@ -1,1 +1,0 @@
-Left menu

--- a/app/views/services/_services.html.haml
+++ b/app/views/services/_services.html.haml
@@ -1,0 +1,4 @@
+%dl
+  = render services
+= will_paginate services
+

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -3,13 +3,11 @@
 .container-float
   .row
     .col-md-1
-      = render 'left_menu'
+      = render "categories/subcategories", subcategories: @subcategories
     .col-md-11
       %h2 Services
       %p
         Service description. When category is selected than title and this
         description shoud reflect it.
       %hr/
-      %dl
-        = render @services
-      = will_paginate @services
+      = render "services", services: @services

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -22,7 +22,7 @@ crumb :service do |service|
 end
 
 crumb :category do |category|
-  link category.name, root_path
+  link category.name, category_path(category)
   if category.parent
     parent category.parent
   else

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -14,5 +14,18 @@ end
 
 crumb :service do |service|
   link service.title, service_path(service)
-  parent :services
+  if service.main_category
+    parent :category, service.main_category
+  else
+    parent :services
+  end
+end
+
+crumb :category do |category|
+  link category.name, root_path
+  if category.parent
+    parent category.parent
+  else
+    parent :services
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   end
 
   resources :services, only: [:index, :show]
+  resources :categories, only: :show
 
   resource :profile, only: [:show]
 

--- a/db/migrate/20180607103156_create_categories.rb
+++ b/db/migrate/20180607103156_create_categories.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false, index: true
+      t.string :description, index: true
+      t.string :ancestry, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180607105149_create_service_categories.rb
+++ b/db/migrate/20180607105149_create_service_categories.rb
@@ -1,0 +1,11 @@
+class CreateServiceCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :service_categories do |t|
+      t.belongs_to :service, index: true
+      t.belongs_to :category, index: true
+      t.boolean :main, null: false, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_25_115028) do
+ActiveRecord::Schema.define(version: 2018_06_07_105149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "description"
+    t.string "ancestry"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ancestry"], name: "index_categories_on_ancestry"
+    t.index ["description"], name: "index_categories_on_description"
+    t.index ["name"], name: "index_categories_on_name"
+  end
 
   create_table "services", force: :cascade do |t|
     t.string "title", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,13 +17,21 @@ ActiveRecord::Schema.define(version: 2018_06_07_105149) do
 
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
-    t.string "description"
     t.string "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["ancestry"], name: "index_categories_on_ancestry"
-    t.index ["description"], name: "index_categories_on_description"
     t.index ["name"], name: "index_categories_on_name"
+  end
+
+  create_table "service_categories", force: :cascade do |t|
+    t.bigint "service_id"
+    t.bigint "category_id"
+    t.boolean "main", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_service_categories_on_category_id"
+    t.index ["service_id"], name: "index_service_categories_on_service_id"
   end
 
   create_table "services", force: :cascade do |t|

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -6,14 +6,24 @@ if Rails.env.development?
   namespace :dev do
     desc "Sample data for local development environment"
     task :prime, [:services_size] => "db:setup" do |task, args|
-      puts "Cleaning all services"
+      puts "Cleaning all services and categories"
       Service.destroy_all
+      Category.destroy_all
+
+      puts "Generating categories"
+      all_categories = []
+      computing = Category.create(name: "Computing")
+      all_categories << computing
+      all_categories << Category.create(name: "HPC", parent: computing)
+      all_categories << Category.create(name: "Cloud", parent: computing)
+      all_categories << Category.create(name: "Data")
 
       services_size = args.fetch(:services_size, 100)
       puts "Generating #{services_size} new services"
       services_size.times do
         Service.create(title: Faker::Lorem.sentence,
-                       description: Faker::Lorem.paragraph)
+                       description: Faker::Lorem.paragraph,
+                       categories: [all_categories.sample])
       end
 
       puts "Done!"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "category #{n}" }
+    sequence(:description) { |n| "category #{n} description" }
+  end
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -3,6 +3,5 @@
 FactoryBot.define do
   factory :category do
     sequence(:name) { |n| "category #{n}" }
-    sequence(:description) { |n| "category #{n} description" }
   end
 end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :service do
+    sequence(:title) { |n| "service #{n}" }
+    sequence(:description) { |n| "service #{n} description" }
+  end
+end

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Service categories" do
+  include OmniauthHelper
+
+  let(:user) { create(:user) }
+
+  before { checkin_sign_in_as(user) }
+
+  scenario "service list shows root categories" do
+    root1, root2 = create_list(:category, 2)
+    sub_category = create(:category, parent: root1)
+
+    visit services_path
+
+    expect(page.body).to have_content root1.name
+    expect(page.body).to have_content root2.name
+    expect(page.body).to_not have_content sub_category.name
+  end
+
+  scenario "are hirearchical" do
+    root = create(:category)
+    sub_category1, sub_category2 = create_list(:category, 2, parent: root)
+    sub_sub_category = create(:category, parent: sub_category1)
+
+    visit category_path(root)
+
+    expect(page.body).to have_content sub_category1.name
+    expect(page.body).to have_content sub_category2.name
+    expect(page.body).to_not have_content sub_sub_category.name
+  end
+
+  scenario "subcategories section is not show when no subcategories" do
+    category = create(:category)
+
+    visit category_path(category)
+
+    expect(page.body).to_not have_content "Subcategories"
+  end
+
+  scenario "shows services from category and subcategories" do
+    root1, root2 = create_list(:category, 2)
+    sub = create(:category, parent: root1)
+    subsub = create(:category, parent: sub)
+
+    s1 = create(:service, categories: [root1])
+    s2 = create(:service, categories: [sub])
+    s3 = create(:service, categories: [subsub])
+    other_service = create(:service, categories: [root2])
+
+    visit category_path(root1)
+
+    expect(page.body).to have_content s1.title
+    expect(page.body).to have_content s2.title
+    expect(page.body).to have_content s3.title
+    expect(page.body).to_not have_content other_service.title
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Category do
+  it { should validate_presence_of(:name) }
+
+  it "is hierarchical" do
+    category = create(:category)
+    subcategory = create(:category, parent: category)
+
+    expect(subcategory.parent).to eq(category)
+    expect(category.children).to include(subcategory)
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe Category do
     expect(subcategory.parent).to eq(category)
     expect(category.children).to include(subcategory)
   end
+
+  it "updates main service category when previous main is destroyed" do
+    main, other = create_list(:category, 2)
+    service = create(:service, categories: [main, other])
+
+    main.destroy
+
+    expect(service.main_category).to eq(other)
+  end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -5,4 +5,29 @@ require "rails_helper"
 RSpec.describe Service do
   it { should validate_presence_of(:title) }
   it { should validate_presence_of(:description) }
+
+  it "sets first category as default" do
+    c1, c2 = create_list(:category, 2)
+    service = create(:service, categories: [c1, c2])
+
+    expect(service.service_categories.first.main).to be_truthy
+    expect(service.service_categories.second.main).to be_falsy
+  end
+
+  it "allows to have only one main category" do
+    c1, c2 = create_list(:category, 2)
+    service = create(:service, categories: [c1])
+
+    service.service_categories.create(category: c2, main: true)
+    old_main = service.service_categories.find_by(category: c1)
+
+    expect(old_main.main).to be_falsy
+  end
+
+  it "has main category" do
+    main, other = create_list(:category, 2)
+    service = create(:service, categories: [main, other])
+
+    expect(service.main_category).to eq(main)
+  end
 end


### PR DESCRIPTION
This is initial categories implementation for services. Each service can belong to one or many categories but only one category is the main category. It is used to render breadcrumbs. 

There is logic for updating the main category after the category is destroyed or service is created. There are also dedicated `/categories/:id` routes and view to show services only from given category.