### PR TITLE
Remove token uniques validation from model

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -25,7 +25,6 @@ class Affiliation < ApplicationRecord
   validate :email_from_webpage_domain, if: :email
 
   validates :status, presence: true
-  validates :token, uniqueness: true
 
   before_save :guarantee_urls_protocol
 

--- a/app/services/affiliation/create.rb
+++ b/app/services/affiliation/create.rb
@@ -6,7 +6,6 @@ class Affiliation::Create
   end
 
   def call
-    @affiliation.token = Affiliation.generate_unique_secure_token
     if @affiliation.save
       AffiliationMailer.verification(@affiliation).deliver_later
     end


### PR DESCRIPTION
This is a source of all problems with affiliation creation. Validation is invoked before `before_create` callback which generates token.