### PR TITLE
Service view redesigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Admin administration panel stub with sidekiq monitoring and MP version (@mkasztelnik)
 - Render root categories in page footer (@mkasztelnik)
 - Use bootstrap cards to show service offers (@mkasztelnik)
+- Add service logo (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem "will_paginate", "~> 3.1.0"
 gem "will_paginate-bootstrap4"
 gem "simple_form"
 
+gem "activestorage-validator"
+gem "image_processing", "~> 1.2"
+
 # validation
 gem "valid_email2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       actionpack (= 5.2.0)
       activerecord (= 5.2.0)
       marcel (~> 0.3.1)
+    activestorage-validator (0.1.0)
+      rails (~> 5.2.0)
     activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -138,6 +140,9 @@ GEM
     httpclient (2.8.3)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.7.1)
+      mini_magick (~> 4.0)
+      ruby-vips (>= 2.0.13, < 3)
     iniparse (1.4.4)
     jaro_winkler (1.5.1)
     jira-ruby (1.5.0)
@@ -162,6 +167,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (0.8.2)
     mimemagic (0.3.2)
+    mini_magick (4.9.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -313,6 +319,8 @@ GEM
       railties (>= 3.0)
       rubocop (~> 0.53)
     ruby-progressbar (1.9.0)
+    ruby-vips (2.0.13)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
@@ -417,6 +425,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activestorage-validator
   ancestry
   bootsnap (>= 1.1.0)
   byebug
@@ -433,6 +442,7 @@ DEPENDENCIES
   gretel
   haml-rails
   haml_lint
+  image_processing (~> 1.2)
   jira-ruby
   listen (>= 3.0.5, < 3.2)
   omniauth

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -p $PORT
-jobs: bundle exec sidekiq -q orders -q mailers
+jobs: bundle exec sidekiq -q orders -q mailers -q default

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: bundle exec rails s
 # watcher: ./bin/webpack-watcher
 webpacker: ./bin/webpack-dev-server
-jobs: bundle exec sidekiq -q orders -q mailers
+jobs: bundle exec sidekiq -q orders -q mailers -q default

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ ENV variables:
     `http://localhost:#{ENV["PORT"] || 3000}` (when foreman is used to start
     application 5000 ENV variable is set)
   * `ELASTICSEARCH_URL` - elasticsearch url
+  * `STORAGE_DIR` - active storage local dir (default set to
+    `RAILS_ROOT/storage`)
 
 
 ## Commits

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,6 +6,8 @@ class Service < ApplicationRecord
   include Elasticsearch::Model
   include Elasticsearch::Model::Callbacks
 
+  has_one_attached :logo
+
   has_many :offers, dependent: :restrict_with_error
   has_many :service_categories, dependent: :destroy
   has_many :categories, through: :service_categories
@@ -48,6 +50,7 @@ class Service < ApplicationRecord
   validates :tutorial_url, presence: true, url: true
   validates :restrictions, presence: true
   validates :phase, presence: true
+  validates :logo, blob: { content_type: :image }
 
   after_save :set_first_category_as_main!, if: :main_category_missing?
 

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -39,7 +39,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
      :access_policies_url, :corporate_sla_url,
      :webpage_url, :manual_url, :helpdesk_url,
      :tutorial_url, :restrictions, :phase,
-     :activate_message,
+     :activate_message, :logo,
      [contact_emails: []]]
   end
 

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -19,6 +19,7 @@
   = f.input :phase
   = f.input :open_access, as: :boolean
   = f.input :activate_message
+  = f.input :logo
   = f.association :provider
   = f.input :contact_emails, as: :array, multiple: true
   %a#add-email-field Add additional email

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -1,8 +1,13 @@
 .container
   %h1= @service.title
-  %p
-    %b= @service.tagline
-  %p= @service.description
+  .row
+    .col-3
+      - if @service.logo.attached?
+        = image_tag @service.logo.variant(resize: "200x200")
+    .col-9
+      %p
+        %b= @service.tagline
+      %p= @service.description
 
   %h2 Terms of use
   = markdown(@service.terms_of_use)

--- a/app/views/services/_about.html.haml
+++ b/app/views/services/_about.html.haml
@@ -1,23 +1,7 @@
 #desc.tab-pane.container.pt-2.active{ "aria-labelledby" => "home-tab", role: "tabpanel" }
   .row.pt-3
     .col-8
-      %h3.mb-3.mt-3 Run virtual machines on-demand with complete control over computing resources.
-      %p.mt-4 With Cloud Compute you can deploy and scale virtual machines on-demand. Cloud Compute offers guaranteed
-      computational resources in a secure and isolated environment with standard API access, without the overhead
-      of managing physical servers.
-      %p.mt-3 Cloud Compute offers the possibility to select preconﬁgured virtual appliances (e.g. CPU, memory, disk,
-      operating system or software) from a catalogue replicated across all EGI cloud providers from a catalogue
-      replicated across all EGI cloud providers.
-      %p.mt-5 Featured usecases
-      %ul.ml-4
-        %li.mt-2
-          %span
-            How to predict social media trends? how Cloud Compute helps to test new ways to detect trends on social
-            networks
-        %li.mt-2
-          %span
-            The genetics of Salmonella infections: how Cloud Compute helped scientists to understand what happens
-            during when a human cell meets Salmonella
+      = markdown(service.description)
       = render "services/offers", offers: offers
     .col-4
       %h3 Places and languages

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -1,23 +1,34 @@
-.row
-  .col-8
-    %h1= service.title
-    %p
-      %b= service.tagline
-    %p= service.description
-    %p
-      Provided by
-      = link_to service.provider.name, service.provider
-    %p
-      = print_rating_stars(service.rating)
-      %span.small.ml-1.font-weight-bold
-        #{service.rating} /5)
-      %a{ href: "", class: "small ml-3" }
-        #{service.service_opinion_count} opinions
-  .col-4
-    - if policy(@service).order?
-      = link_to service_offers_path(@service), class: "btn btn-primary" do
-        = order_button_text
-    - if @service.open_access?
-      = link_to "Go to the service", service.connected_url, class: "btn btn-primary", target: "_blank"
+.media.border-0
+  - if service.logo.attached?
+    = image_tag service.logo.variant(resize: "200x200"), class: "align-self-center mr-4"
+  .media-body
+    .row
+      .col-9
+        %h1= service.title
+        %p= service.tagline
+        .row
+          .col
+            %code TODO
+            Available for SME only within 1 day
+          .col
+            Provided by
+            = link_to service.provider.name, service.provider
+          .col
+            %code TODO
+            Area
+            %strong Biology
+        .row
+          .col
+            = print_rating_stars(service.rating)
+            %span.small.ml-1.font-weight-bold
+              (#{service.rating} /5)
+            %a{ href: "", class: "small ml-3" }
+              #{service.service_opinion_count} opinions
+      .col-3.text-center
+        - if policy(service).order?
+          = link_to service_offers_path(service), class: "btn btn-primary" do
+            = order_button_text
+        - if service.open_access?
+          = link_to "Go to the service", service.connected_url, class: "btn btn-primary", target: "_blank"
 
-    = render "services/ask_question", service: service, question: question
+        = render "services/ask_question", service: service, question: question

--- a/app/views/services/_related.html.haml
+++ b/app/views/services/_related.html.haml
@@ -1,7 +1,7 @@
 - if related_services.count.positive?
   %h3 Services you can use with this service
 
-  %ul
+  .card-columns
     = render partial: "services/service_box",
             collection: related_services,
             as: :service

--- a/app/views/services/_service.html.haml
+++ b/app/views/services/_service.html.haml
@@ -1,27 +1,17 @@
-//Static element from Andrzej's draft
-%ul.list-unstyled
-  %li.media.pb-4.mb-4
-    .media-body
-      %h2.font-weight-bold= link_to service.title, service
-      .mb-3= service.tagline
-      %p.small.float-left.mr-4
+.media
+  .media-body
+    %h2= link_to service.title, service
+    %p.mb-3= service.tagline
+    .row
+      .col
         Provided by
         = link_to service.provider.name, service.provider
-
-      %p.small
+      .col
+        %code TODO
+        Area
+        %strong Biology
+      .col
+        %code TODO
         Available for SME only within 1 day
-      .row
-        .col
-          = print_rating_stars(service.rating)
-          %span.small.ml-1.font-weight-bold
-            (#{service.rating} /5)
-          %a{ href: "", class: "small ml-3" }
-            #{service.service_opinion_count} opinions
-
-    .ml-5
-      %form.d-flex.justify-content-end
-        .form-group.form-check
-          %input.form-check-input{ type: "checkbox" }
-          %label.form-check-label.small{ for: "" }
-            to compare
-
+  - if service.logo.attached?
+    = image_tag service.logo.variant(resize: "150x150"), class: "align-self-center mx-2"

--- a/app/views/services/_service_box.html.haml
+++ b/app/views/services/_service_box.html.haml
@@ -1,5 +1,12 @@
-%li
-  %h3= link_to service.title, service_path(service)
-  %p= service.tagline
-  %p Provided by: #{service.provider.name}
-  %p Dedicated for #{service.dedicated_for}
+.card
+  .card-body
+    .media.border-0
+      - if service.logo.attached?
+        = image_tag service.logo.variant(resize: "100x100"),
+          class: "align-self-center mr-4"
+      .media-body
+        %h3= link_to service.title, service
+        %p= service.tagline
+        .row
+          .col Provided by: #{service.provider.name}
+          .col Dedicated for #{service.dedicated_for}

--- a/app/views/services/_services.html.haml
+++ b/app/views/services/_services.html.haml
@@ -1,6 +1,5 @@
-%dl
-  = render services
-//Static element from Andrzej's draft
+= render services
+
 .d-flex
   .p-2.flex-grow-1
     %nav

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -26,33 +26,4 @@
                                         ["by rate 1-5", "rating"],
                                         ["by rate 5-1", "-rating"]], params[:sort])
 
-      %ul.list-unstyled
-        %li.media.pb-4.mb-4.list-group-item-primary.position-relative
-          %span.badge.badge-primary.text-uppercase.p-2.rounded-0.clearfix.position-absolute
-            We recommended
-          .media-body.pl-3.pt-5
-            %h2.font-weight-bold
-              Nazwa
-            .mb-3
-              opis
-            %p.small.float-left.mr-4
-              Provided by
-              %a{ href: "" }
-                SHAPE
-            %p.small
-              Available for SME only within 1 day
-            .row
-              .col
-                %span.small.ml-1.font-weight-bold
-                  gwiazdki
-                %a{ href: "", class: "small ml-3" }
-                  5 opinions
-
-          .ml-5.pr-3.pt-5
-            %form.d-flex.justify-content-end
-              .form-group.form-check
-                %input.form-check-input{ type: "checkbox" }
-                %label.form-check-label.small{ for: "" }
-                  to compare
-
       = render "services", services: @services

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -2,7 +2,6 @@
 .container
   = render "services/header", service: @service, question: @question
 
-.container
   %ul#my-tab.nav.nav-tabs.mt-4{ role: "tablist" }
     %li.nav-item
       %a#home-tab.nav-link.text-uppercase.active{ "aria-controls" => "home",

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -4,7 +4,7 @@ test:
 
 local:
   service: Disk
-  root: <%= Rails.root.join("storage") %>
+  root: <%= ENV["STORAGE_DIR"] || Rails.root.join("storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:

--- a/db/migrate/20181030074128_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20181030074128_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,26 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_26_063221) do
+ActiveRecord::Schema.define(version: 2018_10_30_074128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "affiliations", force: :cascade do |t|
     t.integer "iid", null: false

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -64,6 +64,6 @@ RSpec.feature "Service categories" do
 
     visit category_path(category, per_page: "1")
 
-    expect(page).to have_selector("dl > ul", count: 1)
+    expect(page).to have_selector(".media", count: 1)
   end
 end

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature "Service filtering and sorting" do
     expect(page.body.index("DDDD Something 1")).to be < page.body.index("DDDD Something 2")
     expect(page.body.index("DDDD Something 2")).to be < page.body.index("DDDD Something 3")
 
-    expect(page).to have_selector("dl > ul", count: 3)
+    expect(page).to have_selector(".media", count: 3)
   end
 
   scenario "clicking filter button in side bar will preserve existing query params", js: true do
@@ -119,7 +119,7 @@ RSpec.feature "Service filtering and sorting" do
     expect(page.body.index("DDDD Something 1")).to be < page.body.index("DDDD Something 2")
     expect(page.body.index("DDDD Something 2")).to be < page.body.index("DDDD Something 3")
 
-    expect(page).to have_selector("dl > ul", count: 3)
+    expect(page).to have_selector(".media", count: 3)
   end
 
   scenario "selecting sorting will set query param and preserve existing ones", js: true do
@@ -139,6 +139,6 @@ RSpec.feature "Service filtering and sorting" do
 
     visit services_path(per_page: "1")
 
-    expect(page).to have_selector("dl > ul", count: 1)
+    expect(page).to have_selector(".media", count: 1)
   end
 end


### PR DESCRIPTION
Following elements were added/improved:
  * service logo can be added to the service
  * services list redesigned
  * service header redesigned
  * related service partial prototype using bootstrap cards

Screenshots from the current version:

![services-list](https://user-images.githubusercontent.com/1265430/47714082-2adbda80-dc3c-11e8-81b0-828c7c20f0da.png)

![service-show](https://user-images.githubusercontent.com/1265430/47714125-49da6c80-dc3c-11e8-89e4-7373ebfee3ef.png)

![service-related](https://user-images.githubusercontent.com/1265430/47714094-34fdd900-dc3c-11e8-8713-7235a4d0159a.png)

