### PR TITLE
Fix random failing test

### DIFF
--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Services in backoffice" do
   end
 
   scenario "I can create new service" do
-    create(:provider)
+    provider = create(:provider)
     visit backoffice_services_path
     click_on "Create new service"
 
@@ -61,7 +61,7 @@ RSpec.feature "Services in backoffice" do
     fill_in "Tutorial url", with: "https://sample.url"
     fill_in "Restrictions", with: "Reaserch affiliation needed"
     fill_in "Phase", with: "Production"
-    select "provider 1", from: "service_provider_id"
+    select provider.name, from: "service_provider_id"
 
     check "Open access"
 


### PR DESCRIPTION
This problem was connected with the situation when other providers were already created in DB. Fix is to use real new created provider name.