### PR TITLE
Introduced Service and Category seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Bootstrap JS and font awesome regular (@mszostak)
 - Add styling for services, improve global styles (@kosmidma)
 - User affiliations (@mkasztelnik)
+- Service and categories database seed
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ We will need:
   * After update run `/bin/update`. It will update dependencies, run db
     migrations and restart currently started application.
 
+### Running parametrized database seeds 
+While running `/bin/setup` rake will seed the database with important data. However seeds can 
+also be re-run with additional parameters allowing to specify e.g. number of services seeded
+to the database.
+ 
+Example use of the database seed:
+```
+rake db:seed services_size=100
+```
+
 ### Generating DB entries for development
 To simplify development `dev:prime` rake task is created. Right now it generates
 services with random title and description (this generation is done using

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,22 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+
+# Initial categories and services
+puts "Generating categories"
+all_categories = []
+computing = Category.create_with(name: "Computing").find_or_create_by(name: "Computing")
+all_categories << computing
+all_categories << Category.create_with(name: "HPC", parent: computing).find_or_create_by(name: "HPC")
+all_categories << Category.create_with(name: "Cloud", parent: computing).find_or_create_by(name: "Cloud")
+all_categories << Category.create_with(name: "Data").find_or_create_by(name: "Data")
+
+services_size = ENV["services_size"].to_i || 0
+puts "Generating #{services_size} new services"
+services_size.times do
+  Service.create(title: Faker::Lorem.sentence,
+                 description: Faker::Lorem.paragraph,
+                 terms_of_use: Faker::Lorem.paragraph,
+                 categories: [Category.all.sample])
+end


### PR DESCRIPTION
Introduced Service and Category database seeds. Updated readme and changelog. 

#### Running parametrized database seeds 
While running `/bin/setup` rake will seed the database with important data. However seeds can 
also be re-run with additional parameters allowing to specify e.g. number of services seeded
to the database.
 
Example use of the database seed:
```
rake db:seed services_size=100
```