### PR TITLE
[#125] Upgrade Font Awesome to fix stars

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -13,7 +13,7 @@ module ServiceHelper
     end
     # empty stars
     for i in 0...5 - rating.ceil
-      result += content_tag(:i, "", class: "fas fa-star-o")
+      result += content_tag(:i, "", class: "far fa-star")
     end
     result.html_safe
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,18 +8,17 @@
 // layout file, like app/views/layouts/application.html.erb
 
 import 'bootstrap/dist/js/bootstrap';
-import 'stylesheets/application'
+import 'stylesheets/application';
 
-import Turbolinks from 'turbolinks'
+import Turbolinks from 'turbolinks';
 Turbolinks.start();
 
-import fontawesome from '@fortawesome/fontawesome'
-import regular from '@fortawesome/fontawesome-free-regular'
-import solid from '@fortawesome/fontawesome-free-solid'
+import { library, dom } from '@fortawesome/fontawesome-svg-core';
+import { far } from '@fortawesome/free-regular-svg-icons';
+import { fas } from '@fortawesome/free-solid-svg-icons';
 
 // :TODO: for now import all fonts, so ux people can work without problems, optimize later
-fontawesome.library.add(solid);
-fontawesome.library.add(regular);
+library.add(fas, far);
 
 import { Application } from "stimulus"
 import { definitionsFromContext } from "stimulus/webpack-helpers"
@@ -29,8 +28,15 @@ const context = require.context("controllers", true, /.js$/);
 application.load(definitionsFromContext(context));
 
 document.addEventListener("turbolinks:before-render", function(event) {
-  FontAwesome.dom.i2svg({
+  dom.i2svg({
     node: event.data.newBody
   });
+});
+
+/**
+ * Apart from turbolinks we need to replace FA for the first page load
+ */
+document.addEventListener('DOMContentLoaded', function () {
+  dom.i2svg();
 });
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "mp",
   "private": true,
   "dependencies": {
-    "@fortawesome/fontawesome": "^1.1.8",
-    "@fortawesome/fontawesome-free-regular": "^5.0.13",
-    "@fortawesome/fontawesome-free-solid": "^5.0.13",
+    "@fortawesome/fontawesome-svg-core": "^1.2.2",
+    "@fortawesome/free-regular-svg-icons": "^5.2.0",
+    "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@rails/webpacker": "3.5",
     "bootstrap": "^4.1.1",
     "expose-loader": "^0.7.5",

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe ServiceHelper, type: :helper do
   end
 
   it "converts from decimal 0.0 value to html" do
-    expect(print_rating_stars(0.0)).to match(/<i class="fas fa-star-o"><\/i><i class="fas fa-star-o"><\/i><i class="fas fa-star-o"><\/i><i class="fas fa-star-o"><\/i><i class="fas fa-star-o"><\/i>/)
+    expect(print_rating_stars(0.0)).to match(/<i class="far fa-star"><\/i><i class="far fa-star"><\/i><i class="far fa-star"><\/i><i class="far fa-star"><\/i><i class="far fa-star"><\/i>/)
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,27 +2,27 @@
 # yarn lockfile v1
 
 
-"@fortawesome/fontawesome-common-types@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.7.tgz#4336c4b06d0b5608ff1215464b66fcf9f4795284"
+"@fortawesome/fontawesome-common-types@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.2.tgz#7fd64eacf7f64e4d7619d21b0b2f2467f5a70611"
 
-"@fortawesome/fontawesome-free-regular@^5.0.13":
-  version "5.0.13"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free-regular/-/fontawesome-free-regular-5.0.13.tgz#eb78c30184e3f456a423a1dcfa0f682f7b50de4a"
+"@fortawesome/fontawesome-svg-core@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.2.tgz#b431e7efb3e3a1887e596daa6ed0d241d2d1aea5"
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.1.7"
+    "@fortawesome/fontawesome-common-types" "^0.2.2"
 
-"@fortawesome/fontawesome-free-solid@^5.0.13":
-  version "5.0.13"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free-solid/-/fontawesome-free-solid-5.0.13.tgz#24b61aaf471a9d34a5364b052d64a516285ba894"
+"@fortawesome/free-regular-svg-icons@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.2.0.tgz#6e96f19e349ac0d19b6758255c777f7331aeb40c"
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.1.7"
+    "@fortawesome/fontawesome-common-types" "^0.2.2"
 
-"@fortawesome/fontawesome@^1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-1.1.8.tgz#75fe66a60f95508160bb16bd781ad7d89b280f5b"
+"@fortawesome/free-solid-svg-icons@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.2.0.tgz#b51c1d49278ef538a97c0ce9575a1b54cc1a52dc"
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.1.7"
+    "@fortawesome/fontawesome-common-types" "^0.2.2"
 
 "@rails/webpacker@3.5":
   version "3.5.3"


### PR DESCRIPTION
# What is in this PR?

* Uprgade FA, to the new library dropping depreciated `@fortawesome/fontawesome-free-*`
* Fix `app/helpers/service_helper.rb:print_rating_stars` to use correct icons from FA 5.2

# How can I test it?

1. Navigate to services, if all stars are displayed then this PR works

Fixes #125