### PR TITLE
[#376] Add category select in text search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add offers to the services (@goreck888)
 - Google analytics integration (@mkasztelnik)
 - Friendly urls for categories and services (@mkasztelnik)
+- Category select box to text searchbar (@michal-szostak)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,17 +7,13 @@ class ApplicationController < ActionController::Base
   include Sentryable
   include Pundit
 
-  before_action :load_root_categories!, :set_search_submit_path
+  before_action :load_root_categories!
 
   protect_from_forgery
 
   rescue_from Pundit::NotAuthorizedError do |exception|
     redirect_back fallback_location: root_path,
                   alert: "You are not authorized to see this page"
-  end
-
-  def set_search_submit_path
-    @search_submit_path = services_path
   end
 
   private

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -17,10 +17,6 @@ class CategoriesController < ApplicationController
     @research_areas = ResearchArea.all
   end
 
-  def set_search_submit_path
-    @search_submit_path = category_path
-  end
-
   private
     def category_services
       records.joins(:service_categories).

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -2,15 +2,13 @@ import {Controller} from 'stimulus'
 
 export default class extends Controller {
     static targets = ['categorySelect', 'form'];
-    SERVICES_URL = "/services";
-    CATEGORIES_URL = "/categories";
-
-    initialize() {
-    }
 
     connect() {
+        this.SERVICES_URL = this.data.get("servicesPath");
+        this.CATEGORIES_URL = this.data.get("categoriesPath");
+
         this.categorySelectTarget.value = "";
-        let match = window.location.pathname.match(new RegExp(`^${this.CATEGORIES_URL}/(\\d+$)`));
+        let match = window.location.pathname.match(new RegExp(`^${this.CATEGORIES_URL}/([^/]+$)`));
         if(match !== null)
             this.categorySelectTarget.value = match[1];
 

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -1,0 +1,28 @@
+import {Controller} from 'stimulus'
+
+export default class extends Controller {
+    static targets = ['categorySelect', 'form'];
+    SERVICES_URL = "/services";
+    CATEGORIES_URL = "/categories";
+
+    initialize() {
+    }
+
+    connect() {
+        this.categorySelectTarget.value = "";
+        let match = window.location.pathname.match(new RegExp(`^${this.CATEGORIES_URL}/(\\d+$)`));
+        if(match !== null)
+            this.categorySelectTarget.value = match[1];
+
+        this.refresh();
+    }
+
+    refresh() {
+        let actionURL = this.SERVICES_URL;
+
+        if(this.categorySelectTarget.value !== "")
+            actionURL = `${this.CATEGORIES_URL}/${this.categorySelectTarget.value}`;
+
+        this.formTarget.setAttribute("action", actionURL);
+    }
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     %header.pb-2
       = render "layouts/navbar"
-      = render "services/search", search_submit_path: @search_submit_path, categories: @root_categories
+      = render "services/search", search_submit_path: @search_submit_path, categories: @siblings || @root_categories
     %main
       = render "layouts/breadcrumb"
       = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     %header.pb-2
       = render "layouts/navbar"
-      = render "services/search", search_submit_path: @search_submit_path
+      = render "services/search", search_submit_path: @search_submit_path, categories: @root_categories
     %main
       = render "layouts/breadcrumb"
       = yield

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -3,8 +3,9 @@
     .col-2
     .col-8
       %p
-        = form_tag "#{search_submit_path}", method: :get, role: "search", class: "", "data-target": "search.form",
-          "data-controller": "search", "data-sync-query-form": "data-sync-query-form" do
+        = form_tag "#{services_path}", method: :get, role: "search", class: "", "data-target": "search.form",
+          "data-controller": "search", "data-sync-query-form": "data-sync-query-form",
+          "data-search-services-path": services_path, "data-search-categories-path": "/categories" do
 
           .input-group
             %label.sr-only{ for: "search" } Search
@@ -13,7 +14,7 @@
                                                              "data-target": "search.categorySelect" }
               %option{ value: "", selected: "selected" }
                 All
-              = options_for_select categories.map { |category| [category.name, category.id] }, params[:category]
+              = options_for_select categories.map { |category| [category.name, category.slug] }, params[:category]
             .input-group-append
               %button#query-submit.input-group-text.bg-white
                 %i.fas.fa-search

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -3,13 +3,17 @@
     .col-2
     .col-8
       %p
-        = form_tag "#{search_submit_path}", method: :get, role: "search", class: "",
-          "data-sync-query-form": "data-sync-query-form" do
+        = form_tag "#{search_submit_path}", method: :get, role: "search", class: "", "data-target": "search.form",
+          "data-controller": "search", "data-sync-query-form": "data-sync-query-form" do
 
           .input-group
             %label.sr-only{ for: "search" } Search
-            = text_field_tag :q, params[:q], class: "form-control", placeholder: "What are you looking for?"
-
+            = text_field_tag :q, params[:q], class: "form-control w-50", placeholder: "What are you looking for?"
+            %select#category-select.custom-select.rounded-0{ "data-action": "change->search#refresh",
+                                                             "data-target": "search.categorySelect" }
+              %option{ value: "", selected: "selected" }
+                All
+              = options_for_select categories.map { |category| [category.name, category.id] }, params[:category]
             .input-group-append
               %button#query-submit.input-group-text.bg-white
                 %i.fas.fa-search

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "Home" do
   include OmniauthHelper
 
-  scenario "should searching should go to /services with correct query" do
+  scenario "searching should go to /services with correct query" do
     visit "/"
 
     fill_in "q", with: "Something"

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+
+RSpec.feature "Service searching in top bar", js: true do
+  include OmniauthHelper
+
+  category = nil
+
+  before { category = create(:category) }
+
+  scenario "search with 'All' selected should submit to /services" do
+    visit root_path
+    select "All", from: "category-select"
+    click_on(id: "query-submit")
+
+    url = URI.parse(page.current_path)
+
+    expect(url.path).to eq(services_path)
+
+    expect(page).to have_select("category-select", selected: "All")
+  end
+
+  scenario "search with any category selected should submit to /categories" do
+    visit root_path
+    select category.name, from: "category-select"
+    click_on(id: "query-submit")
+
+    url = URI.parse(page.current_path)
+
+    expect(url.path).to eq(category_path(category))
+
+    expect(page).to have_select("category-select", selected: category.name)
+  end
+end


### PR DESCRIPTION
# What is in this PR?

This PR extends search bar to include category select: 

![image](https://user-images.githubusercontent.com/13235269/48488125-58ba4500-e820-11e8-935f-0e9ad5618216.png)

* Category select box will automatically set itself based on URL's
  category id (or lack therof)
* Changing category will change form action attribute
* All of this is achieved by some JS magic (via stimulus)

Fixes: #376