### PR TITLE
[#347] Hide Service Offers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Remove description under "Services" header in services, add category description in categories (@michal-szostak)
 - Reorder form parts in order/configuration (@michal-szostak)
 - On project item view show order history in reversed order (@martaswiatkowska)
+- Hide service offers on service about page if no offers are available (@michal-szostak)
 - Rename "Some Header" in services' about page to "Documents" (@michal-szostak)
 - Hide TODO Technical Parameters from service offer selection (@michal-szostak)
 

--- a/app/views/services/_about.html.haml
+++ b/app/views/services/_about.html.haml
@@ -3,7 +3,7 @@
     %main.col-9.pr-5
 
       = markdown(service.description)
-      - if policy(service).order?
+      - if policy(service).order? && !offers.empty?
         = render "services/offers", offers: offers
 
     %sidebar.col-3


### PR DESCRIPTION
# What is in this PR?

* Hide Service Offers in service's about page if no offers are
  available

Fixes: #347