### PR TITLE
Use rails helper to render new project option

### DIFF
--- a/app/views/projects/show.js.erb
+++ b/app/views/projects/show.js.erb
@@ -1,7 +1,8 @@
 let projectSelect = $("#project_item_project_id");
 
-projectSelect.append(
-  $("<option></option>", { value: "<%= @project.id %>" }).text("<%= @project.name %>"));
+
+projectSelect.append("<%= j options_for_select([[@project.name, @project.id]]) %>");
+
 projectSelect.val("<%= @project.id %>");
 projectSelect.focus();
 


### PR DESCRIPTION
This guarantee correct option rendering (no more "a%#36a" when the new project "a'a" is created).

Fixes #371