### PR TITLE
Google analytics integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Category tree in sidebar (@michal-szostak)
 - Global filters to category view (@michal-szostak)
 - Add offers to the services (@goreck888)
+- Google analytics integration (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ ENV variables:
   * `SMTP_ADDRESS` - smtp mail server address
   * `SMTP_USERNAME` - smtp user name or email address
   * `SMTP_PASSWORD` - smtp password
+  * `GOOGLE_ANALYTICS` - google analytics key for GMT (if present than analytics
+    script is added into head section)
 
 ## Commits
 

--- a/app/views/layouts/_google_analytics.html.haml
+++ b/app/views/layouts/_google_analytics.html.haml
@@ -1,0 +1,10 @@
+- if ENV["GOOGLE_ANALYTICS"]
+  %script{ src: "https://www.googletagmanager.com/gtag/js?id=#{ENV["GOOGLE_ANALYTICS"]}", async: true }
+  :javascript
+    document.addEventListener("turbolinks:load", function() {
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '#{ENV["GOOGLE_ANALYTICS"]}');
+    });

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -9,3 +9,4 @@
   = javascript_include_tag "application", "data-turbolinks-track": "reload"
   = stylesheet_pack_tag "application"
   = javascript_pack_tag "application"
+  = render "layouts/google_analytics"

--- a/spec/features/admin/version_spec.rb
+++ b/spec/features/admin/version_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Marketplace version" do
   before { checkin_sign_in_as(admin) }
 
   scenario "can been seen in admin main page" do
-    # allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("MP_VERSION").and_return("1234")
 
     visit admin_path


### PR DESCRIPTION
This is the first attempt to integrate google analytics into MP. Since this can be problematic to work with turbolinks (as described in #405 issue) this need to be carefully tested if no duplicated entries or no entries are reported.  

Fixes #405