### PR TITLE
Fix siblings find when not in root category

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -9,7 +9,7 @@ class CategoriesController < ApplicationController
 
   def show
     @services = paginate(category_services.order(ordering))
-    @siblings = category.ancestry.nil? ? @root_categories : category.ancestry.children.order(:name)
+    @siblings = siblings
     @subcategories = category.children.order(:name)
     @provider_options = provider_options
     @dedicated_for_options = dedicated_for_options
@@ -33,5 +33,9 @@ class CategoriesController < ApplicationController
 
     def category
       @category ||= Category.find(params[:id])
+    end
+
+    def siblings
+      category.ancestry.nil? ? @root_categories : category.parent.children.order(:name)
     end
 end

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -34,12 +34,14 @@ RSpec.feature "Service categories" do
     expect(page.body).to_not have_content sub_sub_category.name
   end
 
-  scenario "subcategories section is not show when no subcategories" do
-    category = create(:category)
+  scenario "when in category siblings categories are shown" do
+    root = create(:category)
+    sub1, sub2 = create_list(:category, 2, parent: root)
 
-    visit category_path(category)
+    visit category_path(sub1)
 
-    expect(page.body).to_not have_content "Subcategories"
+    expect(body).to have_content sub1.name
+    expect(body).to have_content sub2.name
   end
 
   scenario "shows services from category and subcategories" do


### PR DESCRIPTION
`ancestry` method returns parent `id` not object itself.

Fixes #338