### PR TITLE
Remove MP version from footer

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -97,5 +97,3 @@
     %p.mb-1 Union’s Horizon 2020 research and innovation programme with contribution of the European Commission
 
     %p.mt-2 2018 EOSC Portal
-    - if (ENV["MP_VERSION"])
-      %p "- version: #{ENV["MP_VERSION"]}"


### PR DESCRIPTION
Since MP version is shown in the administration panel it can be removed from the footer where it looks very ugly.