### PR TITLE
Autoselect default project for open access service order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 - New header & footer look (@kosmidma)
 - Show 10, 20 or 30 services per page (@mkasztelnik)
 - Go to order configuration step directly when there is only one offer (@mkasztelnik)
+- Autoselect default project to open access service order and go directly to
+  summary page (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -103,15 +103,25 @@ RSpec.feature "Service ordering" do
 
     scenario "I can order open acces service" do
       open_access_service = create(:open_access_service)
+      offer = create(:offer, service: open_access_service)
+      default_project = user.projects.find_by(name: "Services")
 
       visit service_path(open_access_service)
 
       click_on "Add to my services"
 
-      expect(page).to have_current_path(service_offers_path(open_access_service))
-      expect(page).to have_text(open_access_service.title)
+      # Go directly to summary page
+      expect(page).to have_current_path(service_summary_path(open_access_service))
       expect(page).to have_selector(:link_or_button,
-                                    "Next", exact: true)
+                                    "Order", exact: true)
+
+      expect do
+        click_on "Order"
+      end.to change { ProjectItem.count }.by(1)
+      project_item = ProjectItem.last
+
+      expect(project_item.offer).to eq(offer)
+      expect(project_item.project).to eq(default_project)
     end
   end
 


### PR DESCRIPTION
When a project is selected and order (project item) is valid user is redirected directly to the summary order page.