### PR TITLE
[#329, #330] Category Tree, Global Filters

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -9,7 +9,12 @@ class CategoriesController < ApplicationController
 
   def show
     @services = paginate(category_services.order(ordering))
-    @subcategories = category.children
+    @siblings = category.ancestry.nil? ? @root_categories : category.ancestry.children.order(:name)
+    @subcategories = category.children.order(:name)
+    @provider_options = provider_options
+    @dedicated_for_options = dedicated_for_options
+    @rating_options = rating_options
+    @research_areas = ResearchArea.all
   end
 
   def set_search_submit_path

--- a/app/javascript/packs/sort_filter.js
+++ b/app/javascript/packs/sort_filter.js
@@ -45,12 +45,13 @@ export function syncQueryForm(node) {
     $(node || 'body').find("[data-sync-query-form]").each(function() {
         let _params = {...params};
         $(this).find("input").add($(this).find("select")).each(function() {
-            if($(this).attr('name') in _params)
-                delete _params[$(this).attr('name')]
+            let encodedName = encodeURI($(this).attr('name'));
+            if(encodedName in _params)
+                delete _params[encodedName];
         });
 
         for(let key in _params) {
-            $(this).append($(`<input type="hidden" id="${key}" name="${key}" value="${_params[key]}" />`));
+            $(this).append($(`<input type="hidden" id="${decodeURI(key)}" name="${decodeURI(key)}" value="${_params[key]}" />`));
         }
     });
 }

--- a/app/views/categories/_subcategories.html.haml
+++ b/app/views/categories/_subcategories.html.haml
@@ -1,5 +1,15 @@
 = form_tag "", method: :get, role: "search", class: "", "data-sync-query-form": "data-sync-query-form" do
-  - unless subcategories.empty?
-    %h5.text-uppercase.underline-light.mb-2.pb-2 Categories
-    %ul
-      = render partial: "categories/subcategory", collection: subcategories
+  %h5.text-uppercase.underline-light.mb-2.pb-2 Categories
+  %ul
+    - categories.each do |category|
+      .row
+        .col-md-10
+          %li{ class: ("font-weight-bold" if current_category_id == category.id) }
+            = link_to category.name, category_path(category)
+        .col-md-2.text-right
+          %span
+            = category.services_count
+
+      - if current_category_id == category.id && !subcategories.empty?
+        %ul.ml-3
+          = render partial: "categories/subcategory", collection: subcategories

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -3,7 +3,13 @@
 .container
   .row
     .col-md-3
-      = render "subcategories", subcategories: @subcategories
+      = render "subcategories", current_category_id: @category.id,
+                                categories: @siblings,
+                                subcategories: @subcategories
+      = render "services/filters", provider_options: @provider_options,
+                                   research_areas: @research_areas,
+                                   dedicated_for_options: @dedicated_for_options,
+                                   rating_options: @rating_options
     .col-md-9
       .row
         .col-md-8

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -4,7 +4,9 @@
 .container
   .row
     .col-md-3.pr-5
-      = render "categories/subcategories", subcategories: @subcategories
+      = render "categories/subcategories", categories: @subcategories,
+                                           current_category_id: nil,
+                                           subcategories: nil
       = render "filters", provider_options: @provider_options,
                           research_areas: @research_areas,
                           dedicated_for_options: @dedicated_for_options,

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -27,6 +27,8 @@ RSpec.feature "Service categories" do
 
     visit category_path(root)
 
+    expect(page.body).to have_content root.name
+
     expect(page.body).to have_content sub_category1.name
     expect(page.body).to have_content sub_category2.name
     expect(page.body).to_not have_content sub_sub_category.name


### PR DESCRIPTION
# What is in this PR

* Enable global filters for `/categories` view
* Add tree view for categories & subcategories
* Fix issue where query params with `[]` suffixes were not properly
  handled by `syncQueryForm` JS

Fixes: #329, #330