### PR TITLE
[#446] Show affiliation in project item view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Technical parameters display in service offers (@michal-szostak)
 - Add "All Services" link with services count above categories navigation in sidebar (@michal-szostak)
 - Show "Go to the service" for catalog service (@mkasztelnik)
+- Show affiliation info for project item (@jswk)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/views/project_items/show.html.haml
+++ b/app/views/project_items/show.html.haml
@@ -37,6 +37,35 @@
               new_project_item_service_opinion_path(@project_item),
               class: "btn btn-secondary"
 
+      - if @project_item.affiliation.present?
+        %h3.mb-3 Connected affiliation
+        %ul
+          %li
+            %strong Organization:
+            = @project_item.affiliation.organization
+          - if @project_item.affiliation.department.present?
+            %li
+              %strong Department:
+              = @project_item.affiliation.department
+          %li
+            %strong Email:
+            = @project_item.affiliation.email
+          - if @project_item.affiliation.phone.present?
+            %li
+              %strong Phone:
+              = @project_item.affiliation.phone
+          %li
+            %strong Webpage:
+            = @project_item.affiliation.webpage
+          - if @project_item.affiliation.supervisor.present?
+            %li
+              %strong Supervisor:
+              = @project_item.affiliation.supervisor
+          - if @project_item.affiliation.supervisor_profile.present?
+            %li
+              %strong Supervisor profile:
+              = @project_item.affiliation.supervisor_profile
+
       = render "project_items/attributes", property_values: @project_item.property_values
 
 

--- a/app/views/services/summaries/show_normal.html.haml
+++ b/app/views/services/summaries/show_normal.html.haml
@@ -26,8 +26,9 @@
     %dt Reason to request access to #{@service.title}
     %dd= @project_item.access_reason
 
-    %dt Additional information
-    %dd= @project_item.additional_information
+    - if @project_item.additional_information.present?
+      %dt Additional information
+      %dd= @project_item.additional_information
 
   - if @project_item.affiliation
     %h4 Affiliation
@@ -35,23 +36,27 @@
       %dt Organization
       %dd= @project_item.affiliation.organization
 
-      %dt Department
-      %dd= @project_item.affiliation.department.presence || "No department set"
+      - if @project_item.affiliation.department.present?
+        %dt Department
+        %dd= @project_item.affiliation.department
 
       %dt Email
       %dd= @project_item.affiliation.email
 
-      %dt Phone
-      %dd= @project_item.affiliation.phone.presence || "No phone set"
+      - if @project_item.affiliation.phone.present?
+        %dt Phone
+        %dd= @project_item.affiliation.phone
 
       %dt Webpage
       %dd= @project_item.affiliation.webpage
 
-      %dt Supervisor
-      %dd= @project_item.affiliation.supervisor.presence || "No supervisor set"
+      - if @project_item.affiliation.supervisor.present?
+        %dt Supervisor
+        %dd= @project_item.affiliation.supervisor
 
-      %dt Supervisor profile
-      %dd= @project_item.affiliation.supervisor_profile.presence || "No supervisor profile set"
+      - if @project_item.affiliation.supervisor_profile.present?
+        %dt Supervisor profile
+        %dd= @project_item.affiliation.supervisor_profile
 
   %h4 My projects
   %dl.mb-4


### PR DESCRIPTION
* Add a section with connected affiliation data in project view details.
* Don't show affiliation fields which don't have values in project item
  order summary step.

Fixes: #446