### PR TITLE
Improve affiliations and projects views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Rename `OrderChange` to `ProjectItemChange` (@mkasztelnik)
 - Split backend for Service details view (@kmarszalek)
 - Bootstrap improvements towards compliance with the guidelines (@jswk)
+- Improve styling of affiliation list in profile and project list (@jswk)
 
 ### Deprecated
 

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -307,19 +307,6 @@ textarea:-ms-input-placeholder { /* IE 10+ */
   }
 }
 
-.display-3 {
-  font-size: 2.25rem;
-  line-height: 0.8;
-}
-
-.display-4 {
-  font-size: 1.25rem;
-}
-
-.display-5 {
-  font-size: 1.1rem;
-}
-
 .profile-img {
   background: url('../../assets/images/profile-img.png') top left no-repeat;
   width: 140px;

--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -21,6 +21,12 @@ $h3-font-size: $font-size-base * 1.125;
 $h4-font-size: $font-size-base * 0.875;
 $h5-font-size: $font-size-base * 0.75;
 
+$display1-size: 2.25rem; // display3
+$display2-size: 1.25rem; // display4
+$display3-size: 1.1rem; // display5
+
+$display1-weight: $font-weight-light;
+
 $palette-gray-100: #1c313a;
 $palette-gray-10: rgba($palette-gray-100, 0.1);
 $palette-gray-30: rgba($palette-gray-100, 0.3);

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -96,7 +96,7 @@
               %li.list-inline-item.position-relative pcu
         .col-md-6.d-flex.align-items-center
           .mt-3.mb-3
-            %a.display-5.d-inline-block.mb-2{ href: "" } 48 more providers
+            %a.display-3.d-inline-block.mb-2{ href: "" } 48 more providers
             %button.btn.btn-primary.btn-sm Check all
 
 

--- a/app/views/layouts/_breadcrumb.html.haml
+++ b/app/views/layouts/_breadcrumb.html.haml
@@ -1,3 +1,8 @@
 .container
   .mt-4.mb-4
+    -#
+      Note. Current version of gretel (3.0.9) doesn't support :bootstrap correctly.
+      It doesn't add .breadcrumb-item to items, breaking the compatibility.
+      In case this is fixed in some time in the future it may make sense to update
+      and use style: :boostrap. (https://github.com/lassebunk/gretel/pull/73)
     = breadcrumbs pretext: "You are here: ", separator: " &rsaquo; "

--- a/app/views/playground/home-view.html.haml
+++ b/app/views/playground/home-view.html.haml
@@ -131,7 +131,7 @@
                 %li.list-inline-item.position-relative pcu
           .col-md-6.d-flex.align-items-center
             .mt-3.mb-3
-              %a.display-5.d-inline-block.mb-2{ href: "" } 48 more providers
+              %a.display-3.d-inline-block.mb-2{ href: "" } 48 more providers
               %button.btn.btn-primary.btn-sm Check all
 
 

--- a/app/views/profiles/_profile.html.haml
+++ b/app/views/profiles/_profile.html.haml
@@ -1,10 +1,10 @@
 .row.mt-5.h-100
   %img.profile-img{ src: "http://upload.wikimedia.org/wikipedia/commons/c/ce/Transparent.gif" }
   .ml-5.my-auto
-    %p.display-3.font-weight-light.align-top
+    %p.display-1.mb-1
       = current_user.first_name
       = current_user.last_name
-    %p.display-4.font-weight-light
+    %p.display-2.font-weight-light
       = current_user.email
   .col-2.text-right.my-auto
 

--- a/app/views/profiles/affiliations/_affiliation.html.haml
+++ b/app/views/profiles/affiliations/_affiliation.html.haml
@@ -1,54 +1,50 @@
 .card.border.rounded.mb-2.pb-2.pt-2
-  .card-header{ role: "tab", id: "accordion-header-affiliation-#{affiliation.id}" }
-    .row
-      .col-md-6
-        %h6.mb-0{ "data-toggle": "collapse", href: "#accordion-collapse-affiliation-#{affiliation.id}",
-         "aria-expanded": "false" }
-          %p.display-4.mb-1.font-weight-bold
-            #{affiliation.organization}
-          %p.small.mb-0.mt-2
-            - unless affiliation.department.blank?
-              #{affiliation.department} department
-          %span.d-none
-            (email: #{affiliation.email},
-            #{affiliation.phone} telephone).
-      .col-md-2.my-auto.text-center
-        %span.text-uppercase
-          = affiliation.status
-      .col-md-2.my-auto.text-center
-        %span.small
-          last change: 28.02.2111
-      .col-md-2.my-auto.text-right
-        .btn-group
-          - if policy(affiliation).edit?
-            = link_to "Edit",
-                      edit_profile_affiliation_path(affiliation),
-                      class: "btn btn-primary btn-sm"
-          - if policy(affiliation).destroy?
-            = link_to "Delete",
-                      profile_affiliation_path(affiliation),
-                      method: :delete, data: { confirm: "Are you sure?" },
-                      class: "btn btn-link btn-sm d-none"
-  .collapse{ "data-parent": "#accordion", role: "tabpanel", id: "accordion-collapse-affiliation-#{affiliation.id}" }
+  .card-header.d-flex{ role: "tab", id: "accordion-header-affiliation-#{affiliation.id}" }
+    %h6.my-auto.mr-auto{ "data-toggle": "collapse", href: "#accordion-collapse-affiliation-#{affiliation.id}",
+     "aria-expanded": "false" }
+      %p.display-2.font-weight-bold.my-auto
+        #{affiliation.organization}
+      - unless affiliation.department.blank?
+        %p.small.mb-0.mt-2
+          #{affiliation.department} department
+    %span.text-uppercase.my-auto.ml-3
+      = affiliation.status
+    %span.small.my-auto.ml-3
+      last change: #{affiliation.updated_at.strftime("%d.%m.%Y")}
+    .btn-group.my-auto.ml-3
+      - if policy(affiliation).edit?
+        = link_to "Edit",
+                  edit_profile_affiliation_path(affiliation),
+                  class: "btn btn-secondary btn-sm"
+      - if policy(affiliation).destroy?
+        = link_to "Delete",
+                  profile_affiliation_path(affiliation),
+                  method: :delete, data: { confirm: "Are you sure?" },
+                  class: "btn btn-error btn-sm"
+  .collapse{ "data-parent": "#accordion-affiliations",
+             role: "tabpanel",
+             id: "accordion-collapse-affiliation-#{affiliation.id}" }
     .card-block
       .row.container.p-3
         .col-md-3
-          %p.small.mb-0 Country:
-          England
+          %p.small.mb-0 Email:
+          = link_to affiliation.email, "mailto:#{affiliation.email}"
         .col-md-3
-          %p.small.mb-0 Supervisor name:
+          %p.small.mb-0 Phone:
+          - unless affiliation.phone.blank?
+            = affiliation.phone
+        .col-md-3
+          %p.small.mb-0 Supervisor:
           - unless affiliation.supervisor.blank?
-            #{affiliation.supervisor} supervisor
+            - if affiliation.supervisor_profile.blank?
+              #{affiliation.supervisor}
+            - else
+              = link_to affiliation.supervisor, affiliation.supervisor_profile
         .col-md-3
           %p.small.mb-0
             Departmental web page:
-          %a{ href: "" }
+          %a{ href: affiliation.webpage }
             #{affiliation.webpage}
-        .col-md-3
-          %p.small.mb-0
-            Supervisor profile:
-          %a{ href: "" }
-            jakiś link
 
 
 

--- a/app/views/profiles/affiliations/_form.html.haml
+++ b/app/views/profiles/affiliations/_form.html.haml
@@ -10,6 +10,5 @@
       = f.input :supervisor
       = f.input :supervisor_profile
 
-      .btn-group
-        = f.button :submit, class: "btn btn-primary"
-        = link_to "Cancel", profile_path, class: "btn btn-link"
+      = f.button :submit, class: "btn btn-primary"
+      = link_to "Cancel", profile_path, class: "btn btn-link"

--- a/app/views/profiles/affiliations/_index.html.haml
+++ b/app/views/profiles/affiliations/_index.html.haml
@@ -1,14 +1,9 @@
-#affiliations.tab-pane.container.pt-2.active{ "aria-labelledby" => "affiliations-tab", role: "tabpanel" }
-  .container
-    %h2.mt-4.font-weight-bold
-      Affiliations
-      .float-right
-        = link_to "Add new affiliation",
-                  new_profile_affiliation_path,
-                  class: "btn btn-secondary btn-sm"
-    .clearfix
-
-    #accordion.accordion.mt-4{ "aria-multiselectable" => "true", :role => "tablist" }
-      = render partial: "profiles/affiliations/affiliation",
-                        collection: affiliations
-    = will_paginate affiliations
+#affiliations.tab-pane.container.active{ "aria-labelledby" => "affiliations-tab", role: "tabpanel" }
+  #accordion-affiliations.accordion.mb-4{ "aria-multiselectable" => "true", :role => "tablist" }
+    = render partial: "profiles/affiliations/affiliation",
+                      collection: affiliations
+  = will_paginate affiliations
+  = link_to "Add new affiliation",
+            new_profile_affiliation_path,
+            class: "btn btn-primary float-right"
+  .clearfix

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -19,6 +19,6 @@
                                               href: "#newsletter",
                                               role: "tab" } Newsletter
 
-.tab-content
+.tab-content.pt-4
   = render "profiles/affiliations/index", affiliations: @affiliations
   = render "profiles/newsletter"

--- a/app/views/project_items/_project_item.html.haml
+++ b/app/views/project_items/_project_item.html.haml
@@ -1,15 +1,13 @@
 %li.list-group-item
   .row
-    .col-md-7
+    .col-md.font-weight-bold
       = link_to project_item.service.title, project_item
     .col-md-2
-      %span.small.text-uppercase
+      %span.text-uppercase
         = project_item.status
-    .col-md-3.text-left
-      %span.small
-        last change: #{time_ago_in_words(project_item.updated_at)}
-      %span.d-none
-        = project_item.user.full_name
+    .col-md.text-md-right
+      %span
+        last change: #{time_ago_in_words(project_item.updated_at)} ago
 
 
 

--- a/app/views/projects/_empty_project.html.haml
+++ b/app/views/projects/_empty_project.html.haml
@@ -1,3 +1,2 @@
 %li.list-group-item
   Empty project
-

--- a/app/views/projects/_project.html.haml
+++ b/app/views/projects/_project.html.haml
@@ -1,4 +1,6 @@
-%h3= project.name
-%ul.list-group.mt-5
-  = render(project.project_items) || render("empty_project")
-
+.row.mb-4
+  .col-md-3.col-lg-2
+    %h2.font-weight-normal= project.name
+  .col-md
+    %ul.list-group
+      = render(project.project_items) || render("empty_project")

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,20 +1,16 @@
 - breadcrumb :projects
 
 .container
-  .row
-    .col-md-8
-      %h1.mb-0 My Services
-    .col-md-3.offset-md-1.my-auto
-      %form
-        .row
-          .col-md-12
-            %select.form-control.form-control-sm
-              %option
-                All
-              %option
-                option 1
-              %option
-                option 2
-  %ul.list-group.mt-5
-    = render @projects
+  .d-flex.mb-5
+    %h1.mr-auto.my-auto My Services
+    %form.my-auto
+      %select.form-control.form-control-sm.custom-select
+        %option
+          All
+        %option
+          option 1
+        %option
+          option 2
+
+  = render @projects
 


### PR DESCRIPTION
- Remove placeholders from affiliation list view and replace them with
  actual field values.
  Correct affiliations view in line with prefkas.
  Don't use .btn-group in affiliation edit view's footer.
- Redefine .display-* with variables rather than selector redefinitions.
- Try to switch to using Bootstrap for breadcrumbs, but gretel doesn't
  support Bootstrap4 yet.