### PR TITLE
[#430] Page is retained when filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,5 +150,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Correctly expand affiliation accordions in profile (@jswk)
 - Insert a line-break after button(s) in service header right panel (@jswk)
 - Search by text from any view (@michal-szostak)
+- Search does not preserve `page` query param (@michal-szostak)
 
 ### Security

--- a/app/javascript/packs/sort_filter.js
+++ b/app/javascript/packs/sort_filter.js
@@ -2,13 +2,13 @@ function searchToObj(search) {
     let obj = {}, i, parts, len, key, value;
 
     let _params = search.substr(1).split('&');
-
     for (i = 0, len = _params.length; i < len; i++) {
         parts = _params[i].split('=');
         if (! parts[0]) {continue;}
+        // page parameter should not be retained
+        if (parts[0] === 'page') {continue;}
         obj[parts[0]] = parts[1] || "";
     }
-
     return obj;
 }
 

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -294,11 +294,22 @@ RSpec.feature "Service filtering and sorting" do
     expect(page).to have_selector(".media", count: 1)
     expect(page).to have_selector("input[name='dedicated_for[]'][value='VO'][checked='checked']")
   end
+
   scenario "searching via platforms", js: true do
     visit services_path
     find(:css, "input[name='related_platforms[]'][value='#{Platform.order(:name).first.id}']").set(true)
     click_on(id: "filter-submit")
 
+    expect(page).to have_selector(".media", count: 1)
+  end
+
+  scenario "page query param should be reset after filtering", js: true do
+    create_list(:service, 40)
+    visit services_path(page: 3)
+    find(:css, "input[name='related_platforms[]'][value='#{Platform.order(:name).first.id}']").set(true)
+    click_on(id: "filter-submit")
+
+    expect(page.current_path).to_not have_content("page=")
     expect(page).to have_selector(".media", count: 1)
   end
 


### PR DESCRIPTION
# What is in this PR?

* Page query param is not synced from query params now, filtering
  should reset page on which user was prior to filtering

Fixes: #430