### PR TITLE
Add missing has_many orders into user and service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -8,6 +8,7 @@ class Service < ApplicationRecord
 
   has_many :service_categories, dependent: :destroy
   has_many :categories, through: :service_categories
+  has_many :orders
 
   validates :title, presence: true
   validates :description, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :rememberable, :trackable, :validatable,
          :omniauthable, omniauth_providers: %i[checkin]
 
+  has_many :orders, dependent: :destroy
+
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Service do
   it { should validate_presence_of(:title) }
   it { should validate_presence_of(:description) }
 
+  it { should have_many(:service_categories).dependent(:destroy) }
+  it { should have_many(:categories) }
+  it { should have_many(:orders) }
+
   it "sets first category as default" do
     c1, c2 = create_list(:category, 2)
     service = create(:service, categories: [c1, c2])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe User do
   it { should validate_presence_of(:email) }
   it { should validate_presence_of(:uid) }
 
+  it { should have_many(:orders).dependent(:destroy) }
+
   context "#full_name" do
     it "is composed from first and last name" do
       user = build(:user, first_name: "John", last_name: "Rambo")


### PR DESCRIPTION
Relations were added in DB and `belongs_to` relation was defined. Unfortunately, I forgot to add `has_many` to the second relation site (this traversing is not used yet but can be useful in the future and it is good to define what will happen when service or user will be deleted from the system).

Deletion of the user or service is something we need to discuss further - should we allow to do this or some kind of soft deletion technique (by using e.g [discard](https://github.com/jhawthorn/discard))