### PR TITLE
Show alert for logged in user when no active affiliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add sidekiq yaml configuration file (@wziajka)
 - Add smtp configuration (@wziajka)
 - Create new project on order configuration page (@mkasztelnik)
+- Show alert for logged in user when there is not active affiliation (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem "simple_form"
 gem "activestorage-validator"
 gem "image_processing", "~> 1.2"
 
+# turbo-charged counter caches
+gem "counter_culture", "~> 2.0"
+
 # validation
 gem "valid_email2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,9 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     aes_key_wrap (1.0.1)
+    after_commit_action (1.1.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     ancestry (3.0.2)
       activerecord (>= 3.2.0)
     arel (9.0.0)
@@ -72,6 +75,10 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
+    counter_culture (2.1.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      after_commit_action (~> 1.0)
     crass (1.0.4)
     database_cleaner (1.7.0)
     devise (4.4.3)
@@ -431,6 +438,7 @@ DEPENDENCIES
   byebug
   capybara
   colorize (>= 0.8.1)
+  counter_culture (~> 2.0)
   database_cleaner
   devise
   dotenv-rails

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -9,6 +9,11 @@ class Affiliation < ApplicationRecord
   }
 
   belongs_to :user
+  counter_culture :user,
+    column_name: ->(model) { model.active? ? "active_affiliations_count" : nil },
+    column_names: {
+      ["affiliations.status = ?", "active"] => "active_affiliations_count"
+    }
 
   has_many :project_items, dependent: :restrict_with_error
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,8 @@ class User < ApplicationRecord
   def active_affiliations
     affiliations.where(status: :active)
   end
+
+  def active_affiliation?
+    active_affiliations_count.positive?
+  end
 end

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,5 +1,10 @@
 - if alert
-  .alert.alert-danger.mb-0.rounded-0{ role: "alert" }= alert
+  .alert.alert-danger.mb-0.text-center{ role: "alert" }= alert
 - elsif notice
-  .alert.alert-success.mb-0.rounded-0{ role: "alert" }= notice
+  .alert.alert-success.mb-0.text-center{ role: "alert" }= notice
 
+- if user_signed_in? && !current_user.active_affiliation?
+  .alert.alert-warning.mb-0.text-center{ role: "alert" }
+    You don't have active affiliation. It is required to order
+    a service. You can create and activate new affiliation
+    #{link_to "here", new_profile_affiliation_path}.

--- a/db/migrate/20181107143358_add_active_affiliations_count.rb
+++ b/db/migrate/20181107143358_add_active_affiliations_count.rb
@@ -1,0 +1,5 @@
+class AddActiveAffiliationsCount < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :active_affiliations_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_05_150915) do
+ActiveRecord::Schema.define(version: 2018_11_07_143358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -223,6 +223,7 @@ ActiveRecord::Schema.define(version: 2018_11_05_150915) do
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.integer "roles_mask"
+    t.integer "active_affiliations_count", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/lib/tasks/counter_cache.rake
+++ b/lib/tasks/counter_cache.rake
@@ -15,3 +15,8 @@ task service_counter: :environment do
     Service.reset_counters(id, :offers)
   end
 end
+
+desc "Counter cache for user has many active affiliations"
+task active_affiliation_counter: :environment do
+  Affiliation.counter_culture_fix_counts
+end

--- a/spec/features/alerts_spec.rb
+++ b/spec/features/alerts_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Affiliations" do
+  include OmniauthHelper
+
+  let(:user) { create(:user) }
+
+
+  context "as logged in user" do
+    before { checkin_sign_in_as(user) }
+
+    it "shows alert when no active affiliation" do
+      visit root_path
+
+      expect(page).to have_content("You don't have active affiliation")
+    end
+
+    it "does not shows alert when has active affiliation" do
+      create(:affiliation, user: user, status: :active)
+
+      visit root_path
+
+      expect(page).to_not have_content("You don't have active affiliation")
+    end
+  end
+
+  context "as anonymous user" do
+    it "does not shows active affiliation alert" do
+      visit root_path
+
+      expect(page).to_not have_content("You don't have active affiliation")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,5 +28,46 @@ RSpec.describe User do
 
       expect(user.active_affiliations).to contain_exactly(active_affiliation)
     end
+
+    it "stores counter cache" do
+      user = create(:user)
+      _active_affiliation = create(:affiliation, status: :active, user: user)
+      _created__affiliation = create(:affiliation, status: :created, user: user)
+
+      user.reload
+
+      expect(user.active_affiliations_count).to eq(1)
+    end
+
+    it "updates counter cache when state updated" do
+      user = create(:user)
+      affiliation = create(:affiliation, status: :created, user: user)
+
+      affiliation.update(status: :active)
+      user.reload
+
+      expect(user.active_affiliations_count).to eq(1)
+
+    end
+  end
+
+  context "#active_affiliation?" do
+    it "is true when there is active affiliation" do
+      user = create(:user)
+      _active_affiliation = create(:affiliation, status: :active, user: user)
+
+      user.reload
+
+      expect(user).to be_active_affiliation
+    end
+
+    it "is false when there are other than active affiliations" do
+      user = create(:user)
+      _created__affiliation = create(:affiliation, status: :created, user: user)
+
+      user.reload
+
+      expect(user).to_not be_active_affiliation
+    end
   end
 end


### PR DESCRIPTION
Alert is shown for logged in user when there is no active affiliation

![alert](https://user-images.githubusercontent.com/1265430/48157910-447ec100-e2d1-11e8-8fb2-d34bb45b4118.png)

After this is deployed and there are active affiliations count cache should be updated by invoking this command (/cc @wziajka):

```
rails active_affiliation_counter
```