### PR TITLE
[#323] Fix Search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,13 +7,17 @@ class ApplicationController < ActionController::Base
   include Sentryable
   include Pundit
 
-  before_action :load_root_categories!
+  before_action :load_root_categories!, :set_search_submit_path
 
   protect_from_forgery
 
   rescue_from Pundit::NotAuthorizedError do |exception|
     redirect_back fallback_location: root_path,
                   alert: "You are not authorized to see this page"
+  end
+
+  def set_search_submit_path
+    @search_submit_path = services_path
   end
 
   private

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -12,8 +12,11 @@ class CategoriesController < ApplicationController
     @subcategories = category.children
   end
 
-  private
+  def set_search_submit_path
+    @search_submit_path = category_path
+  end
 
+  private
     def category_services
       records.joins(:service_categories).
         where(service_categories: { category_id: category_and_descendant_ids })

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     %header.pb-2
       = render "layouts/navbar"
-      = render "services/search"
+      = render "services/search", search_submit_path: @search_submit_path
     %main
       = render "layouts/breadcrumb"
       = yield

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -3,7 +3,7 @@
     .col-2
     .col-8
       %p
-        = form_tag "", method: :get, role: "search", class: "",
+        = form_tag "#{search_submit_path}", method: :get, role: "search", class: "",
           "data-sync-query-form": "data-sync-query-form" do
 
           .input-group

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Home" do
+  include OmniauthHelper
+
+  scenario "should searching should go to /services with correct query" do
+    visit "/"
+
+    fill_in "q", with: "Something"
+    click_on(id: "query-submit")
+
+    expect(page).to have_current_path(services_path, ignore_query: true)
+    expect(page).to have_selector("#q[value='Something']")
+  end
+end


### PR DESCRIPTION
# What is in this PR?

* Search by text will by default go to `/services`, this form
  submission path can be overriden in specific controller by
  overriding `set_search_submit_path` method which should set
  `@search_submit_path` variable

Fixes: #323