### PR TITLE
Service tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Favicon (@michal-szostak)
 - Research area hierarchy (@mkasztelnik)
 - Redirect user from `/affiliations` to `/profile` (@mkasztelnik)
+- Service tags (@mkasztelnik)
 
 ### Changed
 - Upgrade Sprockets gem to avoid CVE-2018-3760 vulnerability (@mkasztelnik)

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "will_paginate", "~> 3.1.0"
 gem "will_paginate-bootstrap4"
 gem "simple_form"
 gem "friendly_id", "~> 5.2.0"
+gem "acts-as-taggable-on", "~> 6.0"
 
 gem "activestorage-validator"
 gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (6.0.0)
+      activerecord (~> 5.0)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     aes_key_wrap (1.0.1)
@@ -438,6 +440,7 @@ PLATFORMS
 
 DEPENDENCIES
   activestorage-validator
+  acts-as-taggable-on (~> 6.0)
   ancestry
   bootsnap (>= 1.1.0)
   byebug

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -15,6 +15,7 @@ class CategoriesController < ApplicationController
     @dedicated_for_options = dedicated_for_options(category)
     @rating_options = rating_options(category)
     @research_areas = research_areas
+    @tag_options = tag_options
     @related_platform_options = related_platform_options(category)
   end
 

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -41,6 +41,10 @@ module Service::Searchable
             where(service_research_areas: { research_area_id: ids })
       end
     end
+
+    def filter_tag(services, tags)
+      services.tagged_with(tags)
+    end
   end
 
   include FieldFilterable
@@ -116,6 +120,12 @@ private
     query.group("platforms.id")
          .order(:name)
          .map { |provider| [provider.name, provider.id, provider.service_count] }
+  end
+
+  def tag_options
+    ActsAsTaggableOn::Tag.all.
+      map { |t| [t.name, t.name] }.
+      sort { |x, y| x[0] <=> y[0] }
   end
 
   def records

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -13,6 +13,7 @@ class ServicesController < ApplicationController
     @rating_options = rating_options
     @research_areas = research_areas
     @related_platform_options = related_platform_options
+    @tag_options = tag_options
   end
 
   def show

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -9,6 +9,8 @@ class Service < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: :slugged
 
+  acts_as_taggable
+
   has_one_attached :logo
 
   enum service_type: {

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -41,7 +41,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
      :tutorial_url, :restrictions, :phase,
      :activate_message, :logo,
      [contact_emails: []], [research_area_ids: []],
-     [platform_ids: []]]
+     [platform_ids: []], :tag_list]
   end
 
   private

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -24,6 +24,7 @@
   = f.input :contact_emails, multiple: true, as: :array
   = f.association :research_areas, input_html: { multiple: true }, include_hidden: false
   = f.association :platforms, multiple: true
+  = f.input :tag_list
 
   %a#add-email-field Add additional email
   .invalid-feedback{ styles: "display:block" }

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -7,6 +7,7 @@
                            research_areas: @research_areas,
                            dedicated_for_options: @dedicated_for_options,
                            rating_options: @rating_options,
+                           tag_options: @tag_options,
                            related_platform_options: @related_platform_options do
   %h1= @category.name
   %p.text-muted.mb-4= @category.description

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -40,6 +40,12 @@
           %option{ value: "", selected: "selected" }
             Any
           = options_for_select(research_areas, params[:research_area])
+  - if tag_options.present?
+    %h6 Tag
+    .row
+      .col-md-11.offset-md-1
+        .form-group
+          = multi_checkbox :tag, params[:tag], tag_options
   .row
     .col-md-12
       %button#filter-submit.btn.btn-primary.mt-4.w-100{ type: "submit" }

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -8,6 +8,7 @@
                                    research_areas: research_areas,
                                    dedicated_for_options: dedicated_for_options,
                                    rating_options: rating_options,
+                                   tag_options: tag_options,
                                    related_platform_options: related_platform_options
 
     .col-md-9

--- a/app/views/services/_tags.html.haml
+++ b/app/views/services/_tags.html.haml
@@ -1,0 +1,5 @@
+- if service.tag_list.present?
+  .container
+    Tags:
+    - service.tag_list.sort.each do |tag|
+      = link_to tag, services_path(tag: tag), class: "badge badge-light"

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -7,5 +7,6 @@
                            research_areas: @research_areas,
                            dedicated_for_options: @dedicated_for_options,
                            rating_options: @rating_options,
+                           tag_options: @tag_options,
                            related_platform_options: @related_platform_options do
   %h1 Services

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -5,6 +5,7 @@
 
 .tab-content
   = render "services/about", service: @service, offers: @offers
+  = render "services/tags", service: @service
 
 .container.mt-4.pt-4.related-container
   = render "services/related", related_services: @related_services

--- a/config/initializers/act_as_taggable_on.rb
+++ b/config/initializers/act_as_taggable_on.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ActsAsTaggableOn.force_lowercase = true
+ActsAsTaggableOn.remove_unused_tags = true

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -28,6 +28,9 @@ en:
         text: |
           We will send and information service provider.
           You will receive answer to %{email} email.
+      service:
+        tag_list: |
+          Use "," to separate tags
 
     #     username: 'User name to sign in.'
     #     password: 'No special characters, please.'

--- a/db/migrate/20181121094056_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20181121094056_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,36 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20181121094057_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20181121094057_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: "taggings_idx"
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: "taggings_idx"
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20181121094058_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20181121094058_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20181121094059_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20181121094059_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20181121094060_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20181121094060_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20181121094061_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20181121094061_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: "taggings_idy"
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: "taggings_idy"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_19_100216) do
+ActiveRecord::Schema.define(version: 2018_11_21_094061) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -240,6 +240,31 @@ ActiveRecord::Schema.define(version: 2018_11_19_100216) do
     t.index ["owner_id"], name: "index_services_on_owner_id"
     t.index ["provider_id"], name: "index_services_on_provider_id"
     t.index ["title"], name: "index_services_on_title"
+  end
+
+  create_table "taggings", id: :serial, force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,6 +75,7 @@ yaml_hash["services"].each do |_, hash|
                     restrictions: hash["restrictions"],
                     phase: hash["phase"],
                     categories: categories,
+                    tag_list: hash["tags"],
                     platforms: platforms)
 
     service.logo.attached? && service.logo.purge_later

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -39,4 +39,19 @@ RSpec.feature "Service filtering" do
       expect(page).to have_selector(".media", count: 1)
     end
   end
+
+  it "shows services with tag" do
+    create(:service, tag_list: ["a"])
+    create(:service, tag_list: ["a", "b"])
+    create(:service, tag_list: ["c"])
+
+    visit services_path(tag: "a")
+    expect(page).to have_selector(".media", count: 2)
+
+    visit services_path(tag: ["a", "b"])
+    expect(page).to have_selector(".media", count: 1)
+
+    visit services_path(tag: ["a", "b", "c"])
+    expect(page).to have_selector(".media", count: 0)
+  end
 end

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -12,13 +12,14 @@ RSpec.feature "Service browsing" do
     before { checkin_sign_in_as(user) }
 
     scenario "allows to see details" do
-      service = create(:service)
+      service = create(:service, tag_list: ["my-tag"])
 
       visit service_path(service)
 
-      expect(page.body).to have_content service.title
-      expect(page.body).to have_content service.description
-      expect(page.body).to have_content service.tagline
+      expect(body).to have_content service.title
+      expect(body).to have_content service.description
+      expect(body).to have_content service.tagline
+      expect(body).to have_content "my-tag"
     end
 
     scenario "I see Ask Question" do


### PR DESCRIPTION
Service tags can be seen on 2 views:

## service detail views

![service-tag](https://user-images.githubusercontent.com/1265430/48837975-3e83e800-ed87-11e8-89af-722c024553dc.png)


## services filter

![tag-search](https://user-images.githubusercontent.com/1265430/48838016-59565c80-ed87-11e8-9e02-59c7be01239f.png)


To add tag in `seeds` add tags information into `db/data.yml` (cc @roksanaer, @goreck888, @agpul):

```yml
service_name:
  ...
  tags: a, b, c
```

or

```yaml
service_name:
  ...
  tags:
    - a
    - b
    - c
```

Fixes #215