### PR TITLE
Force affiliation token generation

### DIFF
--- a/app/services/affiliation/create.rb
+++ b/app/services/affiliation/create.rb
@@ -6,6 +6,7 @@ class Affiliation::Create
   end
 
   def call
+    @affiliation.token = Affiliation.generate_unique_secure_token
     if @affiliation.save
       AffiliationMailer.verification(@affiliation).deliver_later
     end


### PR DESCRIPTION
There is something strange on doker environment that leads to
generating empty token when has_secure_token is used. To fix this
issue before affiliation is saved we are forcing to generate token
(something which should be also done in before create callback).