### PR TITLE
[#483] Ready service JIRA Issue transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,5 +172,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Search does not preserve `page` query param (@michal-szostak)
 - Multicheckbox does not take into account selected category when calculating available services (@michal-szostak)
 - Change default sort order for services to name ascending (@michal-szostak)
+- Open access services transition to "Done" state (@michal-szostak)
 
 ### Security

--- a/app/models/jira/checker.rb
+++ b/app/models/jira/checker.rb
@@ -44,6 +44,7 @@ class Jira::Checker
   block_error_handling :check_add_comment!
   block_error_handling :check_delete_issue!
   block_error_handling :check_workflow!
+  block_error_handling :check_workflow_transitions!
   block_error_handling :check_webhook!
 
   def check_connection!
@@ -126,6 +127,16 @@ class Jira::Checker
         raise CheckerError.new("STATUS WITH ID: #{id} DOES NOT EXIST IN JIRA")
       else
         raise e
+      end
+    end
+  end
+
+  def check_workflow_transitions!(issue)
+    begin
+      trs = issue.transitions.all.select { |tr| tr.to.id.to_i == client.wf_done_id }
+      if trs.length == 0
+        raise CheckerError.new("Could not transition from 'TODO' to 'DONE' state, " +
+                                   "this will affect open access services ")
       end
     end
   end

--- a/app/services/project_item/ready.rb
+++ b/app/services/project_item/ready.rb
@@ -35,7 +35,7 @@ class ProjectItem::Ready
                     project: { key: client.jira_project_key },
                     issuetype: { id: client.jira_issue_type_id } })
 
-        trs = issue.transitions.all.select { |tr| tr.name == "Done" }
+        trs = issue.transitions.all.select { |tr| tr.to.id.to_i == client.wf_done_id }
         if trs.length > 0
           transition = issue.transitions.build
           transition.save!("transition" => { "id" => trs.first.id })

--- a/lib/jira/console_checker.rb
+++ b/lib/jira/console_checker.rb
@@ -84,6 +84,9 @@ module Jira
       issue = @checker.client.Issue.build
       @checker.check_create_issue(issue) { |e| self.error_and_abort!(e, 2) } && self.ok!
 
+      print "  - check workflow transitions..."
+      @checker.check_workflow_transitions(issue) { |e| self.error_and_abort!(e, 2) } && self.ok!
+
       print "  - update issue..."
       @checker.check_update_issue(issue) { |e| self.error_and_abort!(e, 2) } && self.ok!
 

--- a/spec/lib/jira/console_checker_spec.rb
+++ b/spec/lib/jira/console_checker_spec.rb
@@ -9,7 +9,11 @@ describe Jira::ConsoleChecker do
     double("Jira::Checker",
            client: double("Jira::Client",
                           jira_config: { "url"      => "http://localhost:2990",
-                                         "workflow" => { "todo" => 1, "in_progress" => 2, "done" => 3 }
+                                         "workflow" => { "todo" => 1,
+                                                         "in_progress" => 2,
+                                                         "waiting_for_response" => 4,
+                                                         "done" => 3,
+                                                         "rejected" => 5 }
                           }))
   }
   let(:con_checker) { Jira::ConsoleChecker.new(checker, {}) }
@@ -109,21 +113,25 @@ describe Jira::ConsoleChecker do
     expect(checker).to receive(:check_update_issue).and_return(true)
     expect(checker).to receive(:check_add_comment).and_return(true)
     expect(checker).to receive(:check_delete_issue).and_return(true)
-    expect(checker).to receive(:check_workflow).exactly(3).and_return(true)
+    expect(checker).to receive(:check_workflow).exactly(5).and_return(true)
     expect(checker).to receive(:check_issue_type).and_return(true)
+    expect(checker).to receive(:check_workflow_transitions).and_return(true)
 
     expect { con_checker.check }.to output("Checking connection..." + " OK".green + "\n" +
                                                "Checking issue type presence..." + " OK".green + "\n" +
                                                "Checking project existence..." + " OK".green + "\n" +
                                                "Trying to manipulate issue...\n" +
                                                "  - create issue..." + " OK".green + "\n" +
+                                               "  - check workflow transitions..." + " OK".green + "\n" +
                                                "  - update issue..." + " OK".green + "\n" +
                                                "  - add comment to issue..." + " OK".green + "\n" +
                                                "  - delete issue..." + " OK".green + "\n" +
                                                "Checking workflow...\n" +
                                                "  - todo [id: 1]..." + " OK".green + "\n" +
                                                "  - in_progress [id: 2]..." + " OK".green + "\n" +
+                                               "  - waiting_for_response [id: 4]..." + " OK".green + "\n" +
                                                "  - done [id: 3]..." + " OK".green + "\n" +
+                                               "  - rejected [id: 5]..." + " OK".green + "\n" +
                                                "WARNING: Webhook won't be check, set MP_HOST env variable if you want to check it".yellow + "\n"
                                     ).to_stdout
   end
@@ -144,12 +152,13 @@ describe Jira::ConsoleChecker do
     expect(checker).to receive(:check_project) { |&block| block.call(error); next false }
     expect(checker).to receive(:check_issue_type) { |&block| block.call(error); next false }
     expect(checker).to receive(:check_create_issue) { |&block| block.call(error); next false }
+    expect(checker).to receive(:check_workflow_transitions) { |&block| block.call(error); next false }
     expect(checker).to receive(:check_update_issue) { |&block| block.call(error); next false }
     expect(checker).to receive(:check_add_comment) { |&block| block.call(error); next false }
     expect(checker).to receive(:check_delete_issue) { |&block| block.call(error); next false }
-    expect(checker).to receive(:check_workflow).exactly(3) { |&block| block.call(error); next false }
+    expect(checker).to receive(:check_workflow).exactly(5) { |&block| block.call(error); next false }
 
-    expect(con_checker).to receive(:error_and_abort!).exactly(10).with(error, any_args)
+    expect(con_checker).to receive(:error_and_abort!).exactly(13).with(error, any_args)
     con_checker.check
 
     $stdout = original_stdout

--- a/spec/services/project_item/ready_spec.rb
+++ b/spec/services/project_item/ready_spec.rb
@@ -9,9 +9,16 @@ RSpec.describe ProjectItem::Ready do
 
 
   before(:each) {
-    jira_client = double("Jira::Client", jira_project_key: "MP", jira_issue_type_id: 5)
-    transition_start = double("Transition", id: "1", name: "Start Progress")
-    transition_done = double("Transition", id: "2", name: "Done")
+    wf_done_id = 6
+    wf_in_progress_id = 7
+
+    jira_client = double("Jira::Client", jira_project_key: "MP", jira_issue_type_id: 5,
+                         wf_in_progress_id: wf_in_progress_id,
+                         wf_done_id: wf_done_id)
+    transition_start = double("Transition", id: "1", name: "____Start Progress____",
+                              to: double(id: wf_in_progress_id.to_s))
+    transition_done = double("Transition", id: "2", name: "____Done____",
+                             to: double(id: wf_done_id.to_s))
     jira_class_stub = class_double(Jira::Client).
         as_stubbed_const(transfer_nested_constants: true)
 


### PR DESCRIPTION
# What is in this PR?

* Transition in ready service is now based on configured
  workflow done state id, instead of hardcoded state.

* Add check to `jira:check` rake task which checks whether jira's
  workflow has direct transition from `todo` to `done` state

Fixes: #483