### PR TITLE
Setup rate period for 3 months

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-RATE_PERIOD = 5.days.ago
-RATE_AFTER_PERIOD = 5.days
+# time after which mail is send
+RATE_PERIOD = 3.months.ago
+# time after which user can rate service that starts when service become ready
+RATE_AFTER_PERIOD = 3.months

--- a/spec/helpers/project_items_helper_spec.rb
+++ b/spec/helpers/project_items_helper_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ProjectItemsHelper, type: :helper do
     it "is true when project_item is ready and updated_at before RATE_PERIOD and no service_opinion" do
       @project_item = create(:project_item, status: :created)
       @project_item.new_change(status: :registered, message: "ProjectItem registered")
-      travel_to(6.days.ago)
+      travel_to((RATE_AFTER_PERIOD + 1.day).ago)
       @project_item.new_change(status: :ready, message: "ProjectItem ready")
       travel_back
       expect(ratingable?).to eq(true)


### PR DESCRIPTION
https://github.com/cyfronet-fid/marketplace/issues/539

change time period after which user can rate and mail is sending to 3 months. also fixed test so that they use only variable periods of time.