### PR TITLE
Hierarchic categories count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Show alert for logged in user when there is not active affiliation (@mkasztelnik)
 - Style ordered service view and remove mocked data (@mkasztelnik)
 - User need to accept terms and conditions to order service (@mkasztelnik)
+- Category hierarchical services count (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/models/service_category.rb
+++ b/app/models/service_category.rb
@@ -2,7 +2,12 @@
 
 class ServiceCategory < ApplicationRecord
   belongs_to :service
-  belongs_to :category, counter_cache: :services_count
+  belongs_to :category
+  counter_culture :category,
+                  column_name: "services_count",
+                  foreign_key_values: ->(category_id) do
+                    [category_id, *Category.find(category_id).ancestor_ids]
+                  end
 
   validates :service, presence: true
   validates :category, presence: true

--- a/lib/tasks/counter_cache.rake
+++ b/lib/tasks/counter_cache.rake
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-desc "Counter cache for categories has many services"
-task category_counter: :environment do
-  Category.reset_column_information
-  Category.pluck(:id).each do |id|
-    Category.reset_counters(id, :services)
-  end
-end
-
 desc "Counter cache for services has many offers"
 task service_counter: :environment do
   Service.reset_column_information

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -23,8 +23,12 @@ RSpec.describe Category do
   end
 
   it "has services counter" do
-    category = create(:category, services: create_list(:service, 2))
+    category = create(:category, services: create_list(:service, 1))
+    subcategory = create(:category, parent: category, services: create_list(:service, 1))
+    subsubcategory = create(:category, parent: subcategory, services: create_list(:service, 1))
 
-    expect(category.services_count).to eq(2)
+    expect(subsubcategory.reload.services_count).to eq(1)
+    expect(subcategory.reload.services_count).to eq(2)
+    expect(category.reload.services_count).to eq(3)
   end
 end


### PR DESCRIPTION
Previously only services directly assigned to the category was taken while calculating services count. After this change services directly assigned to the category and all its subcategories are taken into account.