### PR TITLE
Friendly urls for services and category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Category tree in sidebar (@michal-szostak)
 - Global filters to category view (@michal-szostak)
 - Add offers to the services (@goreck888)
+- Friendly urls for categories and services (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "gretel"
 gem "will_paginate", "~> 3.1.0"
 gem "will_paginate-bootstrap4"
 gem "simple_form"
+gem "friendly_id", "~> 5.2.0"
 
 gem "activestorage-validator"
 gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
+    friendly_id (5.2.4)
+      activerecord (>= 4.0.0)
     github-markup (2.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -449,6 +451,7 @@ DEPENDENCIES
   elasticsearch-rails
   factory_bot_rails
   faker
+  friendly_id (~> 5.2.0)
   github-markup
   gretel
   haml-rails

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -55,7 +55,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
     end
 
     def find_and_authorize
-      @service = Service.find(params[:id])
+      @service = Service.friendly.find(params[:id])
       authorize(@service)
     end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -32,7 +32,7 @@ class CategoriesController < ApplicationController
     end
 
     def category
-      @category ||= Category.find(params[:id])
+      @category ||= Category.friendly.find(params[:id])
     end
 
     def siblings

--- a/app/controllers/services/application_controller.rb
+++ b/app/controllers/services/application_controller.rb
@@ -22,7 +22,7 @@ class Services::ApplicationController < ApplicationController
   private
 
     def load_and_authenticate_service!
-      @service = Service.find(params[:service_id])
+      @service = Service.friendly.find(params[:service_id])
       authorize(@service, :order?)
     end
 end

--- a/app/controllers/services/opinions_controller.rb
+++ b/app/controllers/services/opinions_controller.rb
@@ -2,7 +2,7 @@
 
 class Services::OpinionsController < ApplicationController
   def index
-    @service = Service.find(params[:service_id])
+    @service = Service.friendly.find(params[:service_id])
     @service_opinions = ServiceOpinion.joins(project_item: :offer).
         where(offers: { service_id: @service })
     @question = Service::Question.new(service: @service)

--- a/app/controllers/services/questions_controller.rb
+++ b/app/controllers/services/questions_controller.rb
@@ -2,7 +2,7 @@
 
 class Services::QuestionsController < ApplicationController
   def create
-    @service = Service.find(params[:service_id])
+    @service = Service.friendly.find(params[:service_id])
     @service.contact_emails.each  do |email|
       ServiceMailer.new_question(email, params[:service_question], @service).deliver_now
     end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -17,7 +17,7 @@ class ServicesController < ApplicationController
   def show
     @service = Service.
                includes(:offers, related_services: :providers).
-               find(params[:id])
+               friendly.find(params[:id])
 
     @offers = @service.offers
     @related_services = @service.related_services

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Category < ApplicationRecord
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+
+
   has_ancestry
 
   # This callback need to be defined byfore dependent: :destroy

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,7 +6,11 @@ class Service < ApplicationRecord
   include Elasticsearch::Model
   include Elasticsearch::Model::Callbacks
 
+  extend FriendlyId
+  friendly_id :title, use: :slugged
+
   has_one_attached :logo
+
 
   has_many :offers, dependent: :restrict_with_error
   has_many :service_categories, dependent: :destroy

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  # This adds an option to to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20181114222220_create_friendly_id_slugs.rb
+++ b/db/migrate/20181114222220_create_friendly_id_slugs.rb
@@ -1,0 +1,22 @@
+migration_class =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration[4.2]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < migration_class
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           null: false
+      t.integer  :sluggable_id,   null: false
+      t.string   :sluggable_type, limit: 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20181114224426_add_slug_to_service.rb
+++ b/db/migrate/20181114224426_add_slug_to_service.rb
@@ -1,0 +1,5 @@
+class AddSlugToService < ActiveRecord::Migration[5.2]
+  def change
+    add_column :services, :slug, :string, unique: true
+  end
+end

--- a/db/migrate/20181114224431_add_slug_to_category.rb
+++ b/db/migrate/20181114224431_add_slug_to_category.rb
@@ -1,0 +1,5 @@
+class AddSlugToCategory < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categories, :slug, :string, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_143358) do
+ActiveRecord::Schema.define(version: 2018_11_14_224431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,9 +62,22 @@ ActiveRecord::Schema.define(version: 2018_11_07_143358) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "services_count", default: 0
+    t.string "slug"
     t.index ["ancestry"], name: "index_categories_on_ancestry"
     t.index ["description"], name: "index_categories_on_description"
     t.index ["name"], name: "index_categories_on_name"
+  end
+
+  create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
   create_table "offers", force: :cascade do |t|
@@ -78,29 +91,6 @@ ActiveRecord::Schema.define(version: 2018_11_07_143358) do
     t.index ["iid"], name: "index_offers_on_iid"
     t.index ["service_id", "iid"], name: "index_offers_on_service_id_and_iid", unique: true
     t.index ["service_id"], name: "index_offers_on_service_id"
-  end
-
-  create_table "order_changes", force: :cascade do |t|
-    t.string "status"
-    t.text "message"
-    t.bigint "order_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "author_id"
-    t.index ["author_id"], name: "index_order_changes_on_author_id"
-    t.index ["order_id"], name: "index_order_changes_on_order_id"
-  end
-
-  create_table "orders", force: :cascade do |t|
-    t.string "status", null: false
-    t.bigint "service_id", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "issue_id"
-    t.integer "issue_status", default: 2, null: false
-    t.index ["service_id"], name: "index_orders_on_service_id"
-    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "project_item_changes", force: :cascade do |t|
@@ -227,6 +217,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_143358) do
     t.text "phase", null: false
     t.integer "offers_count", default: 0
     t.text "activate_message"
+    t.string "slug"
     t.index ["description"], name: "index_services_on_description"
     t.index ["owner_id"], name: "index_services_on_owner_id"
     t.index ["provider_id"], name: "index_services_on_provider_id"

--- a/lib/tasks/friendly_id.rake
+++ b/lib/tasks/friendly_id.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+desc "Generate friendly ids for services and categories"
+namespace :friendly_id do
+  task generate: :environment do
+    Service.find_each(&:save)
+    Category.find_each(&:save)
+  end
+end


### PR DESCRIPTION
[`friendly_id`](https://github.com/norman/friendly_id) gem was used to add friendly URLs for services and categories. 

When this PR is pushed into an environment where categories and services are already defined in DB friendly ids need to be generated. To do that run the following task (cc @wziajka):

```
rails friendly_id:generate
```

Fixes #30