### PR TITLE
Research area hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Show affiliation info for project item (@jswk)
 - Add a landing page for when affiliation is activated (@jswk)
 - Favicon (@michal-szostak)
+- Research area hierarchy (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)
@@ -160,7 +161,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Insert a line-break after button(s) in service header right panel (@jswk)
 - Search by text from any view (@michal-szostak)
 - Search does not preserve `page` query param (@michal-szostak)
-- Multicheckbox does not take into account selected category when calculating available services (@michal-szostak) 
+- Multicheckbox does not take into account selected category when calculating available services (@michal-szostak)
 - Change default sort order for services to name ascending (@michal-szostak)
 
 ### Security

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -14,7 +14,7 @@ class CategoriesController < ApplicationController
     @provider_options = provider_options(category)
     @dedicated_for_options = dedicated_for_options(category)
     @rating_options = rating_options(category)
-    @research_areas = ResearchArea.all
+    @research_areas = research_areas
     @related_platform_options = related_platform_options(category)
   end
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -11,7 +11,7 @@ class ServicesController < ApplicationController
     @provider_options = provider_options
     @dedicated_for_options = dedicated_for_options
     @rating_options = rating_options
-    @research_areas = ResearchArea.all
+    @research_areas = research_areas
     @related_platform_options = related_platform_options
   end
 

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ResearchArea < ApplicationRecord
+  has_ancestry cache_depth: true
+
   has_many :service_research_areas, autosave: true, dependent: :destroy
   has_many :services, through: :service_research_areas
 

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -39,7 +39,7 @@
         %select#research-area.form-control.form-control-sm{ name: "research_area" }
           %option{ value: "", selected: "selected" }
             Any
-          = options_for_select(research_areas.map { |area| [area.name, area.id] }, params[:research_area])
+          = options_for_select(research_areas, params[:research_area])
   .row
     .col-md-12
       %button#filter-submit.btn.btn-primary.mt-4.w-100{ type: "submit" }

--- a/db/data.yml
+++ b/db/data.yml
@@ -188,6 +188,9 @@ area:
 
     Interdisciplinary:
         name: &interdisciplinary "Interdisciplinary"
+    # sub:
+    #     name: &ra_test "Just for tests - should be removed by Rox"
+    #     parent: *interdisciplinary
     EarthScience:
         name: &earthScience "Earth Science"
     ArtsAndHumanities:

--- a/db/migrate/20181119100216_add_ancestry_to_research_area.rb
+++ b/db/migrate/20181119100216_add_ancestry_to_research_area.rb
@@ -1,0 +1,6 @@
+class AddAncestryToResearchArea < ActiveRecord::Migration[5.2]
+  def change
+    add_column :research_areas, :ancestry, :string, index: true
+    add_column :research_areas, :ancestry_depth, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_16_101816) do
+ActiveRecord::Schema.define(version: 2018_11_19_100216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,6 +146,8 @@ ActiveRecord::Schema.define(version: 2018_11_16_101816) do
 
   create_table "research_areas", force: :cascade do |t|
     t.text "name", null: false
+    t.string "ancestry"
+    t.integer "ancestry_depth", default: 0
   end
 
   create_table "service_categories", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,7 +27,11 @@ yaml_hash["providers"].each do |_, hash|
 end
 
 yaml_hash["area"].each do |_, hash|
-  ResearchArea.find_or_create_by(name: hash["name"])
+  # !!! Warning: parent need to be defined before child in yaml !!!
+  parent = ResearchArea.find_by(name: hash["parent"])
+  ResearchArea.find_or_initialize_by(name: hash["name"]) do |ra|
+    ra.update!(parent: parent)
+  end
   puts "#{ hash["name"] } area generated"
 end
 

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Service filtering" do
+  include OmniauthHelper
+
+  context "research area" do
+    it "is hierarchical" do
+      root = create(:research_area)
+      sub = create(:research_area, parent: root)
+      subsub = create(:research_area, parent: sub)
+
+      visit services_path
+
+      puts body
+      expect(body).to have_text(root.name)
+      # https://github.com/teamcapybara/capybara/issues/1440#issuecomment-62335948
+      expect(body).to have_text("\u00a0\u00a0#{sub.name}")
+      expect(body).to have_text("\u00a0\u00a0\u00a0\u00a0#{subsub.name}")
+    end
+
+    it "shows services from selected research area and sub research areas" do
+      root = create(:research_area)
+      sub = create(:research_area, parent: root)
+      subsub = create(:research_area, parent: sub)
+
+      create(:service, research_areas: [root])
+      create(:service, research_areas: [sub])
+      create(:service, research_areas: [subsub])
+      create(:service)
+
+      visit services_path(research_area: root.id)
+      expect(page).to have_selector(".media", count: 3)
+
+      visit services_path(research_area: sub.id)
+      expect(page).to have_selector(".media", count: 2)
+
+      visit services_path(research_area: subsub.id)
+      expect(page).to have_selector(".media", count: 1)
+    end
+  end
+end


### PR DESCRIPTION
A hierarchy was added to `ResearchArea` using [ancestry](https://github.com/stefankroes/ancestry) (the same used to create categories hierarchy). On the front, no breaking space was used to add name indention ( `&nbsp;`). The option group was not good enough, because you cannot have parent clickable and this is a flat structure. 

This PR is ready from the technical point of view and can be reviewed, but before merging someone (most probably @roksanaer, @agpul, @goreck888) need to introduce correct research area hierarchy. Here you can find example (which need to be removed before merge) how to do this: https://github.com/cyfronet-fid/marketplace/blob/378-research-areas-tree/db/data.yml#L150-L152

![sub](https://user-images.githubusercontent.com/1265430/48710852-f2f7ff80-ec09-11e8-8305-c18ba2f72f64.png)


TODOs:
  - [x] @mkasztelnik: implement hierarchy in `ResearchArea`
  - [ ] @roksanaer, @agpul, @goreck888 create real research area hierarchy in yaml

Fixes #378