### PR TITLE
Show 10, 20 or 30 services per page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Tabs to My profile view (@kmarszalek)
 - 3 steps ordering (@mkasztelnik)
 - New header & footer look (@kosmidma)
+- Show 10, 20 or 30 services per page (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,17 +2,21 @@
 
 class CategoriesController < ApplicationController
   include Service::Searchable
+  include Paginable
 
   before_action :category
 
   def show
-    @services = records.joins(:service_categories).
-      where(service_categories: { category_id: category_and_descendant_ids }).
-      page(params[:page])
+    @services = paginate(category_services)
     @subcategories = category.children
   end
 
   private
+
+    def category_services
+      records.joins(:service_categories).
+        where(service_categories: { category_id: category_and_descendant_ids })
+    end
 
     def category_and_descendant_ids
       [category] + category.descendant_ids

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Paginable
+  extend ActiveSupport::Concern
+
+  private
+
+    def paginate(records)
+      records.paginate(page: params[:page], per_page: per_page)
+    end
+
+    def per_page
+      per_page = params[:per_page].to_i
+      per_page == 0 ? 10 : per_page
+    end
+end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -3,9 +3,10 @@
 class ServicesController < ApplicationController
   include Service::Searchable
   include Service::Sortable
+  include Paginable
 
   def index
-    @services = records.order(ordering).page(params[:page])
+    @services = paginate(records.order(ordering))
     @subcategories = Category.roots
   end
 

--- a/app/views/services/_services.html.haml
+++ b/app/views/services/_services.html.haml
@@ -2,21 +2,21 @@
   = render services
 //Static element from Andrzej's draft
 .d-flex
-  %nav.mr-auto.mt-3.mb-4
-    %ul.pagination
-      %li.page-item.active
-        %a.page-link
-          10
-      %li.page-item
-        %a.page-link
-          20
-      %li.page-item
-        %a.page-link
-          30
-      %li.page-item.disabled
-        %a.page-link.text-dark
-          Items on page
+  .p-2.flex-grow-1
+    %nav
+      %ul.pagination
+        - per_page = params[:per_page]
+        %li.page-item{ class: ("active" if (per_page.blank? || per_page == "10")) }
+          = link_to "10", params.merge(per_page: 10).permit!, class: "page-link"
+        %li.page-item{ class: ("active" if per_page == "20") }
+          = link_to "20", params.merge(per_page: 20).permit!, class: "page-link"
+        %li.page-item{ class: ("active" if per_page == "30") }
+          = link_to "30", params.merge(per_page: 30).permit!, class: "page-link"
+        %li.page-item.disabled
+          %a.page-link.text-dark
+            Items on page
 
-  .mt-3.mb-4
+
+  .p-2
     = will_paginate services
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,25 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "594749ab9e2747f8efd8d221a333f94751a1f3a572ac1a30af8c26fab1a7511f",
+      "check_name": "MassAssignment",
+      "message": "Parameters should be whitelisted for mass assignment",
+      "file": "app/views/services/_services.html.haml",
+      "line": 12,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":12,"file":"app/controllers/categories_controller.rb"},{"type":"template","name":"categories/show","line":9,"file":"app/views/categories/show.html.haml"}],
+      "location": {
+        "type": "template",
+        "template": "services/_services"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "77ce5d3f4dc49b266bfc30250e63c42ce08d3ea00e6709efac8a0cd1d7e69a97",
@@ -38,8 +57,46 @@
       "user_input": "params.require(:file)",
       "confidence": "High",
       "note": ""
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "acd7e7a3f315d8b18f5cacf696a8b2feb9392a12c964e88565ff510c8bbe421e",
+      "check_name": "MassAssignment",
+      "message": "Parameters should be whitelisted for mass assignment",
+      "file": "app/views/services/_services.html.haml",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":12,"file":"app/controllers/categories_controller.rb"},{"type":"template","name":"categories/show","line":9,"file":"app/views/categories/show.html.haml"}],
+      "location": {
+        "type": "template",
+        "template": "services/_services"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "bb6cdc7709cb7df03208d094e5b35e02e2ce614bfbf68ec4bd258ea5d482624a",
+      "check_name": "MassAssignment",
+      "message": "Parameters should be whitelisted for mass assignment",
+      "file": "app/views/services/_services.html.haml",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":12,"file":"app/controllers/categories_controller.rb"},{"type":"template","name":"categories/show","line":9,"file":"app/views/categories/show.html.haml"}],
+      "location": {
+        "type": "template",
+        "template": "services/_services"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
     }
   ],
-  "updated": "2018-07-06 23:53:59 +0200",
-  "brakeman_version": "4.3.1"
+  "updated": "2018-10-25 09:33:06 +0200",
+  "brakeman_version": "4.2.1"
 }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2018_10_22_113346) do
     t.boolean "open_access", default: false
     t.bigint "provider_id"
     t.integer "service_opinion_count", default: 0
+    t.text "contact_emails", default: [], array: true
     t.text "places", null: false
     t.text "languages", null: false
     t.text "dedicated_for", null: false
@@ -139,7 +140,6 @@ ActiveRecord::Schema.define(version: 2018_10_22_113346) do
     t.text "tutorial_url", null: false
     t.text "restrictions", null: false
     t.text "phase", null: false
-    t.text "contact_emails", default: [], array: true
     t.index ["description"], name: "index_services_on_description"
     t.index ["owner_id"], name: "index_services_on_owner_id"
     t.index ["provider_id"], name: "index_services_on_provider_id"

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -57,4 +57,13 @@ RSpec.feature "Service categories" do
     expect(page.body).to have_content s3.title
     expect(page.body).to_not have_content other_service.title
   end
+
+  scenario "limit number of services per page" do
+    category = create(:category)
+    create_list(:service, 2, categories: [category])
+
+    visit category_path(category, per_page: "1")
+
+    expect(page).to have_selector("dl > ul", count: 1)
+  end
 end

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -115,4 +115,12 @@ RSpec.feature "Service filtering and sorting" do
     expect(page.body.index("DDDD Something 3")).to be < page.body.index("DDDD Something 2")
     expect(page.body.index("DDDD Something 2")).to be < page.body.index("DDDD Something 1")
   end
+
+  scenario "limit number of services per page" do
+    create_list(:service, 2)
+
+    visit services_path(per_page: "1")
+
+    expect(page).to have_selector("dl > ul", count: 1)
+  end
 end


### PR DESCRIPTION
Links for defining a number of shown services per page are working.