### PR TITLE
[#113] User can add open access services to my services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Service owner can manage owned services (@mkasztelnik)
 - Add rating for Service (@kmarszalek)
 - Add JIRA integration (marketplace to jira) (@michal-szostak)
+- Add open access services (#martaswiatkowska)
 - Add HAML validation to overcommit via `haml-lint` (@michal-szostak)
 - Add SCSS validation to overcommit via `scss-lint` (@michal-szostak)
 

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -17,4 +17,8 @@ module ServiceHelper
     end
     result.html_safe
   end
+
+  def write_button_text
+    @service.open_access ? "Add to my services" : "Order"
+  end
 end

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -3,6 +3,10 @@
 body {
   font-size: $font-size-sm;
   margin-bottom: 0 !important;
+
+  > main {
+    padding-bottom: 100px;
+  }
 }
 
 *:focus {
@@ -321,4 +325,13 @@ textarea:-ms-input-placeholder { /* IE 10+ */
   .bg-white {
     z-index: 2;
   }
+}
+
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 60px;
+  line-height: 60px;
+  background-color: $footer-bg-color;
 }

--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -19,3 +19,4 @@ $body-color: #233d4c;
 $footer-color: #f5f5f5;
 $card-header-bg: rgba(255, 192, 69, 0.3);
 $pagination-link-color: #dee2e6;
+$footer-bg-color: #f5f5f5;

--- a/app/jobs/order/ready_job.rb
+++ b/app/jobs/order/ready_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Order::ReadyJob < ApplicationJob
+  queue_as :orders
+
+  def perform(order)
+    Order::Ready.new(order).call
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -17,6 +17,7 @@ class Service < ApplicationRecord
   validates :title, presence: true
   validates :description, presence: true
   validates :tagline, presence: true
+  validates :connected_url, presence: true, url: true, if: :open_access?
 
   after_save :set_first_category_as_main!, if: :main_category_missing?
 

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -32,7 +32,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:title, :description, :terms_of_use, :tagline]
+    [:title, :description, :terms_of_use, :tagline, :connected_url, :open_access]
   end
 
   private

--- a/app/services/order/create.rb
+++ b/app/services/order/create.rb
@@ -7,11 +7,17 @@ class Order::Create
 
   def call
     @order.created!
+    @service = Service.find_by(id: @order.service_id)
 
     if @order.save
       @order.new_change(status: :created, message: "Order created")
       OrderMailer.created(@order).deliver_later
-      Order::RegisterJob.perform_later(@order)
+
+      if !@service.open_access
+        Order::RegisterJob.perform_later(@order)
+      else
+        Order::ReadyJob.perform_later(@order)
+      end
     end
 
     @order

--- a/app/services/order/ready.rb
+++ b/app/services/order/ready.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Order::Ready
+  def initialize(order)
+    @order = order
+  end
+
+  def call
+    update_status! &&
+    notify!
+  end
+
+  private
+
+    def update_status!
+      @order.new_change(status: :ready,
+                        message: "Your order is ready")
+    end
+
+    def notify!
+      OrderMailer.changed(@order).deliver_later
+    end
+end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+
+class UrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors[attribute] << (options[:message] || "must be a valid URL") unless url_valid?(value)
+  end
+
+  # a URL may be technically well-formed but may
+  # not actually be valid, so this checks for both.
+  def url_valid?(url)
+    url = URI.parse(url) rescue false
+    url.kind_of?(URI::HTTP) || url.kind_of?(URI::HTTPS)
+  end
+end

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -4,6 +4,8 @@
   = f.input :description
   = f.input :terms_of_use
   = f.input :tagline
+  = f.input :connected_url, label: "Service website"
+  = f.input :open_access, as: :boolean
 
   .btn-group
     = f.button :submit, class: "btn btn-success"

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -7,6 +7,12 @@
   %h2 Terms of use
   = markdown(@service.terms_of_use)
 
+  %h2 Service website
+  %p= @service.connected_url
+
+  %h2 Open access
+  %p= @service.open_access
+
   - if policy([:backoffice, @service]).edit?
     = link_to "Edit",
               edit_backoffice_service_path(@service),

--- a/app/views/services/_description.html.haml
+++ b/app/views/services/_description.html.haml
@@ -7,8 +7,10 @@
       - if policy(Order.new).create?
         = form_for(Order.new) do |f|
           = f.hidden_field :service_id, value: service.id
-          %button{ class: "btn btn-primary", type: "submit" } Order
-
+          %button{ class: "btn btn-primary" }
+            = write_button_text
+          - if @service.open_access?
+            = link_to "Go to the service", service.connected_url, class: "btn btn-primary", target: "_blank"
 
       %h3.mb-3.mt-3 Run virtual machines on-demand with complete control over computing resources.
       %p.mt-4 With Cloud Compute you can deploy and scale virtual machines on-demand. Cloud Compute offers guaranteed

--- a/db/migrate/20180711140914_add_connected_url_to_services.rb
+++ b/db/migrate/20180711140914_add_connected_url_to_services.rb
@@ -1,0 +1,5 @@
+class AddConnectedUrlToServices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :services, :connected_url, :text, null: true
+  end
+end

--- a/db/migrate/20180719071704_add_open_access_to_service.rb
+++ b/db/migrate/20180719071704_add_open_access_to_service.rb
@@ -1,0 +1,5 @@
+class AddOpenAccessToService < ActiveRecord::Migration[5.2]
+  def change
+    add_column :services, :open_access, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_11_132009) do
+ActiveRecord::Schema.define(version: 2018_07_19_071704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,8 @@ ActiveRecord::Schema.define(version: 2018_07_11_132009) do
     t.text "tagline", null: false
     t.bigint "owner_id"
     t.decimal "rating", precision: 2, scale: 1, default: "0.0", null: false
+    t.text "connected_url"
+    t.boolean "open_access", default: false
     t.index ["description"], name: "index_services_on_description"
     t.index ["owner_id"], name: "index_services_on_owner_id"
     t.index ["title"], name: "index_services_on_title"

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -16,7 +16,9 @@ if Rails.env.development?
                        tagline: Faker::Lorem.sentence,
                        categories: [Category.all.sample],
                        owner: users.sample,
-                       rating: Random.rand(5.0))
+                       open_access: Faker::Boolean.boolean,
+                       rating: Random.rand(5.0),
+                       connected_url: Faker::Internet.url)
 
       end
       puts "Done!"

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -6,5 +6,11 @@ FactoryBot.define do
     sequence(:description) { |n| "service #{n} description" }
     sequence(:terms_of_use) { |n| "service #{n} terms of use" }
     sequence(:tagline) { |n| "service #{n} tagline" }
+    sequence(:open_access) { false }
+
+    factory :open_access_service do
+      sequence(:connected_url) { "https://sample.url" }
+      sequence(:open_access) { true }
+    end
   end
 end

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -47,6 +47,8 @@ RSpec.feature "Services in backoffice" do
     fill_in "Description", with: "service description"
     fill_in "Terms of use", with: "service terms of use"
     fill_in "Tagline", with: "service tagline"
+    fill_in "Service website", with: "https://sample.url"
+    check "Open access"
 
     expect { click_on "Create Service" }.
       to change { user.owned_services.count }.by(1)
@@ -55,6 +57,8 @@ RSpec.feature "Services in backoffice" do
     expect(page).to have_content("service description")
     expect(page).to have_content("service terms of use")
     expect(page).to have_content("service tagline")
+    expect(page).to have_content("https://sample.url")
+    expect(page).to have_content("true")
   end
 
   scenario "I can edit owned service" do

--- a/spec/features/orders_spec.rb
+++ b/spec/features/orders_spec.rb
@@ -19,6 +19,13 @@ RSpec.feature "Service order" do
       expect(page).to have_text("Order")
     end
 
+    scenario "I see order open acces service button" do
+      @open_access_service = create(:open_access_service)
+      visit service_path(@open_access_service)
+
+      expect(page).to have_text("Add to my services")
+    end
+
     scenario "I can order service" do
       visit service_path(service)
 
@@ -29,6 +36,21 @@ RSpec.feature "Service order" do
       expect(order.service).to eq(service)
       expect(order.user).to eq(user)
       expect(order).to be_created
+    end
+
+    scenario "I can order open acces service" do
+      @open_access_service = create(:open_access_service)
+      @open_access_order = create(:order, service: @open_access_service, user: user)
+
+      visit service_path(@open_access_service)
+
+      expect { click_button "Add to my services" }.
+        to change { Order.count }.by(1)
+      order = Order.last
+
+      expect(@open_access_order.service).to eq(@open_access_service)
+      expect(@open_access_order.user).to eq(user)
+      expect(@open_access_order).to be_created
     end
 
     scenario "I can see my ordered services" do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -37,4 +37,16 @@ RSpec.describe Service do
 
     expect(service.main_category).to eq(main)
   end
+
+  context "if open access" do
+    before { allow(subject).to receive(:open_access?) { true } }
+
+    it { is_expected.to validate_presence_of(:connected_url) }
+  end
+
+  context "if not open access" do
+    before { allow(subject).to receive(:open_access?) { false } }
+
+    it { is_expected.to_not validate_presence_of(:connected_url) }
+  end
 end

--- a/spec/services/order/ready_spec.rb
+++ b/spec/services/order/ready_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order::Ready do
+  let(:order) { create(:order) }
+
+  it "creates new order change" do
+    described_class.new(order).call
+
+    expect(order.order_changes.last).to be_ready
+  end
+
+  it "changes order status into ready on success" do
+    described_class.new(order).call
+
+    expect(order).to be_ready
+  end
+
+  it "sent email to order owner" do
+    # order change email is sent only when there is more than 1 change
+    order.new_change(status: :ready, message: "Order is ready")
+
+    expect { described_class.new(order).call }.
+      to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+end


### PR DESCRIPTION
User can add to 'my service' open access service.
Open access service is available for all logged users.
User can go to open access service website from service details view 
If user add open access service to "my services" order will change status to ready(i dont know is this good status @roksanaer ???)

User can add open access service in backoffice.
If service is open access then connected url is required. 


Fix #113 