### PR TITLE
[#357] Link to website when serice is active

### DIFF
--- a/app/views/project_items/_project_item.html.haml
+++ b/app/views/project_items/_project_item.html.haml
@@ -5,6 +5,12 @@
     .col-md-2
       %span.text-uppercase
         = project_item.status
+    .col-md-3
+
+      - if project_item.status == ProjectItem.statuses[:ready]
+        %span
+          = link_to "Access the service", project_item.service.webpage_url,
+            class: "btn btn-primary"
     .col-md.text-md-right
       %span
         last change: #{time_ago_in_words(project_item.updated_at)} ago

--- a/spec/features/my_services_spec.rb
+++ b/spec/features/my_services_spec.rb
@@ -107,6 +107,15 @@ RSpec.feature "My Services" do
       expect(page).to have_text(project_item.service.title)
       expect(page).not_to have_text(project2.name)
     end
+
+    scenario "I see webservice link if service is ready" do
+      project = create(:project, user: user)
+      project_item = create(:project_item, project: project, offer: offer, status: :ready)
+
+      visit projects_path
+
+      expect(page).to have_link("Access the service", href: project_item.service.webpage_url)
+    end
   end
 
   context "as anonymous user" do


### PR DESCRIPTION
Display link to service webpage when service is ready 
Fix #357 