### PR TITLE
Sidekiq for background jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Related services (@mkasztelnik)
 - Service activate message (@mkasztelnik)
 - Order steps layout (@mkasztelnik)
+- Sidekiq for delayed jobs (@mkasztelnik)
+- Admin administration panel stub with sidekiq monitoring and MP version (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/Gemfile
+++ b/Gemfile
@@ -43,8 +43,8 @@ gem "redcarpet"
 # jira
 gem "jira-ruby"
 
-# redis
 gem "redis-rails"
+gem "sidekiq"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.2)
     crass (1.0.4)
     database_cleaner (1.7.0)
     devise (4.4.3)
@@ -223,6 +224,8 @@ GEM
       httpclient
       json-jwt (>= 1.9.0)
       rack
+    rack-protection (2.0.4)
+      rack
     rack-proxy (0.6.4)
       rack
     rack-test (1.0.0)
@@ -336,6 +339,10 @@ GEM
     sexp_processor (4.11.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
+    sidekiq (5.2.2)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simple_form (4.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -451,6 +458,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   shoulda-matchers
+  sidekiq
   simple_form
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -p $PORT
+jobs: bundle exec sidekiq -q orders -q mailers

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bundle exec rails s
 # watcher: ./bin/webpack-watcher
 webpacker: ./bin/webpack-dev-server
+jobs: bundle exec sidekiq -q orders -q mailers

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Admin::ApplicationController < ApplicationController
+  before_action :authenticate_user!
+  before_action :admin_authorization!
+
+  layout "admin"
+
+  def policy_scope(scope)
+    super([:admin, scope])
+  end
+
+  def authorize(record, query = nil)
+    super([:admin, record], query)
+  end
+
+  def permitted_attributes(record, action = action_name)
+    super([:admin, record], action)
+  end
+
+  private
+
+    def admin_authorization!
+      authorize :admin, :show?
+    end
+end

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Admin::JobsController < Admin::ApplicationController
+  def index
+  end
+end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class AdminsController < Admin::ApplicationController
+  def show
+  end
+end

--- a/app/javascript/stylesheets/admin/_jobs.scss
+++ b/app/javascript/stylesheets/admin/_jobs.scss
@@ -1,0 +1,5 @@
+.sidekiq-jobs {
+  width: 100%;
+  height: 1000px;
+  border: none;
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -6,3 +6,4 @@
 @import 'footer';
 @import 'header';
 @import 'order';
+@import 'admin/jobs';

--- a/app/jobs/project_item/ready_job.rb
+++ b/app/jobs/project_item/ready_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectItem::ReadyJob < ApplicationJob
-  queue_as :project_items
+  queue_as :orders
 
   def perform(project_item)
     ProjectItem::Ready.new(project_item).call

--- a/app/jobs/project_item/register_job.rb
+++ b/app/jobs/project_item/register_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectItem::RegisterJob < ApplicationJob
-  queue_as :project_items
+  queue_as :orders
 
   rescue_from(ProjectItem::Register::JIRAIssueCreateError) do |exception|
     # TODO: we need to define what to do when question registration in e.g.

--- a/app/jobs/project_item/register_question_job.rb
+++ b/app/jobs/project_item/register_question_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectItem::RegisterQuestionJob < ApplicationJob
-  queue_as :project_items
+  queue_as :orders
 
   rescue_from(ProjectItem::RegisterQuestion::JIRACommentCreateError) do |exception|
     # TODO: we need to define what to do when question registration in e.g.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: %i[checkin]
 
   include RoleModel
-  roles :service_owner
+  roles :admin, :service_owner
 
   has_many :projects, dependent: :destroy
   has_many :affiliations, dependent: :destroy

--- a/app/policies/admin/admin_policy.rb
+++ b/app/policies/admin/admin_policy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# I know that it looks weird to have module and class prefix the same
+# but this is trade off to simplify backoffice policies usage in all
+# backoffice controllers. Taka a look into
+# app/controllers/backoffice/application_controller.rb where default pundit
+# methods are overriden to add :backoffice prefix in automatic way.
+class Admin::AdminPolicy < Struct.new(:user, :admin)
+  def show?
+    user&.admin?
+  end
+end

--- a/app/views/admin/jobs/index.html.haml
+++ b/app/views/admin/jobs/index.html.haml
@@ -1,0 +1,3 @@
+%h1 Delayed jobs
+%p
+  %iframe.sidekiq-jobs{ src: sidekiq_web_path }

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -1,0 +1,9 @@
+- if (ENV["MP_VERSION"])
+  .alert.alert-info.text-center
+    Marketplace version:
+    %code= ENV["MP_VERSION"]
+- else
+  .alert.alert-warning.text-center
+    Marketplace version not defined in
+    %code MP_VERSION
+    environment variable

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -11,6 +11,9 @@
         - if policy([:backoffice, :backoffice]).show?
           %li.list-inline-item.ml-2
             = link_to "Backoffice", backoffice_path
+        - if policy([:admin, :admin]).show?
+          %li.list-inline-item.ml-2
+            = link_to "Admin", admin_path
         %li.list-inline-item.ml-2
           = link_to "Logout", destroy_user_session_path, method: :delete
       - else

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -1,0 +1,14 @@
+!!!
+%html{ lang: "en" }
+  = render "layouts/head"
+  %body
+    %header.pt-2.pb-2
+      = render "layouts/admin/navbar"
+      = render "layouts/flash"
+    %main
+      = render "layouts/breadcrumb"
+      .container
+        = yield
+  = render "layouts/footer"
+
+

--- a/app/views/layouts/admin/_navbar.html.haml
+++ b/app/views/layouts/admin/_navbar.html.haml
@@ -1,0 +1,24 @@
+.container
+  %nav.navbar.navbar-expand-lg.navbar-light.bg-light
+    = link_to admin_path, class: "navbar-brand" do
+      %strong EOSC
+      Administration panel
+    %button.navbar-toggler{ "aria-controls" => "navbar-supported-content",
+                            "aria-expanded" => "false", "aria-label" => "Toggle navigation",
+                            "data-target" => "#navbar-supported-content",
+                            "data-toggle" => "collapse",
+                             type: "button" }
+      %span.navbar-toggler-icon
+
+    #navbar-supported-content.collapse.navbar-collapse
+      %ul.navbar-nav.ml-auto.pt-2
+        = nav_link controller: :admins do
+          = link_to "Getting Started", admin_path, class: "nav-link px-3 py-1"
+        = nav_link controller: :jobs do
+          = link_to "Delayed jobs", admin_jobs_path, class: "nav-link px-3 py-1"
+        = nav_link controller: :home do
+          = link_to "EOSC Portal", root_path, class: "nav-link px-3 py-1"
+        %li.nav-item
+          = link_to "Logout", destroy_user_session_path, method: :delete, class: "nav-link px-3 py-1"
+
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,7 @@ module Mp
     config.generators.system_tests = nil
 
     config.autoload_paths << Rails.root.join("lib")
+
+    config.redis_url = ENV["REDIS_URL"] || "redis://localhost:6379/0"
   end
 end

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActiveJob::Base.queue_adapter = Rails.env.test? ? :inline : :sidekiq

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-if ENV["REDIS_URL"]
-  url = ENV["REDIS_URL"]
-else
-  url = "redis://localhost:6379/0/mp-session"
-end
-
 if Rails.env.test?
   Rails.application.config.session_store :cookie_store,
     key: "_mp_session"
 else
   Mp::Application.config.session_store :redis_store,
-    servers: url,
+    servers: "#{Mp::Application.config.redis_url}/mp-session",
     expire_after: 90.minutes,
     key: "_mp_session",
     threadsafe: false

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+sidekiq_connection = {
+  url: Mp::Application.config.redis_url
+}
+
+Sidekiq.configure_server do |config|
+  config.redis = sidekiq_connection
+  config.average_scheduled_poll_interval = 1
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = sidekiq_connection
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,5 +56,15 @@ Rails.application.routes.draw do
         constraints: { file: %r{[^/\.]+} }
   end
 
+  resource :admin, only: :show
+  namespace :admin do
+    resources :jobs, only: :index
+  end
+  # Sidekiq monitoring
+  authenticate :user, ->(u) { u.admin? } do
+    require "sidekiq/web"
+    mount Sidekiq::Web => "/admin/sidekiq"
+  end
+
   root "home#index"
 end

--- a/spec/features/admin/version_spec.rb
+++ b/spec/features/admin/version_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Marketplace version" do
+  include OmniauthHelper
+
+  let(:admin) { create(:user, roles: [:admin]) }
+
+  before { checkin_sign_in_as(admin) }
+
+  scenario "can been seen in admin main page" do
+    allow(ENV).to receive(:[]).with("MP_VERSION").and_return("1234")
+
+    visit admin_path
+
+    expect(page).to have_content("1234")
+  end
+end

--- a/spec/policies/admin/admin_policy_spec.rb
+++ b/spec/policies/admin/admin_policy_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::AdminPolicy do
+
+  subject { described_class }
+
+  permissions :show? do
+    it "grants access for admin" do
+      expect(subject).
+        to permit(build(:user, roles: [:admin]),
+                 [:admin, :admin])
+    end
+
+    it "denies for normal user" do
+      expect(subject).to_not permit(build(:user), [:admin, :admin])
+    end
+  end
+end


### PR DESCRIPTION
Sidekiq is configured to process all background jobs. Currently, we have `orders` and `mailers` queues. Status of delayed jobs can be monitored using administration panel (`/admin/jobs`).

Some screenshots of new UI:

![admin-menu](https://user-images.githubusercontent.com/1265430/47638261-57b9c000-db5e-11e8-8b78-793d9d77eb03.png)
![admin-version](https://user-images.githubusercontent.com/1265430/47638272-5be5dd80-db5e-11e8-9c3b-d5f7adc86cce.png)
![admin-delayed-jobs](https://user-images.githubusercontent.com/1265430/47638274-5ee0ce00-db5e-11e8-863b-8980415a0619.png)


\cc @wziajka  After this PR is merged additional container with sidekiq should be started. Take a look into `Procfile` for details.