### PR TITLE
Redirect user from affiliations to profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add a landing page for when affiliation is activated (@jswk)
 - Favicon (@michal-szostak)
 - Research area hierarchy (@mkasztelnik)
+- Redirect user from `/affiliations` to `/profile` (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/app/controllers/profiles/affiliations_controller.rb
+++ b/app/controllers/profiles/affiliations_controller.rb
@@ -4,6 +4,10 @@ class Profiles::AffiliationsController < ApplicationController
   before_action :authenticate_user!
   before_action :find_and_authorize, only: [:edit, :update, :destroy]
 
+  def index
+    redirect_to profile_path
+  end
+
   def new
     @affiliation = Affiliation.new(user: current_user)
     authorize(@affiliation)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
 
   resource :profile, only: [:show] do
     scope module: :profiles do
-      resources :affiliations, only: [:new, :create, :edit, :update, :destroy]
+      resources :affiliations
     end
   end
   resources :affiliation_confirmations, only: :index


### PR DESCRIPTION
After affiliation is created and user press f5 ugly 404 page was shown. This situation occurred because `index` action was not defined in routes. To improve this situation redirect from `GET /affiliations` to `GET
/profile` was added.