### PR TITLE
Order change with service provider message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Corrections My Profile view (@kosmidma)
 - Service opinion form and active job that send email to user about rating service 5 days after order is ready (@kmarszalek)
 - Sort services via selection of options in select box (@michal-szostak)
-- Store jira internal id in order change (@mkasztelnik)
+- Store Jira internal id in order change (@mkasztelnik)
+- Create new order change when Jira comment is posted (@mkasztelnik)
 
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We will need:
 ### Generating DB entries for development
 Actually, filling the database is done by parsing yaml: `db/data.yml`.
 Data come from actual official version of the marketplace.
-If you want to update informations, or add new services/categories you can add new records by edit yaml, 
+If you want to update informations, or add new services/categories you can add new records by edit yaml,
 but very imporant is, when some records are parent for other they must be written above their children.
 But if it's necessary, there is other option to fill the database:
 To simplify development `dev:prime` rake task is created. Right now it generates
@@ -67,7 +67,7 @@ or you can also use `systemctl`, it shouldn't matter which one you use.
 
 ## JIRA
 
-Marketplace is integrating with jira on a rather tight level. 
+Marketplace is integrating with jira on a rather tight level.
 For tests JIRA is stubbed, and for normal development it can be omitted,
 but in case there is a need for JIRA instance to exist it is recommeded
 to use jira instance provided by atlassian SDK.
@@ -88,7 +88,7 @@ ids skip it for now, `rails jira:check` will give you sensible hints, `.dotenv` 
 in the development environment, so you can store following variables in `.env` file in the root of the project):
 
 ```
-export MP_JIRA_PROJECT=MP 
+export MP_JIRA_PROJECT=MP
 export MP_JIRA_USERNAME=admin
 export MP_JIRA_PASSWORD=admin
 export MP_JIRA_CONTEXT_PATH=/jira
@@ -116,7 +116,8 @@ rails jira:setup
 As of now webhooks must be created manually. You can do it in your administrator
 panel on your JIRA instance.
 
-Webhook url must be as follows `<MP HOSTNAME e.g. http://localhost:2990>/api/webhooks/jira`.
+Webhook url must be as follows
+`<MP HOSTNAME e.g. http://localhost:2990>/api/webhooks/jira?issue_id=${issue.id}`.
 JQL for querying should be: `project = <PROJECT_KEY>`
 All notifications for issues and comments should be enabled.
 
@@ -160,7 +161,7 @@ ENV variables:
   * `ROOT_URL` (Optional) - root application URL (default
     `http://localhost:#{ENV["PORT"] || 3000}` (when foreman is used to start
     application 5000 ENV variable is set)
-  * `ELASTICSEARCH_URL` - elasticsearch url   
+  * `ELASTICSEARCH_URL` - elasticsearch url
 
 
 ## Commits

--- a/app/controllers/api/webhooks/jiras_controller.rb
+++ b/app/controllers/api/webhooks/jiras_controller.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 class Api::Webhooks::JirasController < ActionController::API
-  # before_action :find_and_authorize, only: [:show, :edit, :update, :destroy]
-
   class WebhookNotAuthorized < StandardError ; end
-
-  rescue_from(ActiveRecord::RecordNotFound) do
-    render json: { message: "No correlating order found" }
-  end
 
   rescue_from(WebhookNotAuthorized) do
     render json: { message: "Secret does not match" }, status: :bad_request
@@ -15,38 +9,32 @@ class Api::Webhooks::JirasController < ActionController::API
 
   before_action :authenticate_jira!
 
-  def initialize
-    @jira_client = Jira::Client.new
-  end
-
   def authenticate_jira!
-    raise WebhookNotAuthorized.new unless request.filtered_parameters.fetch("secret", "") == @jira_client.webhook_secret
+    raise WebhookNotAuthorized.new unless valid_jira_request?
   end
 
   def create
-    issue_id = request.filtered_parameters["issue"]["id"]
+    order = Order.find_by(issue_id: params["issue"]["id"])
 
-    order = Order.find_by!(issue_id: issue_id)
-
-    request.filtered_parameters["changelog"].fetch("items", []).each do |change|
-      if change["field"] == "status"
-        case change["to"].to_i
-        when @jira_client.wf_todo_id
-          status = Order::STATUSES[:registered]
-        when @jira_client.wf_in_progress_id
-          status = Order::STATUSES[:in_progress]
-        when @jira_client.wf_done_id
-          status = Order::STATUSES[:ready]
-        else
-          # :TODO, error, log, or do something to signalise that an unknown issue state has ocurred
-          return render json: { message: "Unknown issue status (#{change["to"]})" }
-        end
-
-        order.new_change(status: status, message: "Order Changed")
-        OrderMailer.changed(order).deliver_later
+    if order
+      case params["webhookEvent"]
+      when "jira:issue_updated"
+        Jira::IssueUpdated.new(order, params["changelog"]).call
+      else
+        logger.warn("Webhook event not supported: #{params["webhookEvent"]}")
       end
-    end
 
+    end
     render json: { message: "Updated" }
   end
+
+  private
+
+    def jira_client
+      @jira_client ||= Jira::Client.new
+    end
+
+    def valid_jira_request?
+      params.fetch("secret", "") == jira_client.webhook_secret
+    end
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -3,12 +3,20 @@
 module OrdersHelper
   def status_change(previous, current)
     if current.question?
-      "Order owner question"
+      "Your question to service provider"
     elsif previous
-      "Order changed from #{previous.status} to #{current.status}"
+      if answer?(previous, current)
+        "Service provider message"
+      else
+        "Order changed from #{previous.status} to #{current.status}"
+      end
     else
       "Order #{current.status}"
     end
+  end
+
+  def answer?(previous, current)
+    previous.status == current.status
   end
 
   def ratingable?

--- a/app/services/jira/comment_created.rb
+++ b/app/services/jira/comment_created.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Jira::CommentCreated
+  def initialize(order, comment)
+    @order = order
+    @comment = comment
+  end
+
+  def call
+    @order.new_change(message: body, author: author, iid: id) if body && unique?
+  end
+
+  private
+
+    def body
+      @comment["body"]
+    end
+
+    def id
+      @comment["id"]
+    end
+
+    def author
+      User.find_by(email: @comment["emailAddress"])
+    end
+
+    def unique?
+      !@order.order_changes.find_by(iid: id)
+    end
+end

--- a/app/services/jira/issue_updated.rb
+++ b/app/services/jira/issue_updated.rb
@@ -3,7 +3,7 @@
 class Jira::IssueUpdated
   def initialize(order, changelog)
     @order = order
-    @changelog = changelog
+    @changelog = changelog || {}
     @jira_client = Jira::Client.new
   end
 

--- a/app/services/jira/issue_updated.rb
+++ b/app/services/jira/issue_updated.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Jira::IssueUpdated
+  def initialize(order, changelog)
+    @order = order
+    @changelog = changelog
+    @jira_client = Jira::Client.new
+  end
+
+  def call
+    @changelog.fetch("items", []).each do |change|
+      status = nil
+      message = "Order status changed"
+
+      if change["field"] == "status"
+        case change["to"].to_i
+        when @jira_client.wf_todo_id
+          status = :registered
+        when @jira_client.wf_in_progress_id
+          status = :in_progress
+        when @jira_client.wf_done_id
+          status = :ready
+          message = "Ordered service is ready to be used"
+        else
+          Rails.logger.warn("Unknown issue status (#{change["to"]}")
+        end
+
+        if status
+          @order.new_change(status: status, message: message)
+          OrderMailer.changed(@order).deliver_later
+        end
+      end
+    end
+  end
+end

--- a/app/views/orders/_order_change.html.haml
+++ b/app/views/orders/_order_change.html.haml
@@ -1,14 +1,9 @@
 %li.step-progress-item.current.ml-4
   -# :TODO UX
   %p.time.x-small.text-muted 15.10.18 10:00
-  - if current.question?
-    .ml-4
-      .x-small.text-uppercase.d-block= status_change(previous, current)
-      %p= current.message
-  - else
-    .ml-4
-      .x-small.text-uppercase.d-block= status_change(previous, current)
-      %p= current.message
+  .ml-4
+    .x-small.text-uppercase.d-block= status_change(previous, current)
+    %p= current.message
 
 
 

--- a/spec/requests/rest/webhooks/jira_spec.rb
+++ b/spec/requests/rest/webhooks/jira_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe "JIRA Webhook API", type: :request do
 
   describe "POST /api/webhooks/jira" do
     describe "wrong secret" do
-      before {
-        post api_webhooks_jira_path
-      }
+      before { post api_webhooks_jira_path }
 
       it "returns error message" do
         expect(json).to eq("message" => "Secret does not match")
@@ -30,7 +28,7 @@ RSpec.describe "JIRA Webhook API", type: :request do
       before {
         order = create(:order, issue_id: issue_id)
         data = create(:jira_webhook_response, issue_id: issue_id, issue_status: 6)
-        post(api_webhooks_jira_url + "?secret=secret", params: data)
+        post(api_webhooks_jira_url + "?secret=secret&issue_id=5", params: data)
       }
 
       it "returns status code 200" do

--- a/spec/requests/rest/webhooks/jira_spec.rb
+++ b/spec/requests/rest/webhooks/jira_spec.rb
@@ -3,20 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "JIRA Webhook API", type: :request do
-  include Rails.application.routes.url_helpers
   include RequestSpecHelper
+  include JiraHelper
 
-  before {
-    jira_client     = double("Jira::Client",
-                             jira_project_key: "MP",
-                             jira_issue_type_id: 5,
-                             webhook_secret: "secret",
-                             wf_todo_id: 5,
-                             wf_in_progress_id: 6,
-                             wf_done_id: 7)
-    jira_class_stub = class_double(Jira::Client).as_stubbed_const(transfer_nested_constants: true)
-    allow(jira_class_stub).to receive(:new).and_return(jira_client)
-  }
+  before { stub_jira }
 
   describe "POST /api/webhooks/jira" do
     describe "wrong secret" do
@@ -30,21 +20,6 @@ RSpec.describe "JIRA Webhook API", type: :request do
 
       it "returns status code 400 if wrong secret is provided" do
         expect(response).to have_http_status(:bad_request)
-      end
-    end
-
-    describe "Correct secret with data" do
-      before {
-        data = create(:jira_webhook_response)
-        post(api_webhooks_jira_url + "?secret=secret", params: data)
-      }
-
-      it "returns status code 200" do
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "returns 'no order changed' message" do
-        expect(json).to eq("message" => "No correlating order found")
       end
     end
 

--- a/spec/services/jira/comment_created_spec.rb
+++ b/spec/services/jira/comment_created_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Jira::CommentCreated do
+  let(:order) { create(:order, status: :registered) }
+
+  it "creates new order change" do
+    expect { described_class.new(order, comment(message: "msg", id: 123)).call }.
+      to change { order.order_changes.count }.by(1)
+  end
+
+  it "sets message and comment id" do
+    described_class.new(order, comment(message: "msg", id: "123")).call
+    last_change = order.order_changes.last
+
+    expect(last_change.message).to eq("msg")
+    expect(last_change.iid).to eq(123)
+  end
+
+  it "does not change order status" do
+    described_class.new(order, comment(message: "msg", id: "123")).call
+
+    expect(order).to be_registered
+    expect(order.order_changes.last).to be_registered
+  end
+
+  it "does not duplicate order changes" do
+    # Such situation can occur when we are sending question from MP to jira.
+    # Than jira webhood with new comment is triggered.
+    order.new_change(message: "question", iid: 321)
+
+    expect do
+      described_class.new(order, comment(message: "question", id: "321")).call
+    end.to_not change { order.order_changes.count }
+  end
+
+  def comment(message:, id:, author: "non@existing.pl")
+    { "body" => message, "id" => id, "emailAddress" => author }
+  end
+end

--- a/spec/services/jira/issue_updated_spec.rb
+++ b/spec/services/jira/issue_updated_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Jira::IssueUpdated do
+  include JiraHelper
+
+  before { stub_jira }
+
+  let(:order) { create(:order) }
+
+  it "creates new changelog entry" do
+    described_class.new(order, changelog(to: jira_client.wf_in_progress_id)).call
+
+    expect(order.order_changes.last).to be_in_progress
+  end
+
+  it "set dedicated changelog message when service become ready" do
+    described_class.new(order, changelog(to: jira_client.wf_done_id)).call
+    last_change = order.order_changes.last
+
+    expect(last_change).to be_ready
+    expect(last_change.message).to include "ready to be used"
+  end
+
+  def changelog(to:)
+    { "items" => [
+      { "field" => "status", "to" => to }
+    ] }
+  end
+end


### PR DESCRIPTION
When a new message is added in Jira it is also registered in MP as service provider message.

To make webhooks more generic (for the status update and messages) `issue_id` query param need to be defined. Otherwise, it was tricky to get issue id for new comment (url regexp was needed). This query param fixes problem (described in the `README.md`).

Fixes #199