### PR TITLE
[#344] Reorder form parts in ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Reorder form parts in order/configuration (@michal-szostak)
 - On project item view show order history in reversed order (@martaswiatkowska)
 - Rename "Some Header" in services' about page to "Documents" (@michal-szostak)
+- Hide TODO Technical Parameters from service offer selection (@michal-szostak)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Clickable next order nav step (@mkasztelnik)
 - Affiliation last step - consent (@martaswiatkowska)
 - Multicheckbox widget to filters (providers & dedicated for) (@michal-szostak)
+- Category tree in sidebar (@michal-szostak)
+- Global filters to category view (@michal-szostak)
 - Add offers to the services (@goreck888)
 
 ### Changed
@@ -120,7 +122,10 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Deny to destroy an affiliation which is associated with a project item (@jswk)
 - Styling of filters (@michal-szostak)
 - Styling of ordering steps (@jarekzet, @michal-szostak)
+- Remove description under "Services" header in services, add category description in categories (@michal-szostak)
+- Reorder form parts in order/configuration (@michal-szostak)
 - On project item view show order history in reversed order (@martaswiatkowska)
+- Rename "Some Header" in services' about page to "Documents" (@michal-szostak)
 
 ### Deprecated
 
@@ -130,5 +135,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Fixed
 - Correctly expand affiliation accordions in profile (@jswk)
 - Insert a line-break after button(s) in service header right panel (@jswk)
+- Search by text from any view (@michal-szostak)
 
 ### Security

--- a/app/views/services/_about.html.haml
+++ b/app/views/services/_about.html.haml
@@ -38,7 +38,7 @@
           %span
             = link_to("Tutorial", service.tutorial_url)
 
-      %h5 Some header
+      %h5 Documents
       %ul.list-group
         %li.list-group-item
           %span

--- a/app/views/services/configurations/show.html.haml
+++ b/app/views/services/configurations/show.html.haml
@@ -1,16 +1,32 @@
 = render "layouts/order/nav", service: @service, step: 2
 
-%h2.mb-4.font-weight-normal Configuration
+%h2.mb-4.font-weight-normal Service configuration
 %p.mb-4
   We need more information about your request.
   Fill form below as much as possible.
   It will help us to proceed you request quicker.
 
-%h5.mb-3.font-weight-bold.configuration-title.text-uppercase My projects
-%p.mb-4
-  You can organize your services in projects. Add this service to specific project, create new one or leave it empty.
 = simple_form_for @project_item, url: service_configuration_path(@service),
   method: :put, html: { id: "order-form"  } do |f|
+
+  - unless @project_item.property_values.blank?
+    %h5.mb-3.font-weight-bold.configuration-title.text-uppercase Technical parameters
+    = render "services/configurations/attributes", project_item: @project_item, form: f
+
+  %h5.mb-3.font-weight-bold.configuration-title.text-uppercase Usage
+  = f.input :customer_typology, collection: @customer_topologies
+  = f.input :access_reason
+  = f.input :additional_information
+
+  %h5.mb-3.font-weight-bold.configuration-title.text-uppercase Affiliation
+  = f.association :affiliation,
+    collection: @affiliations, label_method: :organization,
+    hint: "Click #{link_to "here", new_profile_affiliation_path} to create new affilition".html_safe
+
+
+  %h5.mb-3.font-weight-bold.configuration-title.text-uppercase My projects
+  %p.mb-4
+    You can organize your services in projects. Add this service to specific project, create new one or leave it empty.
   = f.input :project do
     .input-group.col-6.pl-0
       = f.input_field :project_id, collection: @projects,
@@ -19,16 +35,7 @@
         = link_to "Add new project", new_project_path,
           class: "btn btn-primary", remote: true
 
-  - unless @project_item.property_values.blank?
-    %h5.mb-3.font-weight-bold.configuration-title.text-uppercase Technical parameters
-    = render "services/configurations/attributes", project_item: @project_item, form: f
 
-  = f.association :affiliation,
-    collection: @affiliations, label_method: :organization,
-    hint: "Click #{link_to "here", new_profile_affiliation_path} to create new affilition".html_safe
-  = f.input :customer_typology, collection: @customer_topologies
-  = f.input :access_reason
-  = f.input :additional_information
 %p
   %strong Selected offer:
   = @project_item.offer.name

--- a/app/views/services/offers/_offer.html.haml
+++ b/app/views/services/offers/_offer.html.haml
@@ -2,15 +2,15 @@
   .card-body
     %h4.card-title= offer.name
     %p.card-text.mb-4= offer.description
-    %h5.text-uppercase.parameters-title.mb-0= "Technical parameters"
-    %table.table.table-hover
-      %tbody
-        %tr
-          %td TODO: name of an attribute
-          %td TODO: value of an attribute
-        %tr
-          %td TODO: more attributes
-          %td TODO: more values
+    -# %h5.text-uppercase.parameters-title.mb-0= "Technical parameters"
+       %table.table.table-hover
+         %tbody
+           %tr
+             %td TODO: name of an attribute
+             %td TODO: value of an attribute
+           %tr
+             %td TODO: more attributes
+             %td TODO: more values
 
   .card-button.text-center
     %label

--- a/app/views/services/offers/index.html.haml
+++ b/app/views/services/offers/index.html.haml
@@ -1,6 +1,6 @@
 = render "layouts/order/nav", service: @service, step: 1
 
-%h2.mb-4.font-weight-normal Service configuration
+%h2.mb-4.font-weight-normal Offer selection
 %p.mb-4
   This service is available in various options.
   Please select one from the list bellow.

--- a/app/views/services/summaries/show.html.haml
+++ b/app/views/services/summaries/show.html.haml
@@ -10,7 +10,7 @@
   = simple_form_for @confirmation, url: service_summary_path(@service), html: { id: "order-form"  } do |f|
     = f.input :terms_and_conditions, as: :boolean
 
-%h3.mt-5
+%h3.mt-4
   Technical configuration
 
 .card.offer-description.mb-5
@@ -24,12 +24,7 @@
   %h3.mb-4
     Additional information
 
-  %h4 My projects
-  %dl.mb-4
-    %dt Project name
-    %dd= @project_item.project.name
-
-  %h4 Usage
+  %h3 Usage
   %dl.mb-4
     %dt Customer typology
     %dd= @project_item.customer_typology
@@ -63,6 +58,11 @@
 
       %dt Supervisor profile
       %dd= @project_item.affiliation.supervisor_profile.presence || "No supervisor profile set"
+
+  %h4 My projects
+  %dl.mb-4
+    %dt Project name
+    %dd= @project_item.project.name
 
 
 = content_for :next_button do


### PR DESCRIPTION
# What is in this PR?

* Rename order step's headers to match nav bar captions
* Reorder form fields in configuration step, and in summary step according to #344
* Rename "Some Header" in `services/_about.html.haml` to "Documents"
* Hide Technical Parameters in offer selection

# How it looks like?

![screen shot 2018-11-12 at 10 49 05](https://user-images.githubusercontent.com/13235269/48339465-996f5e00-e668-11e8-9e48-95987b36e927.png)

![screen shot 2018-11-12 at 10 49 30](https://user-images.githubusercontent.com/13235269/48339507-ae4bf180-e668-11e8-99ee-c6de43d67147.png)

![screen shot 2018-11-12 at 11 13 16](https://user-images.githubusercontent.com/13235269/48340896-03d5cd80-e66c-11e8-9a02-37b2bd05cae6.png)

Fixes: #344, #346 
