### PR TITLE
Revert setting new affiliation status to :active

### DIFF
--- a/app/controllers/profiles/affiliations_controller.rb
+++ b/app/controllers/profiles/affiliations_controller.rb
@@ -44,10 +44,8 @@ class Profiles::AffiliationsController < ApplicationController
   private
 
     def affiliation_template
-      # TODO: set status active as mail delivery when deployed didn't work,
-      # but obviously, status shouldn't be set to active here
       Affiliation.new(permitted_attributes(Affiliation).
-                      merge(user: current_user, status: :active))
+                      merge(user: current_user))
     end
 
     def find_and_authorize


### PR DESCRIPTION
The affiliation status was forcefully set to :active on creation instead
of :created.
The hack was introduced to be able to test the ordering process while
the delivery of mail (which is necessary to obtain the activation
token) didn't work.