### PR TITLE
Display dedicated_for field in service detail and preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Upgrade service detail view (@kmarszalek)
 - Rename `Order` to `ProjectItem` (@mkasztelnik)
 - Rename `OrderChange` to `ProjectItemChange` (@mkasztelnik)
+- In service view (list and detail) instead of "Available for SME..." show the dedicated_for field (@jswk)
 
 ### Deprecated
 

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -8,8 +8,7 @@
         %p= service.tagline
         .row
           .col
-            %code TODO
-            Available for SME only within 1 day
+            = service.dedicated_for
           .col
             Provided by
             = link_to service.provider.name, service.provider

--- a/app/views/services/_service.html.haml
+++ b/app/views/services/_service.html.haml
@@ -11,7 +11,6 @@
         Area
         %strong Biology
       .col
-        %code TODO
-        Available for SME only within 1 day
+        = service.dedicated_for
   - if service.logo.attached?
     = image_tag service.logo.variant(resize: "150x150"), class: "align-self-center mx-2"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,6 +79,27 @@ ActiveRecord::Schema.define(version: 2018_10_30_074128) do
     t.index ["service_id"], name: "index_offers_on_service_id"
   end
 
+  create_table "order_changes", force: :cascade do |t|
+    t.string "status"
+    t.text "message"
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "author_id"
+    t.index ["author_id"], name: "index_order_changes_on_author_id"
+    t.index ["order_id"], name: "index_order_changes_on_order_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.string "status", null: false
+    t.bigint "service_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["service_id"], name: "index_orders_on_service_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
   create_table "project_item_changes", force: :cascade do |t|
     t.string "status"
     t.text "message"


### PR DESCRIPTION
Replace "Available for SME..." text in service description show
dedicated_for field value.