### PR TITLE
Related services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add breadcrumbs to order index and show (@mkasztelnik)
 - Tabs to My profile view (@kmarszalek)
 - 3 steps ordering (@mkasztelnik)
+- Related services (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/controllers/services/summaries_controller.rb
+++ b/app/controllers/services/summaries_controller.rb
@@ -14,6 +14,7 @@ class Services::SummariesController < Services::ApplicationController
     @project_item = ProjectItem::Create.new(project_item_template).call
 
     if @project_item.persisted?
+      @related_services = @service.related_services.includes(:provider)
       render :confirmation, layout: "ordered"
     else
       redirect_to service_configuration_path(@service),

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -13,5 +13,6 @@ class ServicesController < ApplicationController
     @service = Service.find(params[:id])
     @service_opinions = ServiceOpinion.joins(project_item: :offer).
                         where(offers: { service_id: @service })
+    @related_services = @service.related_services.includes(:provider)
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -11,6 +11,20 @@ class Service < ApplicationRecord
   has_many :categories, through: :service_categories
   has_many :service_opinions, through: :project_items
 
+  has_many :source_relationships,
+           class_name: "ServiceRelationship",
+           foreign_key: "target_id",
+           dependent: :destroy,
+           inverse_of: :target
+  has_many :target_relationships,
+           class_name: "ServiceRelationship",
+           foreign_key: "source_id",
+           dependent: :destroy,
+           inverse_of: :source
+  has_many :related_services,
+           through: :target_relationships,
+           source: :target
+
   belongs_to :owner,
              class_name: "User",
              optional: true

--- a/app/models/service_relationship.rb
+++ b/app/models/service_relationship.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ServiceRelationship < ApplicationRecord
+  belongs_to :source, class_name: "Service", foreign_key: "source_id"
+  belongs_to :target, class_name: "Service", foreign_key: "target_id"
+end

--- a/app/views/services/_related.html.haml
+++ b/app/views/services/_related.html.haml
@@ -1,0 +1,7 @@
+- if related_services.count.positive?
+  %h3 Services you can use with this service
+
+  %ul
+    = render partial: "services/service_box",
+            collection: related_services,
+            as: :service

--- a/app/views/services/_service_box.html.haml
+++ b/app/views/services/_service_box.html.haml
@@ -1,0 +1,5 @@
+%li
+  %h3= link_to service.title, service_path(service)
+  %p= service.tagline
+  %p Provided by: #{service.provider.name}
+  %p Dedicated for #{service.dedicated_for}

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -22,4 +22,4 @@
   = render "services/opinions", service_opinions: @service_opinions
 
 .container
-  %h3 Customers who project_itemed this service also viewed
+  = render "services/related", related_services: @related_services

--- a/app/views/services/summaries/confirmation.html.haml
+++ b/app/views/services/summaries/confirmation.html.haml
@@ -1,3 +1,5 @@
 Huray, you ordered this service!!!
 
 = link_to "Go to your service request", project_item_path(@project_item)
+
+= render "services/related", related_services: @related_services

--- a/db/migrate/20181024093203_create_service_relationships.rb
+++ b/db/migrate/20181024093203_create_service_relationships.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateServiceRelationships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :service_relationships do |t|
+      t.belongs_to :source, foreign_key: { to_table: :services }, null: false
+      t.belongs_to :target, foreign_key: { to_table: :services }, null: false
+
+      t.timestamps
+    end
+
+    add_index :service_relationships, [:source_id, :target_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_22_113346) do
+ActiveRecord::Schema.define(version: 2018_10_24_093203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,6 +114,16 @@ ActiveRecord::Schema.define(version: 2018_10_22_113346) do
     t.index ["project_item_id"], name: "index_service_opinions_on_project_item_id"
   end
 
+  create_table "service_relationships", force: :cascade do |t|
+    t.bigint "source_id", null: false
+    t.bigint "target_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["source_id", "target_id"], name: "index_service_relationships_on_source_id_and_target_id", unique: true
+    t.index ["source_id"], name: "index_service_relationships_on_source_id"
+    t.index ["target_id"], name: "index_service_relationships_on_target_id"
+  end
+
   create_table "services", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
@@ -166,6 +176,8 @@ ActiveRecord::Schema.define(version: 2018_10_22_113346) do
   add_foreign_key "project_item_changes", "users", column: "author_id"
   add_foreign_key "project_items", "offers"
   add_foreign_key "project_items", "projects"
+  add_foreign_key "service_relationships", "services", column: "source_id"
+  add_foreign_key "service_relationships", "services", column: "target_id"
   add_foreign_key "services", "providers"
   add_foreign_key "services", "users", column: "owner_id"
 end

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -19,6 +19,23 @@ RSpec.feature "Service browsing" do
     expect(page.body).to have_content service.tagline
   end
 
+  scenario "shows related services" do
+    service, related = create_list(:service, 2)
+    ServiceRelationship.create!(source: service, target: related)
+
+    visit service_path(service)
+
+    expect(page.body).to have_content "Services you can use with this service"
+    expect(page.body).to have_content related.title
+  end
+
+  scenario "does not show related services section when no related services" do
+    service = create(:service)
+
+    visit service_path(service)
+
+    expect(page.body).to_not have_content "Services you can use with this service"
+  end
 end
 
 

--- a/spec/models/service_relationship_spec.rb
+++ b/spec/models/service_relationship_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe ServiceRelationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -70,4 +70,12 @@ RSpec.describe Service do
     expect(create(:service).rating).to eq(0.0)
   end
 
+  it "has related services" do
+    s1, s2, s3 = create_list(:service, 3)
+
+    ServiceRelationship.create(source: s1, target: s2)
+    ServiceRelationship.create(source: s1, target: s3)
+
+    expect(s1.related_services).to contain_exactly(s2, s3)
+  end
 end


### PR DESCRIPTION
Related services are shown on service show view and in the service order confirmation page. n-n relation between `Services` is modeled using `ServiceRelationship` model. It can be used to model additional
relationships between services. E.g. additional field `relation_type` can be added to `ServiceRelationship`, next `where` condition can be added into `Service` `has_many` relation between services.

This PR solves everything described in #223 except:
  * formatting (nice css which deals with multiple related services need to be created - there can be 1 or 10 related services thus some grid layout need to be applied)
  * showing elements which are not yet available in the service model (`Area (scientific discipline)`)

This is how it looks like right now:
![related-services](https://user-images.githubusercontent.com/1265430/47439259-5e39e780-d7ac-11e8-899f-bf1c90b8c20f.png)

To create relation between services following snippet can be used:

```ruby
service = Service.first
related = Service.second

ServiceRelationship.new(source: service, target: related)
```