### PR TITLE
Show offers as cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Order steps layout (@mkasztelnik)
 - Sidekiq for delayed jobs (@mkasztelnik)
 - Admin administration panel stub with sidekiq monitoring and MP version (@mkasztelnik)
+- Use bootstrap cards to show service offers (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -11,10 +11,15 @@ class ServicesController < ApplicationController
   end
 
   def show
-    @service = Service.find(params[:id])
+    @service = Service.
+               includes(:offers, related_services: :provider).
+               find(params[:id])
+
+    @offers = @service.offers
+    @related_services = @service.related_services
+
     @service_opinions = ServiceOpinion.joins(project_item: :offer).
                         where(offers: { service_id: @service })
     @question = Service::Question.new(service: @service)
-    @related_services = @service.related_services.includes(:provider)
   end
 end

--- a/app/views/services/_about.html.haml
+++ b/app/views/services/_about.html.haml
@@ -18,7 +18,7 @@
           %span
             The genetics of Salmonella infections: how Cloud Compute helped scientists to understand what happens
             during when a human cell meets Salmonella
-      %h3 Service options
+      = render "services/offers", offers: offers
     .col-4
       %h3 Places and languages
       %ul

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -1,0 +1,7 @@
+.card
+  .card-body
+    %h4.card-title= offer.name
+    %p.card-text= offer.description
+    %hr
+    %p.card-text
+      .alert.alert-info Placeholder for offer properties

--- a/app/views/services/_offers.html.haml
+++ b/app/views/services/_offers.html.haml
@@ -1,0 +1,3 @@
+%h3 Service offers
+.card-columns
+  = render partial: "services/offer", collection: offers, as: :offer

--- a/app/views/services/offers/_offer.html.haml
+++ b/app/views/services/offers/_offer.html.haml
@@ -1,0 +1,11 @@
+.card
+  .card-body
+    %h4.card-title= offer.name
+    %p.card-text= offer.description
+    %hr
+    %p.card-text
+      .alert.alert-info Placeholder for offer properties
+  .card-footer
+    %label.btn.btn-secondary
+      = f.radio_button :offer_id, offer.iid
+      Select

--- a/app/views/services/offers/index.html.haml
+++ b/app/views/services/offers/index.html.haml
@@ -6,10 +6,19 @@
   Please select one from the list bellow.
 
 = simple_form_for @project_item, url: service_offers_path(@service), method: :put,
-  html: { id: "order-form", role: "form"  } do |f|
-  = f.association :offer, collection: @offers, value_method: :iid,
-    selected: @project_item.offer
+  html: { id: "order-form", role: "form", class: "btn-group btn-group-toogle", data: { toogle: "buttons" } } do |f|
 
+  .card-columns
+    = render partial: "services/offers/offer",
+      collection: @offers, as: :offer, locals: { f: f }
+
+.btn-group.btn-group-toggle{ data: { toggle: "buttons" } }
+  %label.btn.btn-secondary{ active: true }
+    %input{ type: "radio", name: "options", id: "option1", autocomplete: "off", checked: true } Active
+  %label.btn.btn-secondary
+    %input{ type: "radio", name: "options", id: "option2", autocomplete: "off" } Radio
+  %label.btn.btn-secondary
+    %input{ type: "radio", name: "options", id: "option3", autocomplete: "off" } Radio
 
 = content_for :cancel_button do
   = link_to "Cancel order and quit", service_cancel_path(@service), method: :delete

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -18,7 +18,7 @@
                                               role: "tab" } Opinions (#{@service.service_opinion_count})
 
 .tab-content
-  = render "services/about", service: @service
+  = render "services/about", service: @service, offers: @offers
   = render "services/opinions", service_opinions: @service_opinions
 
 .container

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Service ordering" do
       expect(page).to have_selector(:link_or_button,
                                     "Next", exact: true)
 
-      select offer.name
+      choose "project_item_offer_id_#{offer.iid}"
       click_on "Next", match: :first
 
       # Step 2


### PR DESCRIPTION
Preliminary version for showing service offers using bootstrap cards. Offers cards require work from UX team (cc @kosmidma, @abacz), but I believe this is a good start. 

What needs to  be done by UX team:
  * Better styling
  * small JS for adding active class into the card (than some additional border and button icon can be added) - @michal-szostak can you help with this issue? 

Sample screenshots showing how it looks like right now:

![order-options](https://user-images.githubusercontent.com/1265430/47648398-3b2b8100-db7a-11e8-98eb-43409581e55b.png)

![service-offers](https://user-images.githubusercontent.com/1265430/47648413-41216200-db7a-11e8-9d1a-88291101eb32.png)
