### PR TITLE
Fix asset production build

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
     "bootstrap": "^4.1.1",
     "jquery": "^3.3.1",
     "popper.js": "^1.14.3",
-    "stimulus": "^1.0.1"
-  },
-  "devDependencies": {
+    "stimulus": "^1.0.1",
     "@fortawesome/fontawesome": "^1.1.8",
     "@fortawesome/fontawesome-free-solid": "^5.0.13",
     "expose-loader": "^0.7.5",
-    "turbolinks": "^5.1.1",
+    "turbolinks": "^5.1.1"
+  },
+  "devDependencies": {
     "webpack-dev-server": "2.11.2"
   }
 }


### PR DESCRIPTION
Turn on es6 features for uglifier and move production required dependencies (e.g. fontawesome, bootstrap) into production dependencies section instead of devDependencies.