### PR TITLE
Add hint with new affiliation link

### DIFF
--- a/app/views/services/configurations/show.html.haml
+++ b/app/views/services/configurations/show.html.haml
@@ -17,7 +17,8 @@
           class: "btn btn-primary ml-3", remote: true
 
   = f.association :affiliation,
-    collection: @affiliations, label_method: :organization
+    collection: @affiliations, label_method: :organization,
+    hint: "Click #{link_to "here", new_profile_affiliation_path} to create new affilition".html_safe
   = f.input :customer_typology, collection: @customer_topologies
   = f.input :access_reason
   = f.input :additional_information


### PR DESCRIPTION

If a user is ordering service and active affiliation is not created yet than order cannot be finished. Affiliation needs to be created and activated (through a link sent by email).                                                                       
 
Here we are only adding hint into configuration form with new affiliation link to simplify navigation into required new affiliation form.        
                     
Fixes #266