### PR TITLE
[#368] Fix service count in filter multiselects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,5 +152,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Insert a line-break after button(s) in service header right panel (@jswk)
 - Search by text from any view (@michal-szostak)
 - Search does not preserve `page` query param (@michal-szostak)
+- Multicheckbox does not take into account selected category when calculating available services
 
 ### Security

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -11,11 +11,11 @@ class CategoriesController < ApplicationController
     @services = paginate(category_services.order(ordering))
     @siblings = siblings
     @subcategories = category.children.order(:name)
-    @provider_options = provider_options
-    @dedicated_for_options = dedicated_for_options
-    @rating_options = rating_options
+    @provider_options = provider_options(category)
+    @dedicated_for_options = dedicated_for_options(category)
+    @rating_options = rating_options(category)
     @research_areas = ResearchArea.all
-    @related_platform_options = related_platform_options
+    @related_platform_options = related_platform_options(category)
   end
 
   private

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -3,6 +3,8 @@
 class Platform < ApplicationRecord
   has_many :service_related_platforms, dependent: :destroy
   has_many :services, through: :service_related_platforms
+  has_many :service_categories, through: :services
+  has_many :categories, through: :service_categories
 
   validates :name, presence: true
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -3,6 +3,8 @@
 class Provider < ApplicationRecord
   has_many :service_providers, dependent: :destroy
   has_many :services, through: :service_providers
+  has_many :service_categories, through: :services
+  has_many :categories, through: :service_categories
 
   validates :name, presence: true
 end

--- a/spec/controllers/concerns/searchable_spec.rb
+++ b/spec/controllers/concerns/searchable_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class SearchableFakeController < ApplicationController
+  include Service::Searchable
+end
+
+RSpec.describe SearchableFakeController do
+  let!(:platform_1) { create(:platform) }
+  let!(:platform_2) { create(:platform) }
+  let!(:provider_1) { create(:provider) }
+  let!(:provider_2) { create(:provider) }
+  let!(:service_1) do  create(:service,
+                              providers: [provider_1],
+                              dedicated_for: ["Researchers"],
+                              platforms: [platform_1])
+  end
+  let!(:service_2) do  create(:service,
+                              providers: [provider_2],
+                              dedicated_for: ["VO"],
+                              platforms: [platform_2])
+  end
+  let!(:category_1) { create(:category, services: [service_1, service_2]) }
+  let!(:category_2) { create(:category, services: [service_2]) }
+  let!(:controller) { SearchableFakeController.new }
+
+  context "provider_options" do
+    it "should count services depending on the category" do
+      expect(controller.send(:provider_options, category_2).size).to eq(1)
+      expect(controller.send(:provider_options, category_2).first).to eq([provider_2.name, provider_2.id, 1])
+    end
+
+    it "should count all services if no category is specified" do
+      expect(controller.send(:provider_options).size).to eq(2)
+      expect(controller.send(:provider_options)).to include([provider_2.name, provider_2.id, 2])
+    end
+
+  end
+
+  context "dedicated_for_options" do
+    it "should count services depending on the category" do
+      expect(controller.send(:dedicated_for_options, category_2).size).to eq(1)
+      expect(controller.send(:dedicated_for_options, category_2).first).to eq(["VO", "VO", 1])
+    end
+
+    it "should count all services if no category is specified" do
+      expect(controller.send(:dedicated_for_options).size).to eq(2)
+      expect(controller.send(:dedicated_for_options)).to include(["Researchers", "Researchers", 1])
+    end
+  end
+
+  context "related_platform_options" do
+    it "should count services depending on the category" do
+      expect(controller.send(:related_platform_options, category_2).size).to eq(1)
+      expect(controller.send(:related_platform_options, category_2)).to include([platform_2.name, platform_2.id, 1])
+    end
+
+    it "should count all services if no category is specified" do
+      expect(controller.send(:related_platform_options).size).to eq(2)
+      expect(controller.send(:related_platform_options)).to include([platform_2.name, platform_2.id, 2])
+    end
+  end
+end


### PR DESCRIPTION
# What is in this PR?

* Fix `dedicated_for_options`, `provider_options`,
  `related_platform_options` to count number of services with respect
  to selected category

* create new unit test spec for `Searchable`

Fixes: #368