### PR TITLE
Add for providers section to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ ENV variables:
   * `SMTP_PASSWORD` - smtp password
   * `GOOGLE_ANALYTICS` - google analytics key for GMT (if present than analytics
     script is added into head section)
+  * `PORTAL_BASE_URL` - portal base URL used to generate footer and other static
+    links to EOSC portal
 
 ## Commits
 

--- a/app/views/home/_products.html.haml
+++ b/app/views/home/_products.html.haml
@@ -13,7 +13,7 @@
         Contribute to develop EOSC into a rich environment with a wide range of services and resources for researches.
       %p
         %strong
-          = link_to "Become a provider", "https://eosc-portal.eu/for-providers"
+          = link_to "Become a provider", "#{Mp::Application.config.portal_base_url}/for-providers"
 
     .col-12.col-lg-9.right-column.pl-5
       %p.subtitle.mt-4 In EOSC Marketplace you can

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,5 +1,5 @@
 %footer.footer.pt-3.pb-3
-  - portal_base = "https://eosc-portal.eu"
+  - portal_base = Mp::Application.config.portal_base_url
   .container
     .row.h-100
       .col-md-5
@@ -11,7 +11,7 @@
           privacy policy
     %hr.mb-4
     .row
-      .col-md-2
+      .col-md
         %ul
           %li
             %h5.text-uppercase About
@@ -27,7 +27,7 @@
             %a{ href: "#{portal_base}/about/faqs" } FAQs
           %li.mb-1
             %a{ href: "#{portal_base}/contact-us" } Contact us
-      .col-md-2
+      .col-md
         %ul
           %li
             %h5.text-uppercase Governance
@@ -37,7 +37,7 @@
             %a{ href: "#{portal_base}/governance/rules-participation" } Rules of participation
           %li.mb-1
             %a{ href: "#{portal_base}/governance/best-practices" } Best Practices
-      .col-md-2
+      .col-md
         %ul
           %li
             %h5.text-uppercase Services & Resources
@@ -57,7 +57,7 @@
             %a{ href: "#{portal_base}/services-resources/training" } Training & Support
           %li.mb-1
             %a{ href: "#{portal_base}/services-resources/security-operations" } Security & Operations
-      .col-md-2
+      .col-md
         %ul
           %li
             %h5.text-uppercase Policy
@@ -67,7 +67,7 @@
             %a{ href: "#{portal_base}/policy/europe" } Europe
           %li.mb-1
             %a{ href: "#{portal_base}/policy/eu-member-states" } Member States
-      .col-md-2
+      .col-md
         %ul
           %li
             %h5.text-uppercase EOSC IN PRACTICE
@@ -75,7 +75,7 @@
             %a{ href: "#{portal_base}/eosc-in-practice/use-cases" } Use Cases
           %li.mb-1
             %a{ href: "#{portal_base}/eosc-in-practice/open-call" } Open Call
-      .col-md-2
+      .col-md
         %ul
           %li
             %h5.text-uppercase Media
@@ -85,6 +85,11 @@
             %a{ href: "#{portal_base}/media/events" } Forthcoming events
           %li.mb-1
             %a{ href: "#{portal_base}/media/past-events" } Past Events
+      .col-md
+        %ul
+          %li.mb-1
+            %h5
+              %a{ href: "#{portal_base}/for-providers" } For providers
     .row.mt-4
       .col-md-6
         %a.social-logo.twitter-logo.d-inline-block.mr-2{ href: "https://twitter.com/EoscPortal" }

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,6 @@ module Mp
     config.autoload_paths << Rails.root.join("lib")
 
     config.redis_url = ENV["REDIS_URL"] || "redis://localhost:6379/0"
+    config.portal_base_url = ENV["PORTAL_BASE_URL"] || "https://eosc-portal.eu"
   end
 end


### PR DESCRIPTION
Add missing "For providers" footer link.

EOSC portal base URL was also extracted into the configuration (you can access it using `Mp::Application.config.portal_base_url`). This value can be overridden if needed by setting `PORTAL_BASE_URL` env variable (cc @wziajka). 