### PR TITLE
Use stable pundit 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,7 @@ gem "elasticsearch-rails"
 gem "devise"
 gem "omniauth"
 gem "omniauth_openid_connect"
-# Need to use beta because of https://github.com/varvet/pundit/pull/529
-gem "pundit", "2.0.0.beta1"
+gem "pundit", "2.0.0"
 gem "role_model"
 
 # Markdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
-    pundit (2.0.0.beta1)
+    pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
     rack-oauth2 (1.9.2)
@@ -418,7 +418,7 @@ DEPENDENCIES
   pry-nav
   pry-rails
   puma (~> 3.11)
-  pundit (= 2.0.0.beta1)
+  pundit (= 2.0.0)
   rails (~> 5.2.0)
   redcarpet
   role_model


### PR DESCRIPTION
Pundit version 2.0.0 was already released and it contains a necessary fix for https://github.com/varvet/pundit/pull/529.