### PR TITLE
Fix offer selection empty

### DIFF
--- a/app/controllers/services/offers_controller.rb
+++ b/app/controllers/services/offers_controller.rb
@@ -33,7 +33,7 @@ class Services::OffersController < Services::ApplicationController
     end
 
     def offer_params
-      params.require(:project_item).permit(:offer_id)
+      params.fetch(:project_item, {}).permit(:offer_id)
     end
 
     def init_offer_selection!

--- a/app/views/services/offers/_offer.html.haml
+++ b/app/views/services/offers/_offer.html.haml
@@ -7,5 +7,5 @@
       .alert.alert-info Placeholder for offer properties
   .card-footer
     %label.btn.btn-secondary
-      = f.radio_button :offer_id, offer.iid
+      = f.radio_button :offer_id, offer.iid, checked: project_item.offer == offer
       Select

--- a/app/views/services/offers/index.html.haml
+++ b/app/views/services/offers/index.html.haml
@@ -10,7 +10,7 @@
 
   .card-columns
     = render partial: "services/offers/offer",
-      collection: @offers, as: :offer, locals: { f: f }
+      collection: @offers, as: :offer, locals: { f: f, project_item: @project_item }
 
 = content_for :cancel_button do
   = link_to "Cancel order and quit", service_cancel_path(@service), method: :delete


### PR DESCRIPTION
 `ActionController::ParameterMissing` exception was thrown because there was nothing to put into post `project_item` hash. To sole it instead of `require`, `fetch` is used according to [this](https://stackoverflow.com/questions/17354053/rails-4-strong-parameters-handling-missing-model-params-hash) recommendation.
