### PR TITLE
[#433] Custom error messages for policies

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,12 +13,17 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError do |exception|
     redirect_back fallback_location: root_path,
-                  alert: "You are not authorized to see this page"
+                  alert: not_authorized_message(exception)
   end
 
   private
 
     def load_root_categories!
       @root_categories = Category.roots.order(:name)
+    end
+
+    def not_authorized_message(exception)
+      policy_name = exception.policy.class.to_s.underscore
+      I18n.t "#{policy_name}.#{exception.query}", scope: :pundit, default: :default
     end
 end

--- a/config/locales/pundit.en.yml
+++ b/config/locales/pundit.en.yml
@@ -1,0 +1,6 @@
+en:
+  pundit:
+    default: "You are not authorized to see this page"
+    affiliation_policy:
+      "edit?": "You cannot edit an affiliation which has been activated"
+      "destroy?": "You cannot remove an affiliation which has a project item"

--- a/spec/features/affiliations_spec.rb
+++ b/spec/features/affiliations_spec.rb
@@ -68,5 +68,19 @@ RSpec.feature "Affiliations" do
 
       expect(affiliation.organization).to eq("new org")
     end
+
+    scenario "I cannot remove an affiliation with a project item" do
+      affiliation = create(:affiliation, user: user)
+
+      visit profile_path
+
+      affiliation.status = :active
+      affiliation.save
+      create(:project_item, affiliation: affiliation)
+
+      click_on "Delete"
+
+      expect(page).to have_content("You cannot remove an affiliation which has a project item")
+    end
   end
 end


### PR DESCRIPTION
The previous not authorized error message could be ambiguous for users,
so now it is possible to set a custom one based on policy and query.

* Messages for edit? and destroy? queries for Affiliation are added.

Fixes: #433