### PR TITLE
[#160 #161] Added additionaly step to order creation process 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem "redcarpet"
 # jira
 gem "jira-ruby"
 
+# redis
+gem "redis-rails"
+
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
 
@@ -74,6 +77,7 @@ group :test do
   gem "shoulda-matchers"
   gem "capybara"
   gem "database_cleaner"
+  gem "rack_session_access"
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,9 @@ GEM
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
+    rack_session_access (0.2.0)
+      builder (>= 2.0.0)
+      rack (>= 1.0.0)
     rails (5.2.0)
       actioncable (= 5.2.0)
       actionmailer (= 5.2.0)
@@ -257,6 +260,23 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
+    redis (4.0.2)
+    redis-actionpack (5.0.2)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.0.7)
+      activesupport (>= 3, < 6)
+      redis-store (>= 1.3, < 2)
+    redis-rack (2.0.4)
+      rack (>= 1.5, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.5.0)
+      redis (>= 2.2, < 5)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -411,8 +431,10 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   pundit (= 2.0.0.beta1)
+  rack_session_access
   rails (~> 5.2.0)
   redcarpet
+  redis-rails
   role_model
   rspec-rails (~> 3.7)
   rubocop-rails (>= 1.5.0)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We will need:
     Recommented way to manage nodejs versions is to use [asdf](https://github.com/asdf-vm/asdf)
     with [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs) plugin.
   * [postgresql](https://www.postgresql.org)
-
+  * redis (https://redis.io)
 ### Setup
 
   * First time run `/bin/setup`. It will install bundler, foreman,

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CartsController < ApplicationController
+  before_action :authenticate_user!, except: :create
+
+  def show
+    if !session[:order_item].blank?
+      @cart = Service.find(session[:order_item]["service_id"])
+    end
+  end
+
+  def create
+    session[:order_item] = params[:order]
+    redirect_to(action: :show)
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -16,6 +16,8 @@ class OrdersController < ApplicationController
   end
 
   def create
+    delete_order_from_session
+
     authorize(order_template)
     order = Order::Create.new(order_template).call
 
@@ -32,5 +34,9 @@ class OrdersController < ApplicationController
     def order_template
       @new_order ||= Order.new(permitted_attributes(Order).
                                merge(user: current_user))
+    end
+
+    def delete_order_from_session
+      session.delete(:order_item)
     end
 end

--- a/app/policies/cart_policy.rb
+++ b/app/policies/cart_policy.rb
@@ -1,0 +1,22 @@
+
+# frozen_string_literal: true
+
+class CartsPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.where(user: user)
+    end
+  end
+
+  def show?
+    record.user == user
+  end
+
+  def create?
+    true
+  end
+
+  def permitted_attributes
+    [:service_id]
+  end
+end

--- a/app/views/carts/_cart.html.haml
+++ b/app/views/carts/_cart.html.haml
@@ -1,0 +1,3 @@
+
+.div
+  = render "order_item", order_item: cart

--- a/app/views/carts/_order_item.html.haml
+++ b/app/views/carts/_order_item.html.haml
@@ -1,0 +1,10 @@
+
+.row
+  - if order_item
+    = form_for(Order.new) do |f|
+      %p= order_item.title
+      = f.hidden_field :service_id, value: order_item.id
+      %button{ class: "btn btn-primary" }
+        Order
+  - else
+    %p= "Cart is empty"

--- a/app/views/carts/show.html.haml
+++ b/app/views/carts/show.html.haml
@@ -1,0 +1,6 @@
+
+.container
+  = render "cart", cart: @cart
+
+
+

--- a/app/views/services/_description.html.haml
+++ b/app/views/services/_description.html.haml
@@ -4,13 +4,12 @@
       %h3 Terms of use
       = markdown(service.terms_of_use)
 
-      - if policy(Order.new).create?
-        = form_for(Order.new) do |f|
-          = f.hidden_field :service_id, value: service.id
-          %button{ class: "btn btn-primary" }
-            = write_button_text
-          - if @service.open_access?
-            = link_to "Go to the service", service.connected_url, class: "btn btn-primary", target: "_blank"
+      = form_for(Order.new, url: cart_path) do |f|
+        = f.hidden_field :service_id, value: service.id
+        %button{ class: "btn btn-primary" }
+          = write_button_text
+        - if @service.open_access?
+          = link_to "Go to the service", service.connected_url, class: "btn btn-primary", target: "_blank"
 
       %h3.mb-3.mt-3 Run virtual machines on-demand with complete control over computing resources.
       %p.mt-4 With Cloud Compute you can deploy and scale virtual machines on-demand. Cloud Compute offers guaranteed

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require "rack_session_access/capybara"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+
+  # Access to rack session
+  config.middleware.use RackSessionAccess::Middleware
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+if ENV["REDIS_URL"]
+  url = ENV["REDIS_URL"]
+else
+  url = "redis://localhost:6379/0/mp-session"
+end
+
+if Rails.env.test?
+  Rails.application.config.session_store :cookie_store,
+    key: "_mp_session"
+else
+  Mp::Application.config.session_store :redis_store,
+    servers: url,
+    expire_after: 90.minutes,
+    key: "_mp_session",
+    threadsafe: false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     delete "users/logout", to: "devise/sessions#destroy", as: :destroy_user_session
   end
 
+  resource :cart, only: [:show, :create]
+
   resources :services, only: [:index, :show]
   resources :categories, only: :show
   resources :orders, only: [:index, :show, :create] do

--- a/spec/features/carts_spec.rb
+++ b/spec/features/carts_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Cart" do
+  include OmniauthHelper
+
+  let(:user) { create(:user) }
+  let(:service) { create(:service) }
+
+  before { checkin_sign_in_as(user) }
+
+  scenario "I can create Order service" do
+    visit service_path(service)
+    click_on "Order"
+
+    expect { click_on "Order" }.
+      to change { Order.count }.by(1)
+    order = Order.last
+
+    expect(order.service).to eq(service)
+    expect(order.user).to eq(user)
+    expect(order).to be_created
+    expect(page).to_not have_content("Cart is empty")
+  end
+end


### PR DESCRIPTION
Ordering Button is visible for logged in and unlogged users. 
Added cart as page with order summary(only service  title). This solve the problem with redirection back after login in to the created order. When user click on "Order" service_id is saved in to the session and redirected to cart_path where mus be logged in.
Set Redis as session store.  
"Rack_session_access" gem is for session management in tests.



Fixed #160 #161 