### PR TITLE
Fix jira check after adding issue_id

### DIFF
--- a/app/models/jira/checker.rb
+++ b/app/models/jira/checker.rb
@@ -134,7 +134,7 @@ class Jira::Checker
     webhook = nil
     # noinspection RubyDeadCode
     self.client.Webhook.all.each do |wh|
-      if wh.attrs["url"] == (host + api_webhooks_jira_path)
+      if wh.attrs["url"] == (host + api_webhooks_jira_path + "?issue_id=${issue.id}")
         unless wh.enabled
           raise CheckerWarning.new("Webhook \"#{wh.name}\" is not enabled")
         end

--- a/spec/models/jira/checker_spec.rb
+++ b/spec/models/jira/checker_spec.rb
@@ -117,10 +117,10 @@ describe Jira::Checker do
 
       def initialize(project_key, events = [])
         @filters = {
-            "issue-related-events-section" => "project = #{project_key} "
+          "issue-related-events-section" => "project = #{project_key} "
         }
         @attrs = {
-            "url" => ("http://localhost:2990" + api_webhooks_jira_path)
+          "url" => ("http://localhost:2990" + api_webhooks_jira_path + "?issue_id=${issue.id}")
         }
         @events = events
         @enabled = true


### PR DESCRIPTION
Jira check was not updated after mandatory `issue_id` query param was added to webhook return url. Here this situation if fixed.