### PR TITLE
Fix email word duplication in affiliation validation

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -45,7 +45,7 @@ class Affiliation < ApplicationRecord
 
     def email_from_webpage_domain
       unless email_in_webpage_domain?
-        errors.add(:email, "Email does not belong to webpage domain")
+        errors.add(:email, "does not belong to webpage domain")
       end
     end
 


### PR DESCRIPTION
Fix for issue discovered by @roksanaer in https://github.com/cyfronet-fid/marketplace/pull/299#pullrequestreview-173170738 - email word is duplicated in affiliation validation.