### PR TITLE
[#61] HAML & SCSS validation to overcommit

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,12 @@
+linters:
+  ViewLength:
+    enabled: true
+    max: 150
+
+  LineLength:
+    enabled: true
+    max: 120
+
+  ClassesBeforeIds:
+    enabled: true
+    EnforcedStyle: 'id'

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -70,6 +70,13 @@ PreCommit:
   BundleCheck:
     enabled: true
 
+  HamlLint:
+    enabled: true
+    exclude: ['lib/**/*.haml']
+
+  ScssLint:
+    enabled: true
+
   RuboCop:
     enabled: true
     command: ['bin/bundle', 'exec', 'rubocop']

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,34 @@
+scss_files: 'app/**/*.scss'
+
+exclude: 'app/assets/stylesheets/plugins/**'
+
+linters:
+  BorderZero:
+    enabled: false
+
+  ChainedClasses:
+    enabled: false
+
+  Comment:
+    enabled: false
+
+  PropertySortOrder:
+    enabled: false
+
+  ImportantRule:
+    enabled: false
+
+  NestingDepth:
+    enabled: false
+
+  SelectorDepth:
+    enabled: false
+
+  LeadingZero:
+    style: include_zero
+
+  VendorPrefix:
+    enabled: false
+
+  Indentation:
+    width: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Service owner can manage owned services (@mkasztelnik)
 - Add rating for Service (@kmarszalek)
 - Add JIRA integration (marketplace to jira) (@michal-szostak)
+- Add HAML validation to overcommit via `haml-lint` (@michal-szostak)
+- Add SCSS validation to overcommit via `scss-lint` (@michal-szostak)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ group :development do
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "rubocop-rails", ">=1.5.0"
   gem "overcommit", require: false
+  gem "haml_lint", require: false
+  gem "scss_lint", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,12 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    haml_lint (0.28.0)
+      haml (>= 4.0, < 5.1)
+      rainbow
+      rake (>= 10, < 13)
+      rubocop (>= 0.50.0)
+      sysexits (~> 1.1)
     hashie (3.5.7)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
@@ -294,6 +300,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    scss_lint (0.57.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.5.5)
     sentry-raven (2.7.3)
       faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.11.0)
@@ -319,6 +328,7 @@ GEM
       activesupport (>= 3)
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
+    sysexits (1.2.0)
     temple (0.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
@@ -382,6 +392,7 @@ DEPENDENCIES
   github-markup
   gretel
   haml-rails
+  haml_lint
   jira-ruby
   listen (>= 3.0.5, < 3.2)
   omniauth
@@ -401,6 +412,7 @@ DEPENDENCIES
   rspec-rails (~> 3.7)
   rubocop-rails (>= 1.5.0)
   sass-rails (~> 5.0)
+  scss_lint
   sentry-raven
   shoulda-matchers
   simple_form

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -1,277 +1,324 @@
-body{
+@import 'variables';
+
+body {
   font-size: $font-size-sm;
-  margin-bottom: 0px !important;
+  margin-bottom: 0 !important;
 }
+
 *:focus {
   outline: none !important;
 }
-hr{
-  border-color:$body-color;
+
+hr {
+  border-color: $body-color;
   opacity: 0.2;
 }
-ul{
+
+ul {
   list-style: none;
   padding-left: 0;
   line-height: 1.5rem;
 }
-a{
-  &:hover{
+
+a {
+  &:hover {
     text-decoration: none;
     color: $body-color;
   }
 }
-.text-muted{
+
+.text-muted {
   color: $body-color !important;
 }
-h3{
+
+h3 {
   font-size: 1rem;
   font-weight: 600;
 }
-h5{
+
+h5 {
   font-weight: 600;
   text-transform: uppercase;
   font-size: $font-size-xxs;
-  &:after {
-    content: "";
+
+  &::after {
+    content: '';
     position: absolute;
     top: 22px;
     border-top: 1px solid $body-color;
     width: 90%;
     height: 12px;
-    left:15px;
+    left: 15px;
     z-index: 8;
     opacity: 0.2;
   }
 }
-button, a{
-  &:hover{
+
+//scss-lint:disable SingleLinePerSelector
+button, a {
+  &:hover {
     cursor: pointer;
   }
 }
-header{
+
+header {
+  // scss-lint:disable SpaceAfterPropertyColon
   background-image:
           -moz-linear-gradient(45deg, $gray-200 25%, transparent 25%),
           -moz-linear-gradient(-45deg, $gray-200 25%, transparent 25%),
           -moz-linear-gradient(45deg, transparent 75%, $gray-200 75%),
           -moz-linear-gradient(-45deg, transparent 75%, $gray-200 75%);
+
+  // scss-lint:disable SpaceAfterPropertyColon
   background-image:
-          -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.25, $gray-200), color-stop(.25, transparent)),
-          -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.25, $gray-200), color-stop(.25, transparent)),
-          -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.75, transparent), color-stop(.75, $gray-200)),
-          -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.75, transparent), color-stop(.75, $gray-200));
-  -moz-background-size:6px 6px;
-  background-size:6px 6px;
-  -webkit-background-size:6px 6px;
-  background-position:0 0, 3px 0, 3px -3px, 0px 3px;
+          -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, $gray-200), color-stop(0.25, transparent)),
+          -webkit-gradient(linear, 0 0, 100% 100%, color-stop(0.25, $gray-200), color-stop(0.25, transparent)),
+          -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.75, transparent), color-stop(0.75, $gray-200)),
+          -webkit-gradient(linear, 0 0, 100% 100%, color-stop(0.75, transparent), color-stop(0.75, $gray-200));
+  -moz-background-size: 6px 6px;
+  background-size: 6px 6px;
+  -webkit-background-size: 6px 6px;
+  background-position: 0 0, 3px 0, 3px -3px, 0 3px;
+
+  .input-group {
+    &:focus {
+      box-shadow: 0 0 3px $primary;
+      border-radius: 0.2rem;
+    }
+
+    &:hover {
+      box-shadow: 0 0 3px $primary;
+    }
+  }
 }
-.navbar{
+
+.navbar {
   &.bg-light {
     background-color: transparent !important;
   }
-  &.navbar-expand-lg{
-    .navbar-nav{
-      .nav-link{
+
+  &.navbar-expand-lg {
+    .navbar-nav {
+      .nav-link {
         font-size: $font-size-xs;
       }
-      .active{
+
+      .active {
         background-color: $white;
         border-radius: 0.2rem;
       }
     }
   }
 }
-.btn{
+
+.btn {
   border-radius: 0;
   font-size: $font-size-xs;
   text-transform: uppercase;
-  svg{
+
+  svg {
     margin-right: 9px;
   }
 }
+
 .btn-primary {
   color: $white !important;
 }
-.breadcrumbs{
+
+.breadcrumbs {
   font-size: $font-size-xxs;
-  a{
-    &:hover{
-      opacity: .6;
+
+  a {
+    &:hover {
+      opacity: 0.6;
       text-decoration: none;
     }
   }
 }
-header{
-  .input-group{
-    &:focus{
-      box-shadow: 0 0 3px $primary;
-      border-radius: 0.2rem;
-    }
-    &:hover{
-      box-shadow: 0 0 3px $primary;
-    }
-  }
+
+.input-group > .form-control:not(:first-child),
+.input-group > .custom-select:not(:first-child) {
+  border-top-left-radius: 0.2rem;
+  border-bottom-left-radius: 0.2rem;
 }
 
-.input-group > .form-control:not(:first-child), .input-group > .custom-select:not(:first-child) {
-  border-top-left-radius: .2rem;
-  border-bottom-left-radius: .2rem;
-}
-.form-control{
-  border-color: #c6c6c6;
+.form-control {
   border-radius: 0.2rem;
-}
-.input-group-text{
-  border-radius: .2rem;
-  background-color: transparent;
-  outline:none;
-  &:hover{
-    outline: none;
-  }
-  &:focus{
-    outline: none;
-  }
-}
-.form-control{
   outline: none !important;
   border: 1px solid $gray-400;
-  &:hover{
+
+  &:hover {
     outline: none !important;
     -webkit-box-shadow: none;
     box-shadow: none;
     border: 1px solid $gray-400;
   }
-  &:focus{
-    outline: none!important;
+
+  &:focus {
+    outline: none !important;
     -webkit-box-shadow: none;
     box-shadow: none;
     border: 1px solid $gray-400;
   }
 }
-input::-webkit-input-placeholder, textarea::-webkit-input-placeholder { /* Chrome/Opera/Safari */
-  font-size: $font-size-xs;
-  font-weight: 400;
-  font-style: italic;
-  color: $gray-500 !important;
+
+.input-group-text {
+  border-radius: 0.2rem;
+  background-color: transparent;
+  outline: none;
+
+  &:hover {
+    outline: none;
+  }
+
+  &:focus {
+    outline: none;
+  }
 }
-input::-moz-placeholder, textarea::-moz-placeholder { /* Firefox 19+ */
-  font-size: $font-size-xs;
-  font-weight: 400;
-  font-style: italic;
-  color: $gray-500 !important;
-}
-input:-ms-input-placeholder, textarea:-ms-input-placeholder  { /* IE 10+ */
-  font-size: $font-size-xs;
-  font-weight: 400;
-  font-style: italic;
-  color: $gray-500 !important;
-}
-input:-moz-placeholder, textarea:-moz-placeholder { /* Firefox 18- */
+
+input::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder { /* Chrome/Opera/Safari */
   font-size: $font-size-xs;
   font-weight: 400;
   font-style: italic;
   color: $gray-500 !important;
 }
 
-.pagination{
-  a{
-    color:$body-color;
-    &:hover{
-      color:$body-color;
+input::-moz-placeholder,
+textarea::-moz-placeholder { /* Firefox 19+ */ /* Firefox 18- */
+  font-size: $font-size-xs;
+  font-weight: 400;
+  font-style: italic;
+  color: $gray-500 !important;
+}
+
+input:-ms-input-placeholder,
+textarea:-ms-input-placeholder { /* IE 10+ */
+  font-size: $font-size-xs;
+  font-weight: 400;
+  font-style: italic;
+  color: $gray-500 !important;
+}
+
+.pagination {
+  a {
+    color: $body-color;
+
+    &:hover {
+      color: $body-color;
       opacity: 0.6;
       background-color: transparent;
     }
   }
+
   .page-item.active {
     .page-link {
       color: $body-color;
       background-color: transparent;
       box-sizing: border-box;
-      -moz-box-sizing: border-box;
-      -webkit-box-sizing: border-box;
-      border: 1px solid #dee2e6;
+      border: 1px solid $pagination-link-color;
       border-bottom: 1px solid $body-color;
       font-weight: 800;
     }
   }
-  .text-dark{
+
+  .text-dark {
     color: $body-color;
   }
 }
+
 .media {
   border-bottom: 1px solid $gray-300;
+
   .form-check-input {
     margin-top: 0.5rem;
   }
+
   .form-check-label {
-    font-size: $small-font-size
+    font-size: $small-font-size;
   }
-  .form-group{
-    margin-bottom:0px;
+
+  .form-group {
+    margin-bottom: 0;
   }
-  svg{
-    color: $primary
+
+  svg {
+    color: $primary;
   }
 }
 
-.nav-tabs{
+.nav-tabs {
   background-color: $primary;
   border: none;
-  .nav-link{
+
+  .nav-link {
     color: $white;
     padding: 0.6rem 1rem;
     font-weight: 600;
     border-radius: 0;
-    &:hover{
+
+    &:hover {
       border-color: transparent;
       opacity: 0.7;
     }
-    &.active{
+
+    &.active {
       border-color: $primary $primary $white;
       padding: 0.8rem 1rem;
       margin-top: -5px;
-      &:hover{
+
+      &:hover {
         opacity: 1;
       }
     }
   }
 }
-.tab-content{
+
+.tab-content {
   border-top: 1px solid $primary;
+
   ul {
     list-style-position: outside;
     list-style: disc;
     color: $link-color;
-    li{
-      span{
+
+    li {
+      span {
         color: $body-color;
       }
     }
   }
 }
-.card{
+
+.card {
   border-color: $primary;
-  border-radius: 0px;
-  .card-header{
-    background-color: rgba(255,192,69,0.3);
+  border-radius: 0;
+
+  .card-header {
+    background-color: $card-header-bg;
     border-bottom: none;
   }
 }
+
 .steps-form-2 {
   position: relative;
-  .steps-row-2:before {
+
+  .steps-row-2::before {
     top: 11px;
     bottom: 0;
     position: absolute;
-    content: " ";
+    content: ' ';
     width: 100%;
     z-index: 1;
     height: 1px;
     background-color: $primary;
   }
-  a{
+
+  a {
     color: $primary !important;
   }
-  .bg-white{
-    z-index:2;
+
+  .bg-white {
+    z-index: 2;
   }
 }

--- a/app/javascript/stylesheets/_footer.scss
+++ b/app/javascript/stylesheets/_footer.scss
@@ -12,9 +12,9 @@ body {
 
 .footer {
   width: 100%;
+  background-color: $footer-color;
   /* Set the fixed height of the footer here */
   height: 60px;
   line-height: 60px; /* Vertically center the text there */
-  background-color: #f5f5f5;
 }
 

--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -1,9 +1,11 @@
-$navbar-light-active-color:  #233D4C !default;
-$navbar-light-color: #233D4C !default;
-$font-family-sans-serif:   Muli, Roboto, "Helvetica Neue", Arial, sans-serif !default;
+// Bootstrap Variables
 
-$font-size-xs:   .8125rem !default;
-$font-size-xxs: .75rem !default;
+$navbar-light-active-color:  #233c4c;
+$navbar-light-color: #233d4c;
+$font-family-sans-serif: Muli, Roboto, "Helvetica Neue", Arial, sans-serif;
+
+$font-size-xs:  0.8125rem;
+$font-size-xxs: 0.75rem;
 
 $link-color: #3540b6;
 $h1-font-size: 1.5rem;
@@ -11,4 +13,9 @@ $h2-font-size: 1.25rem;
 $h5-font-size: 1rem;
 $primary: #ffc045;
 $secondary: #2144b2;
-$body-color: #233D4C;
+$body-color: #233d4c;
+
+// MP Variables
+$footer-color: #f5f5f5;
+$card-header-bg: rgba(255, 192, 69, 0.3);
+$pagination-link-color: #dee2e6;

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for [:backoffice, @service] do |f|
+= simple_form_for [:backoffice, service] do |f|
   = f.error_notification
   = f.input :title
   = f.input :description
@@ -6,7 +6,7 @@
   = f.input :tagline
 
   .btn-group
-    = f.button :submit, class: 'btn btn-success'
-    - path = @service.persisted? ? backoffice_service_path(@service) : backoffice_services_path
+    = f.button :submit, class: "btn btn-success"
+    - path = service.persisted? ? backoffice_service_path(service) : backoffice_services_path
     = link_to "Cancel", path, class: "btn btn-secondary"
 

--- a/app/views/backoffice/services/_service.html.haml
+++ b/app/views/backoffice/services/_service.html.haml
@@ -6,7 +6,7 @@
       .mb-3= service.description
       %p.small.float-left.mr-4
         Provided by
-        %a{href: ""}
+        %a{ href: "" }
           SHAPE
       %p.small
         Available for SME only within 1 day
@@ -19,7 +19,7 @@
           %i.fas.fa-star-half-alt
           %span.small.ml-1.font-weight-bold
             (2.3/5)
-          %a{href: "", class: "small ml-3"}
+          %a.small.ml-3{ href: "" }
             5 opinions
 
 

--- a/app/views/backoffice/services/edit.html.haml
+++ b/app/views/backoffice/services/edit.html.haml
@@ -1,4 +1,4 @@
 .container
   %h2 Edit Service
-  = render 'form'
+  = render "form", service: @service
 

--- a/app/views/backoffice/services/new.html.haml
+++ b/app/views/backoffice/services/new.html.haml
@@ -1,4 +1,4 @@
 .container
   %h2 New Service
-  = render 'form'
+  = render "form", service: @service
 

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,5 +1,5 @@
 - if alert
-  .alert.alert-danger{role: "alert"}= alert
+  .alert.alert-danger{ role: "alert" }= alert
 - elsif notice
-  .alert.alert-success{role: "alert"}= notice
+  .alert.alert-success{ role: "alert" }= notice
 

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -2,5 +2,5 @@
   .container
     %span.text-muted 2018 EOSC Portal
     - if (ENV["MP_VERSION"])
-      %span.text-muted= "- version: #{ENV["MP_VERSION"]}"
+      %span.text-muted "- version: #{ENV["MP_VERSION"]}"
 

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -1,11 +1,11 @@
 %head
-  %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
-  %meta{charset: "utf-8"}/
-  %meta{content: "width=device-width, initial-scale=1, shrink-to-fit=no", name: "viewport"}/
+  %meta{ content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type" }/
+  %meta{ charset: "utf-8" }/
+  %meta{ content: "width=device-width, initial-scale=1, shrink-to-fit=no", name: "viewport" }/
   %title Mp
   = csrf_meta_tags
   = csp_meta_tag
-  = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-  = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
-  = stylesheet_pack_tag 'application'
-  = javascript_pack_tag 'application'
+  = stylesheet_link_tag    "application", media: "all", "data-turbolinks-track": "reload"
+  = javascript_include_tag "application", "data-turbolinks-track": "reload"
+  = stylesheet_pack_tag "application"
+  = javascript_pack_tag "application"

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -1,15 +1,17 @@
 .container
   %nav.navbar.navbar-expand-lg.navbar-light.bg-light
-    = link_to root_path, class: 'navbar-brand' do
+    = link_to root_path, class: "navbar-brand" do
       %strong EOSC
       Portal
-    %button.navbar-toggler{"aria-controls" => "navbarSupportedContent",
-       "aria-expanded" => "false", "aria-label" => "Toggle navigation",
-       "data-target" => "#navbarSupportedContent",
-       "data-toggle" => "collapse", type: "button"}
+    %button.navbar-toggler{ "aria-controls" => "navbar-supported-content",
+                           "aria-expanded" => "false",
+                           "aria-label" => "Toggle navigation",
+                           "data-target" => "#navbar-supported-content",
+                           "data-toggle" => "collapse",
+                           type: "button" }
       %span.navbar-toggler-icon
 
-    #navbarSupportedContent.collapse.navbar-collapse
+    #navbar-supported-content.collapse.navbar-collapse
       %ul.navbar-nav.ml-auto.pt-2
         = nav_link controller: :home do
           = link_to "Getting Started", root_path, class: "nav-link px-3 py-1"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html{lang: "en"}
+%html{ lang: "en" }
   = render "layouts/head"
   %body
     %header.pt-2.pb-2

--- a/app/views/layouts/backoffice.html.haml
+++ b/app/views/layouts/backoffice.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html{lang: "en"}
+%html{ lang: "en" }
   = render "layouts/head"
   %body
     %header.pt-2.pb-2

--- a/app/views/layouts/backoffice/_navbar.html.haml
+++ b/app/views/layouts/backoffice/_navbar.html.haml
@@ -1,15 +1,16 @@
 .container
   %nav.navbar.navbar-expand-lg.navbar-light.bg-light
-    = link_to backoffice_path, class: 'navbar-brand' do
+    = link_to backoffice_path, class: "navbar-brand" do
       %strong EOSC
       Portal Backoffice
-    %button.navbar-toggler{"aria-controls" => "navbarSupportedContent",
-       "aria-expanded" => "false", "aria-label" => "Toggle navigation",
-       "data-target" => "#navbarSupportedContent",
-       "data-toggle" => "collapse", type: "button"}
+    %button.navbar-toggler{ "aria-controls" => "navbar-supported-content",
+                            "aria-expanded" => "false", "aria-label" => "Toggle navigation",
+                            "data-target" => "#navbar-supported-content",
+                            "data-toggle" => "collapse",
+                             type: "button" }
       %span.navbar-toggler-icon
 
-    #navbarSupportedContent.collapse.navbar-collapse
+    #navbar-supported-content.collapse.navbar-collapse
       %ul.navbar-nav.ml-auto.pt-2
         = nav_link controller: :backoffices do
           = link_to "Getting Started", backoffice_path, class: "nav-link px-3 py-1"

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %meta{content: "text/html; charset=utf-8", "http-equiv" => "Content-Type"}/
+    %meta{ content: "text/html; charset=utf-8", "http-equiv" => "Content-Type" }/
     :css
       /* Email styles need to be inline */
   %body

--- a/app/views/orders/_order_changes.html.haml
+++ b/app/views/orders/_order_changes.html.haml
@@ -6,4 +6,4 @@
 - else
   %p No order changes yet
 
-= render "orders/question", order: order
+= render "orders/question", order: order, question: question

--- a/app/views/orders/_question.html.haml
+++ b/app/views/orders/_question.html.haml
@@ -1,9 +1,9 @@
-- if policy(@question).create?
+- if policy(question).create?
   %hr/
   %h4 Ask question about about your order
 
-  = form_for @question, url: order_questions_path(order) do |f|
-    - if @question.errors[:text].present?
-      .alert.alert-danger= @question.errors[:text]&.first
+  = form_for question, url: order_questions_path(order) do |f|
+    - if question.errors[:text].present?
+      .alert.alert-danger= question.errors[:text]&.first
     = f.text_area :text
-    %button{class: "btn btn-info", type: "submit"} Ask question
+    %button.btn.btn-info{ type: "submit" } Ask question

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -13,6 +13,7 @@
 
 = render "orders/order_changes",
          order_changes: @order.order_changes.to_a,
-         order: @order
+         order: @order,
+         question: @question
 
 

--- a/app/views/playground/static-tabs.html.haml
+++ b/app/views/playground/static-tabs.html.haml
@@ -1,40 +1,58 @@
 .container
-  %ul#myTab.nav.nav-tabs{:role => "tablist"}
+  %ul#my-tab.nav.nav-tabs{ role: "tablist" }
     %li.nav-item
-      %a#home-tab.nav-link.active{"aria-controls" => "home", "aria-selected" => "true", "data-toggle" => "tab", :href => "#desc", :role => "tab"} DESCRIPTION
+      %a#home-tab.nav-link.active{ "aria-controls" => "home",
+                                   "aria-selected" => "true",
+                                   "data-toggle" => "tab",
+                                   href: "#desc",
+                                   role: "tab" } DESCRIPTION
     %li.nav-item
-      %a#profile-tab.nav-link{"aria-controls" => "profile", "aria-selected" => "false", "data-toggle" => "tab", :href => "#order", :role => "tab"} ORDER SPECIFICATION
+      %a#profile-tab.nav-link{ "aria-controls" => "profile",
+                               "aria-selected" => "false",
+                               "data-toggle" => "tab",
+                               href: "#order",
+                               role: "tab" } ORDER SPECIFICATION
     %li.nav-item
-      %a#messages-tab.nav-link{"aria-controls" => "messages", "aria-selected" => "false", "data-toggle" => "tab", :href => "#opinions", :role => "tab"} OPINIONS (5)
+      %a#messages-tab.nav-link{ "aria-controls" => "messages",
+                                "aria-selected" => "false",
+                                "data-toggle" => "tab",
+                                href: "#opinions",
+                                role: "tab" } OPINIONS (5)
 
 / Tab panes
 .tab-content
-  #desc.tab-pane.container.active{"aria-labelledby" => "home-tab", :role => "tabpanel"}
+  #desc.tab-pane.container.active{ "aria-labelledby" => "home-tab", role: "tabpanel" }
     .row.pt-3
       .col-8
         %h3.mb-3 Run virtual machines on-demand with complete control over computing resources.
-        %p.mt-4 With Cloud Compute you can deploy and scale virtual machines on-demand. Cloud Compute offers guaranteed computational resources in a secure and isolated environment with standard API access, without the overhead of managing physical servers.
-        %p.mt-3 Cloud Compute offers the possibility to select preconﬁgured virtual appliances (e.g. CPU, memory, disk, operating system or software) from a catalogue replicated across all EGI cloud providers from a catalogue replicated across all EGI cloud providers.
+        %p.mt-4 With Cloud Compute you can deploy and scale virtual machines on-demand. Cloud Compute offers guaranteed
+        computational resources in a secure and isolated environment with standard API access, without the overhead
+        of managing physical servers.
+        %p.mt-3 Cloud Compute offers the possibility to select preconﬁgured virtual appliances (e.g. CPU, memory, disk,
+        operating system or software) from a catalogue replicated across all EGI cloud providers from a catalogue
+        replicated across all EGI cloud providers.
         %p.mt-5 Featured usecases
         %ul.ml-4
           %li.mt-2
             %span
-              How to predict social media trends? how Cloud Compute helps to test new ways to detect trends on social networks
+              How to predict social media trends? how Cloud Compute helps to test new ways to detect trends on
+              social networks
           %li.mt-2
             %span
-              The genetics of Salmonella infections: how Cloud Compute helped scientists to understand what happens during when a human cell meets Salmonella
+              The genetics of Salmonella infections: how Cloud Compute helped scientists to understand what happens
+              during when a human cell meets Salmonella
       .col-1
       .col-3
         %p
           Featured details:
         %ul.ml-4
           %li
-            %a{:href => ""}Terms of use
+            %a{ href: "" }Terms of use
           %li
-            %a{:href => ""}SLA
+            %a{ href: "" }SLA
           %li
-            %a{:href => ""}Access policy
-  #order.tab-pane.container{"aria-labelledby" => "profile-tab", :role => "tabpanel"}
+            %a{ href: "" }Access policy
+  #order.tab-pane.container{ "aria-labelledby" => "profile-tab", role: "tabpanel" }
     .row.pt-3
       .col-7
         %h3.mb-3
@@ -44,35 +62,35 @@
             .col
               %label
                 Number of CPU cores
-              %input{:type => "text", :class => "form-control"}
+              %input.form-control{ type: "text" }
             .col
               %label
                 Amount of RAM per CPU core
-              %input{:type => "text", :class => "form-control"}
+              %input.form-control{ type: "text" }
           .row.mt-4
             .col
               %label
                 Local disk
-              %select{:class => "form-control"}
+              %select.form-control
                 %option
                   10
             .col
               %label
                 Number of instances
-              %select{:class => "form-control"}
+              %select.form-control
                 %option
                   1
           .row.mt-4
             .col
               %label
                 Access type
-              %select{:class => "form-control"}
+              %select.form-control
                 %option
                   Reserved
             .col
               %label
                 Number of public IP
-              %select{:class => "form-control"}
+              %select.form-control
                 %option
                   1
           .row.mt-4
@@ -80,14 +98,14 @@
               %label
                 Start of service
               .input-group.date
-                %input{:class => "form-control"}
+                %input.form-control
                 .input-group-append
                   %span.input-group-text
                     %i.far.fa-calendar-alt
             .col
               %label
                 Number of days
-              %input{:type => "text", :class => "form-control"}
+              %input.form-control{ type: "text" }
       .col-1
       .col-4
         .card
@@ -99,21 +117,21 @@
             .steps-form-2.ml-5.mr-5
               .steps-row-2.setup-panel-2.d-flex.justify-content-between
                 .bg-white.position-relative
-                  %a{:href => "#step-1", :class => "ml-0"}
+                  %a.ml-0{ href: "#step-1" }
                     %i.fas.fa-circle.fa-lg
                 .bg-white.position-relative
-                  %a{:href => "#step-2", :class => "ml-0"}
+                  %a.ml-0{ href: "#step-2" }
                     %i.fas.fa-dot-circle.fa-lg
                 .bg-white.position-relative
-                  %a{:href => "#step-3", :class => "ml-0"}
+                  %a.ml-0{ href: "#step-3" }
                     %i.far.fa-circle.fa-lg
                 .bg-white.position-relative
-                  %a{:href => "#step-4", :class => "ml-0"}
+                  %a.ml-0{ href: "#step-4" }
                     %i.far.fa-circle.fa-lg
             .small.text-center.font-italic.ml-2.mr-2
               %span.d-block.font-weight-bold.mt-3
                 NEXT STEP
               Summary of your request, some additional information to ﬁll
-  #opinions.tab-pane.container{"aria-labelledby" => "messages-tab", :role => "tabpanel"}
+  #opinions.tab-pane.container{ "aria-labelledby" => "messages-tab", role: "tabpanel" }
 
 

--- a/app/views/profiles/affiliations/_affiliation.html.haml
+++ b/app/views/profiles/affiliations/_affiliation.html.haml
@@ -1,6 +1,6 @@
 #li
   #{affiliation.iid}: #{affiliation.organization}
-  -unless affiliation.department.blank?
+  - unless affiliation.department.blank?
     #{affiliation.department} department
   (#{affiliation.webpage}, email: #{affiliation.email},
   #{affiliation.phone} telephone).

--- a/app/views/profiles/affiliations/_form.html.haml
+++ b/app/views/profiles/affiliations/_form.html.haml
@@ -9,5 +9,5 @@
   = f.input :supervisor_profile
 
   .btn-group
-    = f.button :submit, class: 'btn btn-success'
+    = f.button :submit, class: "btn btn-success"
     = link_to "Cancel", profile_path, class: "btn btn-secondary"

--- a/app/views/profiles/affiliations/edit.html.haml
+++ b/app/views/profiles/affiliations/edit.html.haml
@@ -1,4 +1,4 @@
 .container
   - breadcrumb :affiliation, @affiliation
   %h2 Edit Affiliations
-  = render 'form'
+  = render "form"

--- a/app/views/profiles/affiliations/new.html.haml
+++ b/app/views/profiles/affiliations/new.html.haml
@@ -1,4 +1,4 @@
 .container
   - breadcrumb :affiliation_new
   %h2 New Affiliations
-  = render 'form'
+  = render "form"

--- a/app/views/services/_description.html.haml
+++ b/app/views/services/_description.html.haml
@@ -1,34 +1,40 @@
-#desc.tab-pane.container.pt-2.active{"aria-labelledby" => "home-tab", role: "tabpanel"}
+#desc.tab-pane.container.pt-2.active{ "aria-labelledby" => "home-tab", role: "tabpanel" }
   .row.pt-3
     .col-8
       %h3 Terms of use
-      = markdown(@service.terms_of_use)
+      = markdown(service.terms_of_use)
 
       - if policy(Order.new).create?
         = form_for(Order.new) do |f|
-          = f.hidden_field :service_id, value: @service.id
-          %button{class: "btn btn-primary", type: "submit"} Order
+          = f.hidden_field :service_id, value: service.id
+          %button{ class: "btn btn-primary", type: "submit" } Order
 
 
       %h3.mb-3.mt-3 Run virtual machines on-demand with complete control over computing resources.
-      %p.mt-4 With Cloud Compute you can deploy and scale virtual machines on-demand. Cloud Compute offers guaranteed computational resources in a secure and isolated environment with standard API access, without the overhead of managing physical servers.
-      %p.mt-3 Cloud Compute offers the possibility to select preconﬁgured virtual appliances (e.g. CPU, memory, disk, operating system or software) from a catalogue replicated across all EGI cloud providers from a catalogue replicated across all EGI cloud providers.
+      %p.mt-4 With Cloud Compute you can deploy and scale virtual machines on-demand. Cloud Compute offers guaranteed
+      computational resources in a secure and isolated environment with standard API access, without the overhead
+      of managing physical servers.
+      %p.mt-3 Cloud Compute offers the possibility to select preconﬁgured virtual appliances (e.g. CPU, memory, disk,
+      operating system or software) from a catalogue replicated across all EGI cloud providers from a catalogue
+      replicated across all EGI cloud providers.
       %p.mt-5 Featured usecases
       %ul.ml-4
         %li.mt-2
           %span
-            How to predict social media trends? how Cloud Compute helps to test new ways to detect trends on social networks
+            How to predict social media trends? how Cloud Compute helps to test new ways to detect trends on social
+            networks
         %li.mt-2
           %span
-            The genetics of Salmonella infections: how Cloud Compute helped scientists to understand what happens during when a human cell meets Salmonella
+            The genetics of Salmonella infections: how Cloud Compute helped scientists to understand what happens
+            during when a human cell meets Salmonella
     .col-1
     .col-3
       %p
         Featured details:
       %ul.ml-4
         %li
-          %a{href: ""}Terms of use
+          %a{ href: "" }Terms of use
         %li
-          %a{href: ""}SLA
+          %a{ href: "" }SLA
         %li
-          %a{href: ""}Access policy
+          %a{ href: "" }Access policy

--- a/app/views/services/_opinions.html.haml
+++ b/app/views/services/_opinions.html.haml
@@ -1,1 +1,1 @@
-#opinions.tab-pane.pt-2.container{"aria-labelledby" => "messages-tab", role: "tabpanel"}
+#opinions.tab-pane.pt-2.container{ "aria-labelledby" => "messages-tab", role: "tabpanel" }

--- a/app/views/services/_order.html.haml
+++ b/app/views/services/_order.html.haml
@@ -1,4 +1,4 @@
-#order.tab-pane.pt-2.container{"aria-labelledby" => "profile-tab", role: "tabpanel"}
+#order.tab-pane.pt-2.container{ "aria-labelledby" => "profile-tab", role: "tabpanel" }
   .row.pt-3
     .col-7
       %h3.mb-3
@@ -8,35 +8,35 @@
           .col
             %label
               Number of CPU cores
-            %input{type: "text", class: "form-control"}
+            %input.form-control{ type: "text" }
           .col
             %label
               Amount of RAM per CPU core
-            %input{type: "text", class: "form-control"}
+            %input.form-control{ type: "text" }
         .row.mt-4
           .col
             %label
               Local disk
-            %select{class: "form-control"}
+            %select.form-control
               %option
                 10
           .col
             %label
               Number of instances
-            %select{class: "form-control"}
+            %select.form-control
               %option
                 1
         .row.mt-4
           .col
             %label
               Access type
-            %select{class: "form-control"}
+            %select.form-control
               %option
                 Reserved
           .col
             %label
               Number of public IP
-            %select{class: "form-control"}
+            %select.form-control
               %option
                 1
         .row.mt-4
@@ -44,14 +44,14 @@
             %label
               Start of service
             .input-group.date
-              %input{class: "form-control"}
+              %input.form-control
               .input-group-append
                 %span.input-group-text
                   %i.far.fa-calendar-alt
           .col
             %label
               Number of days
-            %input{type: "text", class: "form-control"}
+            %input.form-control{ type: "text" }
     .col-1
     .col-4
       .card
@@ -63,16 +63,16 @@
           .steps-form-2.ml-5.mr-5
             .steps-row-2.setup-panel-2.d-flex.justify-content-between
               .bg-white.position-relative
-                %a{href: "#step-1", class: "ml-0"}
+                %a.ml-0{ href: "#step-1" }
                   %i.fas.fa-circle.fa-lg
               .bg-white.position-relative
-                %a{href: "#step-2", class: "ml-0"}
+                %a.ml-0{ href: "#step-2" }
                   %i.fas.fa-dot-circle.fa-lg
               .bg-white.position-relative
-                %a{href: "#step-3", class: "ml-0"}
+                %a.ml-0{ href: "#step-3" }
                   %i.far.fa-circle.fa-lg
               .bg-white.position-relative
-                %a{href: "#step-4", class: "ml-0"}
+                %a.ml-0{ href: "#step-4" }
                   %i.far.fa-circle.fa-lg
           .small.text-center.font-italic.ml-2.mr-2
             %span.d-block.font-weight-bold.mt-3

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -3,9 +3,9 @@
     .col-2
     .col-8
       %p
-        = form_tag services_path, method: :get, role: 'search', class: '' do
+        = form_tag services_path, method: :get, role: "search", class: "" do
           .input-group
-            %label.sr-only{for: "search"} Search
+            %label.sr-only{ for: "search" } Search
             = text_field_tag :q, params[:q], class: "form-control", placeholder: "What are you looking for?"
 
             .input-group-append

--- a/app/views/services/_service.html.haml
+++ b/app/views/services/_service.html.haml
@@ -6,22 +6,22 @@
       .mb-3= service.tagline
       %p.small.float-left.mr-4
         Provided by
-        %a{href: ""}
+        %a{ href: "" }
           SHAPE
       %p.small
         Available for SME only within 1 day
       .row
         .col
-          =print_rating_stars(service.rating)
+          = print_rating_stars(service.rating)
           %span.small.ml-1.font-weight-bold
             (#{service.rating} /5)
-          %a{href: "", class: "small ml-3"}
+          %a{ href: "", class: "small ml-3" }
             5 opinions
 
     .ml-5
       %form.d-flex.justify-content-end
         .form-group.form-check
-          %input{type: "checkbox", class: "form-check-input", id: ""}
-          %label{class: "form-check-label", for: ""}
+          %input.form-check-input{ type: "checkbox" }
+          %label.form-check-label{ for: "" }
             to compare
 

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -2,26 +2,38 @@
 .container
   %h1= @service.title
   %p
-    %b=@service.tagline
+    %b= @service.tagline
   %p= @service.description
   .row
     .col
-      =print_rating_stars(@service.rating)
+      = print_rating_stars(@service.rating)
       %span.small.ml-1.font-weight-bold
         (#{@service.rating} /5)
-      %a{href: "", class: "small ml-3"}
+      %a{ href: "", class: "small ml-3" }
         5 opinions
 
 .container
-  %ul#myTab.nav.nav-tabs.mt-4{role: "tablist"}
+  %ul#my-tab.nav.nav-tabs.mt-4{ role: "tablist" }
     %li.nav-item
-      %a#home-tab.nav-link.text-uppercase.active{"aria-controls" => "home", "aria-selected" => "true", "data-toggle" => "tab", href: "#desc", role: "tab"} Description
+      %a#home-tab.nav-link.text-uppercase.active{ "aria-controls" => "home",
+                                                  "aria-selected" => "true",
+                                                  "data-toggle" => "tab",
+                                                  href: "#desc",
+                                                  role: "tab" } Description
     %li.nav-item
-      %a#profile-tab.nav-link.text-uppercase{"aria-controls" => "profile", "aria-selected" => "false", "data-toggle" => "tab", href: "#order", role: "tab"} Order Specification
+      %a#profile-tab.nav-link.text-uppercase{ "aria-controls" => "profile",
+                                              "aria-selected" => "false",
+                                              "data-toggle" => "tab",
+                                              href: "#order",
+                                              role: "tab" } Order Specification
     %li.nav-item
       -# TODO - insert rating comment count into parenthesis - for now static (5) is left
-      %a#messages-tab.nav-link.text-uppercase{"aria-controls" => "messages", "aria-selected" => "false", "data-toggle" => "tab", href: "#opinions", role: "tab"} Opinions (5)
+      %a#messages-tab.nav-link.text-uppercase{ "aria-controls" => "messages",
+                                               "aria-selected" => "false",
+                                               "data-toggle" => "tab",
+                                               href: "#opinions",
+                                               role: "tab" } Opinions (5)
 .tab-content
-  = render "services/description"
+  = render "services/description", service: @service
   = render "services/order"
   = render "services/opinions"


### PR DESCRIPTION
# What is in this PR

In this PR validation for scss (via `scss-lint`) and HAML (via `haml-lint`) has been 
added to overcommit.

These checks has been added to preCommit hook, which means that running
```
overcommit --run
```

Will call them, which means that no modification to `.travis.yml` is required.

Additionally all offending files have been fixed according to new rules.

# Sensible defaults

Almost all defaults for HAML linting have been left *as is*, except for some minor things like:

- changed maximum line length to 120 characters
- changed maximum file length to 150 lines
- enforced id to be placed before classes

As for SCSS more fine tuning has been done. I dropped more restrictive validators, as they would create more problems than benefits IMHO. The most important validators which are enabled are:

- enforcing trailing newline after `}`
- enforcing space before `{`
- enforcing space after `:`
- no inline color allowed
- proper usage of `:` with pseudo selectors and pseudo elements
- and couple of smaller ones.

Fixes: #61