### PR TITLE
[#358] Terms and condition hint have dynamic url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Hide TODO Technical Parameters from service offer selection (@michal-szostak)
 - Fields on Service entry to not be required (@kmarszalek)
 - Link to webpage on project_item view (#martaswiatkowska)
+- Url of terms and condition hint are taken from service.term_of_use_url (@martaswiatkowska)
 
 ### Deprecated
 

--- a/app/controllers/services/summaries_controller.rb
+++ b/app/controllers/services/summaries_controller.rb
@@ -11,7 +11,9 @@ class Services::SummariesController < Services::ApplicationController
   end
 
   def create
-    @confirmation = Confirmation.new(confirmation_params)
+    @confirmation = Confirmation.new(confirmation_params.
+                                       merge(required: @service.terms_of_use_url))
+
     if @confirmation.valid?
       authorize(project_item_template)
 
@@ -45,6 +47,10 @@ class Services::SummariesController < Services::ApplicationController
     end
 
     def confirmation_params
-      params.fetch(:confirmation).permit(:terms_and_conditions)
+      if @service.terms_of_use_url.present?
+        params.fetch(:confirmation).permit(:terms_and_conditions)
+      else
+        {}
+      end
     end
 end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -25,4 +25,9 @@ module ServiceHelper
   def any_present?(record, *fields)
     fields.map { |f| record.send(f) }.any? { |v| v.present? }
   end
+
+  def get_terms_and_condition_hint_text(service)
+    "You are about to order an #{service.title}. Please accept " \
+      "#{link_to service.title, service.terms_of_use_url} to preceed.".html_safe
+  end
 end

--- a/app/models/confirmation.rb
+++ b/app/models/confirmation.rb
@@ -5,7 +5,9 @@ class Confirmation
   include ActiveModel::Conversion
   extend ActiveModel::Naming
 
-  validates :terms_and_conditions, acceptance: true, presence: true
+  attr_accessor :required
+
+  validates :terms_and_conditions, acceptance: true, presence: true, if: Proc.new { |u| u.required.present? }
 
   def initialize(attributes = {})
     attributes.each { |name, value| send("#{name}=", value) }

--- a/app/views/services/summaries/show_normal.html.haml
+++ b/app/views/services/summaries/show_normal.html.haml
@@ -7,9 +7,9 @@
   You can change anything now if you need.
   After clicking the order button your request will be sent to service provider.
 
-
   = simple_form_for @confirmation, url: service_summary_path(@service), html: { id: "order-form"  } do |f|
-    = f.input :terms_and_conditions, as: :boolean
+    - if @service.terms_of_use_url.present?
+      = f.input :terms_and_conditions, as: :boolean, hint: get_terms_and_condition_hint_text(@service).html_safe
 
 = render "services/summaries/technical_configuration",
          service: @service, project_item: @project_item

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -24,10 +24,6 @@ en:
     #     edit:
     #       email: 'E-mail.'
     hints:
-      defaults:
-        terms_and_conditions: |
-          You are about to order an EOSC Service. Please accept
-          <a href="http://eoscportal.trust-itservices.com/governance/rules-participation">EOSC Terms and Conditions</a> to preceed.
       question:
         text: |
           We will send and information service provider.

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -87,6 +87,38 @@ RSpec.feature "Service ordering" do
       expect(page).to have_content(service.title)
     end
 
+    scenario "I can order service without terms and contitions" do
+      service = create(:service, terms_of_use_url: "")
+      offer, _seconds_offer = create_list(:offer, 2, service: service)
+      affiliation = create(:affiliation, status: :active, user: user)
+
+      visit service_path(service)
+
+      click_on "Order"
+
+      # Step 1
+
+      choose "project_item_offer_id_#{offer.iid}"
+      click_on "Next", match: :first
+
+      # Step 2
+
+      select "Services"
+      select affiliation.organization
+      select "Single user", from: "Customer typology"
+      fill_in "Access reason", with: "To pass test"
+      fill_in "Additional information", with: "Additional information test"
+
+      click_on "Next", match: :first
+
+      # Step 3
+      expect(page).not_to have_text("Accept terms and conditions")
+
+      expect do
+        click_on "Order", match: :first
+      end.to change { ProjectItem.count }.by(1)
+    end
+
     scenario "Skip offers selection when only one offer" do
       create(:offer, service: service)
 


### PR DESCRIPTION
Terms and condition are taken from service.terms_of_use_url. 

Fix #358  