### PR TITLE
Eliminate n + 1 queries for services logos

### DIFF
--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -125,6 +125,6 @@ private
   end
 
   def scope
-    policy_scope(Service)
+    policy_scope(Service).with_attached_logo
   end
 end


### PR DESCRIPTION
Right now we are doing a log of additional db queries - simply we have n+1 queries problems. One of n+1 problem is connected with loading services logos. This PR solves this problem.

Before:

```
23:32:11 web.1       |   Service Load (0.6ms)  SELECT  "services".* FROM "services" LIMIT $1 OFFSET $2  [["LIMIT", 10], ["OFFSET", 0]]
23:32:11 web.1       |   ↳ app/views/services/index.html.haml:31
23:32:11 web.1       |   ResearchArea Load (0.4ms)  SELECT "research_areas".* FROM "research_areas" INNER JOIN "service_research_areas" ON "research_areas"."id" = "service_research_areas"."research_area_id" WHERE "service_research_areas"."service_id" = $1  [["service_id", 15]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:2
23:32:11 web.1       |   Provider Load (0.3ms)  SELECT "providers".* FROM "providers" INNER JOIN "service_providers" ON "providers"."id" = "service_providers"."provider_id" WHERE "service_providers"."service_id" = $1  [["service_id", 15]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:8
23:32:11 web.1       |   Rendered services/_categorization.html.haml (19.5ms)
23:32:11 web.1       |   ActiveStorage::Attachment Load (0.5ms)  SELECT  "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = $1 AND "active_storage_attachments"."record_type" = $2 AND "active_storage_attachments"."name" = $3 LIMIT $4  [["record_id", 15], ["record_type", "Service"], ["name", "logo"], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ActiveStorage::Blob Load (0.3ms)  SELECT  "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 15], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ResearchArea Load (0.3ms)  SELECT "research_areas".* FROM "research_areas" INNER JOIN "service_research_areas" ON "research_areas"."id" = "service_research_areas"."research_area_id" WHERE "service_research_areas"."service_id" = $1  [["service_id", 1]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:2
23:32:11 web.1       |   Provider Load (0.3ms)  SELECT "providers".* FROM "providers" INNER JOIN "service_providers" ON "providers"."id" = "service_providers"."provider_id" WHERE "service_providers"."service_id" = $1  [["service_id", 1]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:8
23:32:11 web.1       |   Rendered services/_categorization.html.haml (2.7ms)
23:32:11 web.1       |   ActiveStorage::Attachment Load (0.3ms)  SELECT  "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = $1 AND "active_storage_attachments"."record_type" = $2 AND "active_storage_attachments"."name" = $3 LIMIT $4  [["record_id", 1], ["record_type", "Service"], ["name", "logo"], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ActiveStorage::Blob Load (0.2ms)  SELECT  "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ResearchArea Load (1.0ms)  SELECT "research_areas".* FROM "research_areas" INNER JOIN "service_research_areas" ON "research_areas"."id" = "service_research_areas"."research_area_id" WHERE "service_research_areas"."service_id" = $1  [["service_id", 17]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:2
23:32:11 web.1       |   Provider Load (0.3ms)  SELECT "providers".* FROM "providers" INNER JOIN "service_providers" ON "providers"."id" = "service_providers"."provider_id" WHERE "service_providers"."service_id" = $1  [["service_id", 17]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:8
23:32:11 web.1       |   Rendered services/_categorization.html.haml (4.6ms)
23:32:11 web.1       |   ActiveStorage::Attachment Load (0.3ms)  SELECT  "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = $1 AND "active_storage_attachments"."record_type" = $2 AND "active_storage_attachments"."name" = $3 LIMIT $4  [["record_id", 17], ["record_type", "Service"], ["name", "logo"], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ActiveStorage::Blob Load (0.2ms)  SELECT  "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 17], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ResearchArea Load (0.3ms)  SELECT "research_areas".* FROM "research_areas" INNER JOIN "service_research_areas" ON "research_areas"."id" = "service_research_areas"."research_area_id" WHERE "service_research_areas"."service_id" = $1  [["service_id", 16]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:2
23:32:11 web.1       |   Provider Load (0.2ms)  SELECT "providers".* FROM "providers" INNER JOIN "service_providers" ON "providers"."id" = "service_providers"."provider_id" WHERE "service_providers"."service_id" = $1  [["service_id", 16]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:8
23:32:11 web.1       |   Rendered services/_categorization.html.haml (2.5ms)
23:32:11 web.1       |   ActiveStorage::Attachment Load (1.4ms)  SELECT  "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = $1 AND "active_storage_attachments"."record_type" = $2 AND "active_storage_attachments"."name" = $3 LIMIT $4  [["record_id", 16], ["record_type", "Service"], ["name", "logo"], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ActiveStorage::Blob Load (0.3ms)  SELECT  "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 16], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ResearchArea Load (0.4ms)  SELECT "research_areas".* FROM "research_areas" INNER JOIN "service_research_areas" ON "research_areas"."id" = "service_research_areas"."research_area_id" WHERE "service_research_areas"."service_id" = $1  [["service_id", 18]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:2
23:32:11 web.1       |   Provider Load (0.6ms)  SELECT "providers".* FROM "providers" INNER JOIN "service_providers" ON "providers"."id" = "service_providers"."provider_id" WHERE "service_providers"."service_id" = $1  [["service_id", 18]]
23:32:11 web.1       |   ↳ app/views/services/_categorization.html.haml:8
23:32:11 web.1       |   Rendered services/_categorization.html.haml (4.4ms)
23:32:11 web.1       |   ActiveStorage::Attachment Load (0.7ms)  SELECT  "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = $1 AND "active_storage_attachments"."record_type" = $2 AND "active_storage_attachments"."name" = $3 LIMIT $4  [["record_id", 18], ["record_type", "Service"], ["name", "logo"], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
23:32:11 web.1       |   ActiveStorage::Blob Load (0.3ms)  SELECT  "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 18], ["LIMIT", 1]]
23:32:11 web.1       |   ↳ app/views/services/_service.html.haml:6
...
```

After

```
23:25:26 web.1       |   Service Load (0.3ms)  SELECT  "services".* FROM "services" LIMIT $1 OFFSET $2  [["LIMIT", 10], ["OFFSET", 0]]
23:25:26 web.1       |   ↳ app/views/services/index.html.haml:31
23:25:26 web.1       |   ActiveStorage::Attachment Load (0.4ms)  SELECT "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_type" = $1 AND "active_storage_attachments"."name" = $2 AND "active_storage_attachments"."record_id" IN ($3, $4, $5, $6, $7, $8, $9, $10, $11, $12)  [["record_type", "Service"], ["name", "logo"], ["record_id", 15], ["record_id", 1], ["record_id", 17], ["record_id", 16], ["record_id", 18], ["record_id", 19], ["record_id", 33], ["record_id", 2], ["record_id", 20], ["record_id", 21]]
```