### PR TITLE
Clickable next order nav step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Show alert for logged in user when there is not active affiliation (@mkasztelnik)
 - Style ordered service view and remove mocked data (@mkasztelnik)
 - User need to accept terms and conditions to order service (@mkasztelnik)
+- Clickable next order nav step (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/helpers/order_nav_helper.rb
+++ b/app/helpers/order_nav_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module OrderNavHelper
+  def order_nav_link(title, path, step, current_step)
+    content_tag(:li, class: "nav-item") do
+      link_to_if(step <= current_step, title, path,
+                 class: "nav-link #{"active" if step == current_step}") do
+        if step == current_step + 1
+          content_tag(:a, title, class: "nav-link", href: "#",
+                      onclick: "document.getElementById('order-form').submit();")
+        else
+          content_tag(:div, title, class: "nav-link disabled")
+        end
+      end
+    end
+  end
+end

--- a/app/views/layouts/order/_nav.html.haml
+++ b/app/views/layouts/order/_nav.html.haml
@@ -1,12 +1,4 @@
 %ul.nav.nav-fill.order-nav
-  %li.nav-item
-    = link_to "Offer selection", service_offers_path(service),
-      class: "nav-link #{"active" if step == 1}"
-  %li.nav-item
-    = link_to_if step > 1, "Service configuration", service_configuration_path(service),
-      class: "nav-link #{"active" if step == 2}" do
-      .nav-link.disabled Service configuration
-  %li.nav-item
-    = link_to_if step > 2,  "Summary", service_summary_path(service),
-      class: "nav-link #{"active" if step == 3}" do
-      .nav-link.disabled Summary
+  = order_nav_link("Offer selection", service_offers_path(service), 1, step)
+  = order_nav_link("Service configuration", service_configuration_path(service), 2, step)
+  = order_nav_link("Summary", service_summary_path(service), 3, step)


### PR DESCRIPTION
After @agpul presentation yesterday it was clear that the next nav button should be clickable and behave the same as "Next" button. Here this feature is added. I needed to use js to submit a form because button with submit type cannot be used in navbar (it looks ugly and behave very strange).