### PR TITLE
Upgrade Sprockets gem to avoid CVE-2018-3760

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Send email to order owner when order is created or updated (@mkasztelnik)
 
 ### Changed
+- Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)
 
 ### Deprecated
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k for details