### PR TITLE
Unify confirmation views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Platforms are not mandatory (@martaswiatkowska)
 - Base URL for footer link updated to `https://eosc-portal.eu` (@mkasztelnik)
 - Changed VO to Research groups in filters UI (@michal-szostak)
+- Unify confirmation views - order, new affiliation, affiliation confirmations (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/views/affiliation_confirmations/index.html.haml
+++ b/app/views/affiliation_confirmations/index.html.haml
@@ -11,7 +11,8 @@
     %h1 Cannot activate affiliation
     %p= t ".#{@result}"
 
-  = link_to profile_path, class: "btn btn-primary mb-2 mr-2" do
-    Take me to my profile
-  = link_to services_path, class: "btn btn-primary mb-2" do
-    Go to services list
+  .my-4
+    = link_to "Take me to my profile", profile_path,
+      class: "btn btn-primary mr-3"
+    = link_to "Go to services list", services_path,
+      class: "btn btn-secondary"

--- a/app/views/profiles/affiliations/consent.html.haml
+++ b/app/views/profiles/affiliations/consent.html.haml
@@ -5,7 +5,8 @@
     Please click on the link given in the email in order to activate
     your affiliation and be able to use it when requesting access to EOSC services.
 
-  = link_to profile_path, class: "btn btn-primary" do
-    I understand. Take me to My profile
-  = link_to services_path, class: "btn btn-primary" do
-    Go to services list
+  .my-4
+    = link_to "I understand. Take me to My profile", profile_path,
+      class: "btn btn-primary mr-3"
+    = link_to "Go to services list", services_path,
+      class: "btn btn-secondary"


### PR DESCRIPTION
Order confirmation view was used as a template for affiliation create "last step" and affiliation confirmation views

## Affiliation - final step

Was:

![drobnica](https://user-images.githubusercontent.com/1265430/48828702-b85ca700-ed70-11e8-830b-3356d5c51047.png)

Now:

![final-step-new](https://user-images.githubusercontent.com/1265430/48828909-43d63800-ed71-11e8-8dc2-27b57b311f47.png)

## Affiliation activation

Was:
![activation-was](https://user-images.githubusercontent.com/1265430/48828845-16898a00-ed71-11e8-9c84-5f9ba2013478.png)

Now: 

![activation-new](https://user-images.githubusercontent.com/1265430/48828806-01146000-ed71-11e8-87ad-db36d82de6af.png)

