### PR TITLE
Improve ask service question view

### DIFF
--- a/app/controllers/services/questions_controller.rb
+++ b/app/controllers/services/questions_controller.rb
@@ -4,7 +4,8 @@ class Services::QuestionsController < ApplicationController
   def create
     @service = Service.friendly.find(params[:service_id])
     @service.contact_emails.each  do |email|
-      ServiceMailer.new_question(email, params[:service_question], @service).deliver_now
+      ServiceMailer.new_question(email, current_user,
+                                 params[:service_question], @service).deliver_now
     end
 
     redirect_to service_path(@service)

--- a/app/mailers/service_mailer.rb
+++ b/app/mailers/service_mailer.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class ServiceMailer < ApplicationMailer
-  def new_question(recipient_email, service_question, service)
+  def new_question(recipient_email, author, service_question, service)
     @service = service
     @message = service_question[:text]
-    @author = User.find(service_question[:author])
+    @author = author
 
     mail(to: recipient_email,
          from: @author.email,

--- a/app/views/services/_question.html.haml
+++ b/app/views/services/_question.html.haml
@@ -11,7 +11,6 @@
             &times;
       .modal-body
         = simple_form_for question, url: service_questions_path(service) do |f|
-          = f.hidden_field :author, value: current_user.id
           = f.input :text, as: :text, input_html: { rows: 10 },
             label: t("simple_form.labels.question.text", title: service.title),
             hint: t("simple_form.hints.question.text", email: current_user.email)

--- a/app/views/services/_question.html.haml
+++ b/app/views/services/_question.html.haml
@@ -10,15 +10,11 @@
           %span{ "aria-hidden": true }
             &times;
       .modal-body
-        = form_for question, url: service_questions_path(service) do |f|
-          .form-group
-            %label.col-form-label{ for: "message-text" }
-              Our question to provider about #{service.title}
-            = f.hidden_field :author, value: current_user.id
-            = f.text_area :text, size: "53x10"
-            %label
-              We will send an information to this provider. You will receive answer to your mail
-              #{current_user.email}
+        = simple_form_for question, url: service_questions_path(service) do |f|
+          = f.hidden_field :author, value: current_user.id
+          = f.input :text, as: :text, input_html: { rows: 10 },
+            label: t("simple_form.labels.question.text", title: service.title),
+            hint: t("simple_form.hints.question.text", email: current_user.email)
       .modal-footer
         %button#submit-button.btn.btn-primary
           SEND

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -14,6 +14,8 @@ en:
     labels:
       defaults:
         terms_and_conditions: Accept terms and conditions
+      question:
+        text: Your question to provider about %{title}
     #   defaults:
     #     password: 'Password'
     #   user:
@@ -26,6 +28,10 @@ en:
         terms_and_conditions: |
           You are about to order an EOSC Service. Please accept
           <a href="http://eoscportal.trust-itservices.com/governance/rules-participation">EOSC Terms and Conditions</a> to preceed.
+      question:
+        text: |
+          We will send and information service provider.
+          You will receive answer to %{email} email.
 
     #     username: 'User name to sign in.'
     #     password: 'No special characters, please.'

--- a/spec/mailers/service_spec.rb
+++ b/spec/mailers/service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe ServiceMailer, type: :mailer do
     let(:recipient) { create(:user) }
     let(:author) { create(:user) }
     let(:service) { build(:service) }
-    let(:mail) { described_class.new_question(recipient.email,
-                                              { "author": author.id, "text": "text message" },
+    let(:mail) { described_class.new_question(recipient.email, author,
+                                              { "text": "text message" },
                                               service).deliver_now }
 
     it "sends verification email to service representative" do


### PR DESCRIPTION
3 improvements:
  * use bootstrap classes to style question form nicely
  * remove author id from modal and use `current_user` in the backend
  * show "Ask a question" link only when service defines `contact_emails`
The last bullet can be important to @roksanaer because right all services do not have this field defined and this link will be not shown.