### PR TITLE
Simple form checks validation if conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - User need to accept terms and conditions to order service (@mkasztelnik)
 - Add new relic rpm (@mkasztelnik)
 - Category hierarchical services count (@mkasztelnik)
+- Simple form checks validation if conditions (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -43,7 +43,7 @@ class ProjectItem < ApplicationRecord
   delegate :service, to: :offer
 
   def open_access?
-    offer&.service&.open_access
+    @is_open_access ||= offer&.service&.open_access
   end
 
   def active?

--- a/config/initializers/simple_form_validation.rb
+++ b/config/initializers/simple_form_validation.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SimpleForm
+  module Inputs
+    class Base
+      private
+
+        def valid_validator?(validator)
+          # conditional validators are no surprise
+          # to us, so just check the action:
+          action_validator_match?(validator)
+        end
+    end
+  end
+end


### PR DESCRIPTION
This was done as advised in https://github.com/plataformatec/simple_form/issues/250#issuecomment-5855384. `||=` was added into `ProjectItem` class to avoid multiple checks if ordered service is an open-access service.

The problem was visible on order configuration view when normal service was ordered.