### PR TITLE
User can ask question about active order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Configure `database_cleaner` for rspec (@mkasztelnik)
 - Service terms of use with markdown renderer (@mkasztelnik)
 - Send email to order owner when order is created or updated (@mkasztelnik)
+- User can ask about processed order (@mkasztelnik)
 
 ### Changed
 

--- a/app/controllers/orders/questions_controller.rb
+++ b/app/controllers/orders/questions_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Orders::QuestionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    redirect_to order_path(id: params[:order_id])
+  end
+
+  def create
+    @order = Order.find(params[:order_id])
+    @question = Order::Question.
+                new(permitted_attributes(Order::Question).
+                    merge(author: current_user, order: @order))
+
+    authorize(@question)
+
+    if Order::Question::Create.new(@question).call
+      redirect_to order_path(@order)
+    else
+      render "orders/show"
+    end
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -9,7 +9,10 @@ class OrdersController < ApplicationController
 
   def show
     @order = Order.joins(:user, :service).find(params[:id])
+
     authorize(@order)
+
+    @question = Order::Question.new(order: @order)
   end
 
   def create

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -2,7 +2,9 @@
 
 module OrdersHelper
   def status_change(previous, current)
-    if previous
+    if current.question?
+      "Order owner question"
+    elsif previous
       "Order changed from #{previous.status} to #{current.status}"
     else
       "Order #{current.status}"

--- a/app/jobs/order/register_question_job.rb
+++ b/app/jobs/order/register_question_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Order::RegisterQuestionJob < ApplicationJob
+  queue_as :orders
+
+  rescue_from(StandardError) do |exception|
+    # TODO: we need to define what to do when question registration in e.g.
+    #       JIRA fails. Maybe we should report this problem to Sentry and
+    #       do some manual intervantion?
+  end
+
+  def perform(question)
+    if question.question?
+      Order::RegisterQuestion.new(question.order, question.message).call
+    end
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -19,8 +19,13 @@ class Order < ApplicationRecord
   validates :user, presence: true
   validates :status, presence: true
 
-  def new_change(new_status, message)
-    order_changes.create(status: new_status, message: message)
-    update_attributes(status: new_status)
+  def new_change(status: nil, message: nil, author: nil)
+    # don't create change when there is not status and message given
+    return unless status || message
+
+    status ||= self.status
+
+    order_changes.create(status: status, message: message, author: author)
+    update_attributes(status: status)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -19,13 +19,22 @@ class Order < ApplicationRecord
   validates :user, presence: true
   validates :status, presence: true
 
+  def active?
+    !(ready? || rejected?)
+  end
+
   def new_change(status: nil, message: nil, author: nil)
     # don't create change when there is not status and message given
     return unless status || message
 
     status ||= self.status
 
-    order_changes.create(status: status, message: message, author: author)
-    update_attributes(status: status)
+    order_changes.create(status: status, message: message, author: author).tap do
+      update_attributes(status: status)
+    end
+  end
+
+  def to_s
+    "##{id}"
   end
 end

--- a/app/models/order/question.rb
+++ b/app/models/order/question.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Order::Question
+  include ActiveModel::Validations
+  include ActiveModel::Conversion
+  extend ActiveModel::Naming
+
+  attr_accessor :text, :author, :order
+
+  validates :text, presence: { message: "Question cannot be blank" }
+  validates :author, presence: true
+  validates :order, presence: true
+
+  def initialize(attributes = {})
+    attributes.each { |name, value| send("#{name}=", value) }
+  end
+
+  def persisted?
+    false
+  end
+end

--- a/app/models/order_change.rb
+++ b/app/models/order_change.rb
@@ -3,8 +3,15 @@
 class OrderChange < ApplicationRecord
   enum status: Order::STATUSES
 
-  belongs_to :order, dependent: :destroy
+  belongs_to :order
+  belongs_to :author,
+             class_name: "User",
+             optional: true
 
   validates :status, presence: true, unless: :message
   validates :message, presence: true, unless: :status
+
+  def question?
+    author == order.user
+  end
 end

--- a/app/policies/order/question_policy.rb
+++ b/app/policies/order/question_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Order::QuestionPolicy < ApplicationPolicy
+  def create?
+    record.order.active? && record.order.user == user
+  end
+
+  def permitted_attributes
+    [:text]
+  end
+end

--- a/app/services/order/create.rb
+++ b/app/services/order/create.rb
@@ -9,7 +9,7 @@ class Order::Create
     @order.created!
 
     if @order.save
-      @order.new_change(:created, "Order created")
+      @order.new_change(status: :created, message: "Order created")
       OrderMailer.created(@order).deliver_later
       Order::RegisterJob.perform_later(@order)
     end

--- a/app/services/order/question/create.rb
+++ b/app/services/order/question/create.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Order::Question::Create
+  def initialize(question)
+    @question = question
+  end
+
+  def call
+    if @question.valid?
+      order = @question.order
+      history_entry = order.new_change(message: @question.text,
+                                       author: @question.author)
+
+      if history_entry&.persisted?
+        Order::RegisterQuestionJob.perform_later(history_entry)
+        true
+      end
+    end
+  end
+end

--- a/app/services/order/register.rb
+++ b/app/services/order/register.rb
@@ -21,8 +21,8 @@ class Order::Register
     end
 
     def update_status!
-      @order.new_change(:registered,
-                        "Your order was registered in the order handling system")
+      @order.new_change(status: :registered,
+                        message: "Your order was registered in the order handling system")
       true
     end
 

--- a/app/services/order/register_question.rb
+++ b/app/services/order/register_question.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Order::RegisterQuestion
+  def initialize(order, question)
+    @order = order
+    @question = question
+  end
+
+  def call
+    # TODO: Jira integration. This method should throw error on errors which
+    #       can be connected with temporary jira issue. Than registration
+    #       process will be retired by delayed job.
+    puts <<-MSQ
+      REGISTER: #{@order.user.full_name} asks question about #{@order}:
+        "#{@question}"
+    MSQ
+  end
+end

--- a/app/views/orders/_order_change.html.haml
+++ b/app/views/orders/_order_change.html.haml
@@ -1,3 +1,9 @@
-%dt= status_change(previous, current)
-%dd= current.message
+- if current.question?
+  .card.text-white.bg-info
+    .card-header= status_change(previous, current)
+    .card-body= current.message
+- else
+  .card
+    .card-header= status_change(previous, current)
+    .card-body= current.message
 

--- a/app/views/orders/_order_changes.html.haml
+++ b/app/views/orders/_order_changes.html.haml
@@ -1,8 +1,9 @@
-%h3 Order changes
+%h3 Order history
 
 - if order_changes.count.positive?
-  %dl
-    = ([nil] + order_changes).each_cons(2) do |previous, current|
-      = render "order_change", previous: previous, current: current
+  = ([nil] + order_changes).each_cons(2) do |previous, current|
+    = render "orders/order_change", previous: previous, current: current
 - else
   %p No order changes yet
+
+= render "orders/question", order: order

--- a/app/views/orders/_question.html.haml
+++ b/app/views/orders/_question.html.haml
@@ -1,0 +1,9 @@
+- if policy(@question).create?
+  %hr/
+  %h4 Ask question about about your order
+
+  = form_for @question, url: order_questions_path(order) do |f|
+    - if @question.errors[:text].present?
+      .alert.alert-danger= @question.errors[:text]&.first
+    = f.text_area :text
+    %button{class: "btn btn-info", type: "submit"} Ask question

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -11,6 +11,8 @@
     Current status:
     = @order.status
 
-= render "order_changes", order_changes: @order.order_changes.to_a
+= render "orders/order_changes",
+         order_changes: @order.order_changes.to_a,
+         order: @order
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
 
   resources :services, only: [:index, :show]
   resources :categories, only: :show
-  resources :orders, only: [:index, :show, :create]
+  resources :orders, only: [:index, :show, :create] do
+    scope module: :orders do
+      resources :questions, only: [:index, :create]
+    end
+  end
 
   resource :profile, only: [:show]
 

--- a/db/migrate/20180622083036_add_author_to_order_change.rb
+++ b/db/migrate/20180622083036_add_author_to_order_change.rb
@@ -1,0 +1,6 @@
+class AddAuthorToOrderChange < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :order_changes, :author
+    add_foreign_key :order_changes, :users, column: :author_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_22_072458) do
+ActiveRecord::Schema.define(version: 2018_06_22_083036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 2018_06_22_072458) do
     t.bigint "order_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "author_id"
+    t.index ["author_id"], name: "index_order_changes_on_author_id"
     t.index ["order_id"], name: "index_order_changes_on_order_id"
   end
 
@@ -82,4 +84,5 @@ ActiveRecord::Schema.define(version: 2018_06_22_072458) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "order_changes", "users", column: "author_id"
 end

--- a/spec/factories/order_changes.rb
+++ b/spec/factories/order_changes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :order_change do
+    status :created
+    sequence(:message) { |n| "order change #{n} message" }
+    order
+  end
+end

--- a/spec/features/orders_spec.rb
+++ b/spec/features/orders_spec.rb
@@ -59,9 +59,9 @@ RSpec.feature "Service order" do
     scenario "I can see order change history" do
       order = create(:order, user: user, service: service)
 
-      order.new_change(:created, "Order created")
-      order.new_change(:registered, "Order registered")
-      order.new_change(:ready, "Order ready")
+      order.new_change(status: :created, message: "Order created")
+      order.new_change(status: :registered, message: "Order registered")
+      order.new_change(status: :ready, message: "Order ready")
 
       visit order_path(order)
 

--- a/spec/features/orders_spec.rb
+++ b/spec/features/orders_spec.rb
@@ -75,6 +75,25 @@ RSpec.feature "Service order" do
       expect(page).to have_text("Order changed from registered to ready")
       expect(page).to have_text("Order registered")
     end
+
+    scenario "I can ask question about my order" do
+      order = create(:order, user: user, service: service)
+
+      visit order_path(order)
+      fill_in "order_question_text", with: "This is my question"
+      click_button "Ask question"
+
+      expect(page).to have_text("This is my question")
+    end
+
+    scenario "question message is mandatory" do
+      order = create(:order, user: user, service: service)
+
+      visit order_path(order)
+      click_button "Ask question"
+
+      expect(page).to have_text("Question cannot be blank")
+    end
   end
 
   context "as anonymous user" do

--- a/spec/jobs/order/register_question_job_spec.rb
+++ b/spec/jobs/order/register_question_job_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order::RegisterQuestionJob do
+  let(:order_owner) { create(:user) }
+  let(:order) { create(:order, user: order_owner) }
+  let(:register_service) { instance_double(Order::RegisterQuestion) }
+
+  it "triggers registration process for order owner question" do
+    question = create(:order_change,
+                      message: "Question text",
+                      order: order, author: order_owner)
+
+    expect(Order::RegisterQuestion).to receive(:new).
+      with(order, "Question text").and_return(register_service)
+    expect(register_service).to receive(:call)
+
+    described_class.perform_now(question)
+  end
+
+  it "does nothing when change is not a question" do
+    question = create(:order_change,
+                      message: "State change",
+                      status: :registered,
+                      order: order)
+
+    expect(Order::RegisterQuestion).to_not receive(:new)
+
+    described_class.perform_now(question)
+  end
+end

--- a/spec/mailers/order_spec.rb
+++ b/spec/mailers/order_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe OrderMailer, type: :mailer do
   describe "order change" do
     it "notifies about order status change" do
       order = create(:order)
-      order.new_change(:created, "Order created")
-      order.new_change(:registered, "Order registered")
+      order.new_change(status: :created, message: "Order created")
+      order.new_change(status: :registered, message: "Order registered")
 
       mail = described_class.changed(order).deliver_now
       encoded_body = mail.body.encoded
@@ -37,8 +37,8 @@ RSpec.describe OrderMailer, type: :mailer do
 
     it "notifies about new order message" do
       order = create(:order)
-      order.new_change(:created, "Order created")
-      order.new_change(:created, "New message")
+      order.new_change(status: :created, message: "Order created")
+      order.new_change(status: :created, message: "New message")
 
       mail = described_class.changed(order).deliver_now
       encoded_body = mail.body.encoded

--- a/spec/models/order/question_spec.rb
+++ b/spec/models/order/question_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order::Question do
+  subject { Order::Question.new(text: "text", author: build(:user), order: build(:order)) }
+
+  it { should validate_presence_of(:text).with_message("Question cannot be blank") }
+  it { should validate_presence_of(:author) }
+  it { should validate_presence_of(:order) }
+end

--- a/spec/models/order_change_spec.rb
+++ b/spec/models/order_change_spec.rb
@@ -4,4 +4,31 @@ require "rails_helper"
 
 RSpec.describe OrderChange, type: :model do
   it { should belong_to(:order) }
+  it { should belong_to(:author) }
+
+  describe "#question?" do
+    it "is true when order change is created by order owner" do
+      owner = create(:user)
+      order = create(:order, user: owner)
+      order_change = create(:order_change, order: order, author: owner,
+                            message: "some question")
+
+      expect(order_change).to be_question
+    end
+
+    it "is false when there is not change author" do
+      order_change = create(:order_change, author: nil)
+
+      expect(order_change).to_not be_question
+    end
+
+    it "is false when change author is not order owner" do
+      owner = create(:user)
+      order = create(:order, user: owner)
+      order_change = create(:order_change, order: order, author: create(:user),
+                            message: "some question")
+
+      expect(order_change).to_not be_question
+    end
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Order do
   it { should have_many(:order_changes).dependent(:destroy) }
 
   describe "#new_change" do
-    it "it is not created when no message and status is given" do
+    it "change is not created when no message and status is given" do
       order = create(:order)
 
       expect { order.new_change }.to_not change { OrderChange.count }
@@ -48,6 +48,19 @@ RSpec.describe Order do
       order_change = order.order_changes.last
 
       expect(order_change.author).to eq(author)
+    end
+  end
+
+  describe "#active?" do
+    it "is true when processing is not done" do
+      expect(build(:order, status: :created)).to be_active
+      expect(build(:order, status: :registered)).to be_active
+      expect(build(:order, status: :in_progress)).to be_active
+    end
+
+    it "is false when processing is done" do
+      expect(build(:order, status: :ready)).to_not be_active
+      expect(build(:order, status: :rejected)).to_not be_active
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -11,14 +11,43 @@ RSpec.describe Order do
   it { should belong_to(:service) }
   it { should have_many(:order_changes).dependent(:destroy) }
 
-  it "change order state" do
-    order = create(:order, status: :created)
-    order.new_change(:registered, "Order registered")
+  describe "#new_change" do
+    it "it is not created when no message and status is given" do
+      order = create(:order)
 
-    order_change = order.order_changes.first
+      expect { order.new_change }.to_not change { OrderChange.count }
+    end
 
-    expect(order).to be_registered
-    expect(order_change).to be_registered
-    expect(order_change.message).to eq("Order registered")
+    it "change order status" do
+      order = create(:order, status: :created)
+
+      order.new_change(status: :registered, message: "Order registered")
+      order_change = order.order_changes.last
+
+      expect(order).to be_registered
+      expect(order_change).to be_registered
+      expect(order_change.message).to eq("Order registered")
+    end
+
+    it "does not change status when only message is given" do
+      order = create(:order, status: :created)
+
+      order.new_change(message: "some update")
+      order_change = order.order_changes.last
+
+      expect(order).to be_created
+      expect(order_change).to be_created
+      expect(order_change.message).to eq("some update")
+    end
+
+    it "set change author" do
+      order = create(:order, status: :created)
+      author = create(:user)
+
+      order.new_change(message: "update", author: author)
+      order_change = order.order_changes.last
+
+      expect(order_change.author).to eq(author)
+    end
   end
 end

--- a/spec/policies/order/question_policy_spec.rb
+++ b/spec/policies/order/question_policy_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order::QuestionPolicy do
+  let(:user) { create(:user) }
+  let(:question) { Order::Question.new(order: order) }
+
+  subject { described_class }
+
+
+  permissions :create? do
+    context "with active order" do
+      let(:order) { create(:order, user: user, status: :created) }
+
+      it "grants access for order owner when order is active" do
+        expect(subject).to permit(user, question)
+      end
+
+      it "denies access for others" do
+        expect(subject).to_not permit(build(:user), question)
+      end
+    end
+
+    context "with inactive order" do
+      let(:order) { create(:order, user: user, status: :ready) }
+
+      it "denies access even for order owner" do
+        expect(subject).to_not permit(user, question)
+      end
+    end
+  end
+end

--- a/spec/services/order/question/create_spec.rb
+++ b/spec/services/order/question/create_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order::Question::Create do
+  let(:order_owner) { create(:user) }
+  let(:order) { create(:order, user: order_owner) }
+
+  context "valid question" do
+    let(:question) do
+      Order::Question.new(author: order_owner,
+                          order: order, text: "Question text")
+    end
+
+    it "returns true" do
+      expect(described_class.new(question).call).to be_truthy
+    end
+
+    it "creates new order change" do
+      expect { described_class.new(question).call }.
+        to change { order.order_changes.count }.by(1)
+      last_history_entry = order.order_changes.last
+
+      expect(last_history_entry.message).to eq("Question text")
+      expect(last_history_entry.author).to eq(order_owner)
+    end
+
+    it "triggers question registration" do
+      described_class.new(question).call
+      last_history_entry = order.order_changes.last
+
+      expect(Order::RegisterQuestionJob).
+        to have_been_enqueued.with(last_history_entry)
+    end
+  end
+
+  context "invalid question" do
+    let(:question) do
+      Order::Question.new(author: order_owner,
+                          order: order, text: nil)
+    end
+
+    it "returns false" do
+      expect(described_class.new(question).call).to be_falsy
+    end
+
+    it "does not create new order change" do
+      expect { described_class.new(question).call }.
+        to_not change { order.order_changes.count }
+    end
+
+    it "does not triggers question registration" do
+      described_class.new(question).call
+
+      expect(Order::RegisterQuestionJob).
+        to_not have_been_enqueued
+    end
+  end
+end

--- a/spec/services/order/register_question_spec.rb
+++ b/spec/services/order/register_question_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order::RegisterQuestion do
+  pending "Specs should be added when service implementation will be done"
+end

--- a/spec/services/order/register_spec.rb
+++ b/spec/services/order/register_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Order::Register do
 
   it "sent email to order owner" do
     # order change email is sent only when there is more than 1 change
-    order.new_change(:created, "Order created")
+    order.new_change(status: :created, message: "Order created")
 
     expect { described_class.new(order).call }.
       to change { ActionMailer::Base.deliveries.count }.by(1)


### PR DESCRIPTION
This is an implementation of #45 user story, where the user can ask questions for active order. This implementation has a placeholder for 2 elements:
  1. question registration in JIRA (`Order::RegisterQuestion`)
  2. what to do when we failed to register question in JIRA. I propose to add sentry error. Than marketplace administrator will need to perform a manual intervention (`Order::RegisterQuestionJob`).

/cc @jswk, @michal-szostak, @martaswiatkowska: This is quite complex PR, which touches almost all application layers, thus is it worth to see how it was implemented. If possible I would like to present this PR next week.