### PR TITLE
Skip offer selection when only one offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Tabs to My profile view (@kmarszalek)
 - 3 steps ordering (@mkasztelnik)
 - New header & footer look (@kosmidma)
+- Go to order configuration step directly when there is only one offer (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/controllers/services/offers_controller.rb
+++ b/app/controllers/services/offers_controller.rb
@@ -3,11 +3,16 @@
 class Services::OffersController < Services::ApplicationController
   def index
     @offers = @service.offers
+
+    if @service.offers_count == 1
+      select_offer(@offers.first)
+      redirect_to service_configuration_path(@service)
+    end
   end
 
   def update
     if offer
-      session[session_key] = { "offer_id" => offer.id }
+      select_offer(offer)
       redirect_to service_configuration_path(@service)
     else
       @offers = @service.offers
@@ -17,6 +22,10 @@ class Services::OffersController < Services::ApplicationController
   end
 
   private
+
+    def select_offer(offer)
+      session[session_key] = { "offer_id" => offer.id }
+    end
 
     def offer
       @offer ||= @service.offers.find_by(iid: offer_params[:offer_id])

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class Offer < ApplicationRecord
-  belongs_to :service
+  belongs_to :service,
+             counter_cache: true
 
-  has_many :project_items, dependent: :restrict_with_error
+  has_many :project_items,
+           dependent: :restrict_with_error
 
   validate :set_iid, on: :create
   validates :name, presence: true

--- a/db/migrate/20181022085713_create_offers.rb
+++ b/db/migrate/20181022085713_create_offers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateOffers < ActiveRecord::Migration[5.2]
   def change
     create_table :offers do |t|

--- a/db/migrate/20181022113319_add_offer_ref_to_project_item.rb
+++ b/db/migrate/20181022113319_add_offer_ref_to_project_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOfferRefToProjectItem < ActiveRecord::Migration[5.2]
   def change
     add_reference :project_items, :offer, foreign_key: true, index: true

--- a/db/migrate/20181022113346_remove_service_ref_from_project_item.rb
+++ b/db/migrate/20181022113346_remove_service_ref_from_project_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveServiceRefFromProjectItem < ActiveRecord::Migration[5.2]
   def change
     remove_reference :project_items, :service, index: true, foreign: true

--- a/db/migrate/20181025095520_add_offers_count.rb
+++ b/db/migrate/20181025095520_add_offers_count.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOffersCount < ActiveRecord::Migration[5.2]
   def change
     add_column :services, :offers_count, :integer, default: 0

--- a/db/migrate/20181025095520_add_offers_count.rb
+++ b/db/migrate/20181025095520_add_offers_count.rb
@@ -1,0 +1,5 @@
+class AddOffersCount < ActiveRecord::Migration[5.2]
+  def change
+    add_column :services, :offers_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_22_113346) do
+ActiveRecord::Schema.define(version: 2018_10_25_095520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2018_10_22_113346) do
     t.boolean "open_access", default: false
     t.bigint "provider_id"
     t.integer "service_opinion_count", default: 0
+    t.text "contact_emails", default: [], array: true
     t.text "places", null: false
     t.text "languages", null: false
     t.text "dedicated_for", null: false
@@ -139,7 +140,7 @@ ActiveRecord::Schema.define(version: 2018_10_22_113346) do
     t.text "tutorial_url", null: false
     t.text "restrictions", null: false
     t.text "phase", null: false
-    t.text "contact_emails", default: [], array: true
+    t.integer "offers_count", default: 0
     t.index ["description"], name: "index_services_on_description"
     t.index ["owner_id"], name: "index_services_on_owner_id"
     t.index ["provider_id"], name: "index_services_on_provider_id"

--- a/lib/tasks/counter_cache.rake
+++ b/lib/tasks/counter_cache.rake
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 desc "Counter cache for categories has many services"
-task service_counter: :environment do
+task category_counter: :environment do
   Category.reset_column_information
   Category.pluck(:id).each do |id|
     Category.reset_counters(id, :services)
+  end
+end
+
+desc "Counter cache for services has many offers"
+task service_counter: :environment do
+  Service.reset_column_information
+  Service.pluck(:id).each do |id|
+    Service.reset_counters(id, :offers)
   end
 end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature "Service ordering" do
 
     let(:user) { create(:user) }
     let(:service) { create(:service) }
-    let(:offer) { create(:offer, service: service) }
 
     before { checkin_sign_in_as(user) }
 
@@ -28,8 +27,8 @@ RSpec.feature "Service ordering" do
     end
 
     scenario "I can order service" do
-      # force offer creation
-      offer
+      offer, _seconds_offer = create_list(:offer, 2, service: service)
+
       visit service_path(service)
 
       click_on "Order"
@@ -74,6 +73,16 @@ RSpec.feature "Service ordering" do
       expect(page).to have_content(service.title)
     end
 
+    scenario "Skip offers selection when only one offer" do
+      create(:offer, service: service)
+
+      visit service_path(service)
+
+      click_on "Order"
+
+      expect(page).to have_current_path(service_configuration_path(service))
+    end
+
     scenario "I'm redirected into service offers when offer is not chosen" do
       visit service_configuration_path(service)
 
@@ -81,13 +90,10 @@ RSpec.feature "Service ordering" do
     end
 
     scenario "I'm redirected into service configuration when order is not valid" do
-      # Force offer creation
-      offer
-      visit service_offers_path(service)
+      create(:offer, service: service)
+      visit service_path(service)
 
-      # Select offer
-      select offer.iid
-      click_on "Next"
+      click_on "Order"
 
       # Go directly to summary page
       visit service_summary_path(service)


### PR DESCRIPTION
@wziajka after this PR is merged following rake task need to be invoked manually once

```
rails service_counter 
```

this will generate counter cache for existing service offers