### PR TITLE
Clear order session after ordering service

### DIFF
--- a/app/controllers/services/summaries_controller.rb
+++ b/app/controllers/services/summaries_controller.rb
@@ -14,6 +14,7 @@ class Services::SummariesController < Services::ApplicationController
     @project_item = ProjectItem::Create.new(project_item_template).call
 
     if @project_item.persisted?
+      session.delete(session_key)
       render :confirmation, layout: "ordered"
     else
       redirect_to service_configuration_path(@service),


### PR DESCRIPTION
This avoids user to reload summary page and order service once again.