### PR TITLE
[#546] Support for SELECT options for custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,5 +175,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Change default sort order for services to name ascending (@michal-szostak)
 - Open access services transition to "Done" state (@michal-szostak)
 - Affiliations UI on small screens (@jarekzet)
+- Support for Select type custom fields in JIRA (`CP-CustomerTypology`) (@michal-szostak)
 
 ### Security

--- a/app/jobs/project_item/register_job.rb
+++ b/app/jobs/project_item/register_job.rb
@@ -3,15 +3,17 @@
 class ProjectItem::RegisterJob < ApplicationJob
   queue_as :orders
 
-  rescue_from(ProjectItem::Register::JIRAIssueCreateError) do |exception|
+  rescue_from(Jira::Client::JIRAIssueCreateError) do |exception|
     # TODO: we need to define what to do when question registration in e.g.
     #       JIRA fails. Maybe we should report this problem to Sentry and
     #       do some manual intervantion?
+    raise exception
   end
 
   rescue_from(StandardError) do |exception|
     # This is general error, which should not occur, but should be
     # caught just in case
+    raise exception
   end
 
   def perform(project_item)

--- a/config/jira.yml
+++ b/config/jira.yml
@@ -31,6 +31,12 @@ default: &default
     CP-ReasonForAccess: <%= "'" + (ENV["MP_JIRA_FIELD_CP_ReasonForAccess"] || "") + "'" %>
     SO-1: <%= "'" + (ENV["MP_JIRA_FIELD_SO_1"] || "") + "'" %>
 
+    select_values:
+      CP-CustomerTypology:
+        single_user: <%= "'" + (ENV["MP_JIRA_FIELD_SELECT_VALUES_CP_CustomerTypology_single_user"] || "") + "'" %>
+        research: <%= "'" + (ENV["MP_JIRA_FIELD_SELECT_VALUES_CP_CustomerTypology_research"] || "") + "'" %>
+        private_company: <%= "'" + (ENV["MP_JIRA_FIELD_SELECT_VALUES_CP_CustomerTypology_private_company"] || "") + "'" %>
+
 development:
   <<: *default
 
@@ -63,6 +69,12 @@ test:
     CP-CustomerTypology: "CP-CustomerTypology-1"
     CP-ReasonForAccess: "CP-ReasonForAccess-1"
     SO-1: "SO-1-1"
+
+    select_values:
+      CP-CustomerTypology:
+        single_user: '20000'
+        research: '20001'
+        private_company: '20002'
 
 production:
   <<: *default

--- a/spec/jobs/project_item/ready_job_spec.rb
+++ b/spec/jobs/project_item/ready_job_spec.rb
@@ -2,26 +2,26 @@
 
 require "rails_helper"
 
-RSpec.describe ProjectItem::RegisterJob do
+RSpec.describe ProjectItem::ReadyJob do
   let(:project_item_owner) { create(:user) }
   let(:project) { create(:project, user: project_item_owner) }
-  let(:register_service) { instance_double(ProjectItem::Register) }
+  let(:ready_service) { instance_double(ProjectItem::Ready) }
   let(:project_item) {
     project_item = create(:project_item, project: project)
-    expect(ProjectItem::Register).to receive(:new).
-        with(project_item).and_return(register_service)
+    allow(ProjectItem::Ready).to receive(:new).
+        with(project_item).and_return(ready_service)
     next project_item
   }
 
-  it "triggers registration process for project_item" do
-    expect(register_service).to receive(:call)
+  it "triggers ready process for project_item" do
+    expect(ready_service).to receive(:call)
     described_class.perform_now(project_item)
   end
 
-  it "should recast exceptions cast by ProjectItem::Register" do
+  it "should recast exceptions cast by ProjectItem::Ready" do
     error = Jira::Client::JIRAIssueCreateError.new(project_item)
 
-    expect(register_service).
+    expect(ready_service).
         to receive(:call).
             and_raise(error)
 

--- a/spec/models/jira/client_spec.rb
+++ b/spec/models/jira/client_spec.rb
@@ -76,7 +76,7 @@ describe Jira::Client do
                        "CI-DepartmentalWebPage-1" => "http://organization.com",
                        "CI-SupervisorName-1" => "Jim Supervisor",
                        "CI-SupervisorProfile-1" => "http://jim.supervisor.edu",
-                       "CP-CustomerTypology-1" => "single_user",
+                       "CP-CustomerTypology-1" => { "id" => "20000" },
                        "CP-ReasonForAccess-1" => "some reason",
                        "SO-1-1" => "cat1/s1/Data repository name=aaaaaa&" +
                                    "Harvesting method=OAI-PMH&" +

--- a/spec/services/project_item/ready_spec.rb
+++ b/spec/services/project_item/ready_spec.rb
@@ -7,95 +7,115 @@ RSpec.describe ProjectItem::Ready do
   let(:issue) { double("Issue", id: 1) }
   let(:transition) { double("Transition") }
 
+  context "(JIRA works without errors)" do
+    before(:each) {
+      wf_done_id = 6
+      wf_in_progress_id = 7
 
-  before(:each) {
-    wf_done_id = 6
-    wf_in_progress_id = 7
-
-    jira_client = double("Jira::Client",
-                         jira_project_key: "MP",
-                         jira_issue_type_id: 5,
-                         wf_in_progress_id: wf_in_progress_id,
-                         wf_done_id: wf_done_id)
-    transition_start = double("Transition", id: "1", name: "____Start Progress____",
-                              to: double(id: wf_in_progress_id.to_s))
-    transition_done = double("Transition", id: "2", name: "____Done____",
-                             to: double(id: wf_done_id.to_s))
-    jira_class_stub = class_double(Jira::Client).
-        as_stubbed_const(transfer_nested_constants: true)
+      jira_client = double("Jira::Client",
+                           jira_project_key: "MP",
+                           jira_issue_type_id: 5,
+                           wf_in_progress_id: wf_in_progress_id,
+                           wf_done_id: wf_done_id)
+      transition_start = double("Transition", id: "1", name: "____Start Progress____",
+                                to: double(id: wf_in_progress_id.to_s))
+      transition_done = double("Transition", id: "2", name: "____Done____",
+                               to: double(id: wf_done_id.to_s))
+      jira_class_stub = class_double(Jira::Client).
+          as_stubbed_const(transfer_nested_constants: true)
 
 
-    allow(jira_class_stub).to receive(:new).and_return(jira_client)
-    allow(issue).to receive(:save).and_return(issue)
-    allow(issue).to receive_message_chain(:transitions, :find) { issue }
-    allow(jira_client).to receive(:create_service_issue).and_return(issue)
-    allow(jira_client).to receive_message_chain(:Issue, :find) { issue }
-    allow(jira_client).to receive_message_chain(:Issue, :build) { issue }
-    allow(issue).to receive_message_chain(:transitions, :all) { [transition_start, transition_done] }
-    allow(issue).to receive_message_chain(:transitions, :build) { transition }
-    allow(transition). to receive(:save!).and_return(transition)
-  }
+      allow(jira_class_stub).to receive(:new).and_return(jira_client)
+      allow(issue).to receive(:save).and_return(issue)
+      allow(issue).to receive_message_chain(:transitions, :find) { issue }
+      allow(jira_client).to receive(:create_service_issue).and_return(issue)
+      allow(jira_client).to receive_message_chain(:Issue, :find) { issue }
+      allow(jira_client).to receive_message_chain(:Issue, :build) { issue }
+      allow(issue).to receive_message_chain(:transitions, :all) { [transition_start, transition_done] }
+      allow(issue).to receive_message_chain(:transitions, :build) { transition }
+      allow(transition). to receive(:save!).and_return(transition)
+    }
 
-  it "creates new project_item change" do
-    described_class.new(project_item).call
+    it "creates new project_item change" do
+      described_class.new(project_item).call
 
-    expect(project_item.project_item_changes.last).to be_ready
-  end
+      expect(project_item.project_item_changes.last).to be_ready
+    end
 
-  it "changes project_item status into ready on success" do
-    described_class.new(project_item).call
+    it "changes project_item status into ready on success" do
+      described_class.new(project_item).call
 
-    expect(project_item).to be_ready
-  end
+      expect(project_item).to be_ready
+    end
 
-  it "uses activate message when project item status is changed to ready" do
-    service = create(:open_access_service, activate_message: "Welcome!!!")
-    offer = create(:offer, service: service)
-    project_item = create(:project_item, offer: offer)
+    it "uses activate message when project item status is changed to ready" do
+      service = create(:open_access_service, activate_message: "Welcome!!!")
+      offer = create(:offer, service: service)
+      project_item = create(:project_item, offer: offer)
 
-    described_class.new(project_item).call
-    last_change = project_item.project_item_changes.last
+      described_class.new(project_item).call
+      last_change = project_item.project_item_changes.last
 
-    expect(last_change.message).to eq("Welcome!!!")
-  end
+      expect(last_change.message).to eq("Welcome!!!")
+    end
 
-  it "creates new jira issue and do the transition" do
-    jira_client = Jira::Client.new
+    it "creates new JIRA issue and do the transition" do
+      jira_client = Jira::Client.new
 
-    expect(jira_client).to receive(:create_service_issue).with(project_item).and_return(issue)
+      expect(jira_client).to receive(:create_service_issue).with(project_item).and_return(issue)
 
-    expect(transition).to receive(:save!).with("transition" => { "id" => "2" })
+      expect(transition).to receive(:save!).with("transition" => { "id" => "2" })
 
-    described_class.new(project_item).call
-    expect(project_item).to be_ready
+      described_class.new(project_item).call
+      expect(project_item).to be_ready
 
-  end
+    end
 
-  context "Normal service project item" do
-    it "sents ready and rate service emails to owner" do
-      # project_item change email is sent only when there is more than 1 change
-      project_item.new_change(status: :created, message: "ProjectItem is ready")
+    context "Normal service project item" do
+      it "sents ready and rate service emails to owner" do
+        # project_item change email is sent only when there is more than 1 change
+        project_item.new_change(status: :created, message: "ProjectItem is ready")
 
-      expect { described_class.new(project_item).call }.
-        to change { ActionMailer::Base.deliveries.count }.by(2)
-      expect(ActionMailer::Base.deliveries[-2].subject).to start_with("Status of your")
-      expect(ActionMailer::Base.deliveries.last.subject).to eq("EOSC Portal - Rate your service")
+        expect { described_class.new(project_item).call }.
+            to change { ActionMailer::Base.deliveries.count }.by(2)
+        expect(ActionMailer::Base.deliveries[-2].subject).to start_with("Status of your")
+        expect(ActionMailer::Base.deliveries.last.subject).to eq("EOSC Portal - Rate your service")
+      end
+    end
+
+    context "Open access service project item" do
+      let(:project_item) do
+        create(:project_item,
+               offer: create(:offer, service: create(:open_access_service)))
+      end
+
+      it "sends only rate service email to owner" do
+        project_item.new_change(status: :ready, message: "ProjectItem is ready")
+
+        expect { described_class.new(project_item).call }.
+            to change { ActionMailer::Base.deliveries.count }.by(1)
+        expect(ActionMailer::Base.deliveries.last.subject).to eq("EOSC Portal - Rate your service")
+        expect(ActionMailer::Base.deliveries.last.subject).to_not start_with("[ProjectItem #")
+      end
     end
   end
 
-  context "Open access service project item" do
-    let(:project_item) do
-      create(:project_item,
-             offer: create(:offer, service: create(:open_access_service)))
+  context "(JIRA raises Errors)" do
+    let!(:jira_client) do
+      client = double("Jira::Client", jira_project_key: "MP")
+      jira_class_stub = class_double(Jira::Client).
+          as_stubbed_const(transfer_nested_constants: true)
+      allow(jira_class_stub).to receive(:new).and_return(client)
+      client
     end
 
-    it "sends only rate service email to owner" do
-      project_item.new_change(status: :ready, message: "ProjectItem is ready")
+    it "sets jira error and raises exception on failed jira issue creation" do
+      error = Jira::Client::JIRAIssueCreateError.new(project_item, "key" => "can not have value X")
 
-      expect { described_class.new(project_item).call }.
-        to change { ActionMailer::Base.deliveries.count }.by(1)
-      expect(ActionMailer::Base.deliveries.last.subject).to eq("EOSC Portal - Rate your service")
-      expect(ActionMailer::Base.deliveries.last.subject).to_not start_with("[ProjectItem #")
+      allow(jira_client).to receive(:create_service_issue).with(project_item).and_raise(error)
+
+      expect { described_class.new(project_item).call }.to raise_error(error)
+      expect(project_item.jira_errored?).to be_truthy
     end
   end
 end

--- a/spec/services/project_item/register_spec.rb
+++ b/spec/services/project_item/register_spec.rb
@@ -6,42 +6,62 @@ RSpec.describe ProjectItem::Register do
   let(:project_item) { create(:project_item, offer: create(:offer)) }
   let(:issue) { double("Issue", id: 1) }
 
+  context "(JIRA works without errors)" do
+    before(:each) {
+      jira_client = double("Jira::Client", jira_project_key: "MP", jira_issue_type_id: 5)
+      jira_class_stub = class_double(Jira::Client).
+          as_stubbed_const(transfer_nested_constants: true)
 
-  before(:each) {
-    jira_client = double("Jira::Client", jira_project_key: "MP", jira_issue_type_id: 5)
-    jira_class_stub = class_double(Jira::Client).
-        as_stubbed_const(transfer_nested_constants: true)
+      allow(jira_class_stub).to receive(:new).and_return(jira_client)
+      allow(jira_client).to receive_message_chain(:Issue, :find) { issue }
+      allow(jira_client).to receive(:create_service_issue).and_return(issue)
+    }
 
-    allow(jira_class_stub).to receive(:new).and_return(jira_client)
-    allow(jira_client).to receive_message_chain(:Issue, :find) { issue }
-    allow(jira_client).to receive(:create_service_issue).and_return(issue)
-  }
+    it "creates new jira issue" do
+      jira_client = Jira::Client.new
 
-  it "creates new jira issue" do
-    jira_client = Jira::Client.new
+      expect(jira_client).to receive(:create_service_issue).with(project_item)
 
-    expect(jira_client).to receive(:create_service_issue).with(project_item)
+      described_class.new(project_item).call
+      expect(project_item.project_item_changes.last).to be_registered
+    end
 
-    described_class.new(project_item).call
-    expect(project_item.project_item_changes.last).to be_registered
+    it "creates new project_item change" do
+      described_class.new(project_item).call
+      expect(project_item.project_item_changes.last).to be_registered
+    end
+
+    it "changes project_item status into registered on success" do
+      described_class.new(project_item).call
+
+      expect(project_item).to be_registered
+    end
+
+    it "sent email to project_item owner" do
+      # project_item change email is sent only when there is more than 1 change
+      project_item.new_change(status: :created, message: "ProjectItem created")
+
+      expect { described_class.new(project_item).call }.
+          to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
   end
 
-  it "creates new project_item change" do
-    described_class.new(project_item).call
-    expect(project_item.project_item_changes.last).to be_registered
-  end
+  context "(JIRA raises Errors)" do
+    let!(:jira_client) do
+      client = double("Jira::Client", jira_project_key: "MP")
+      jira_class_stub = class_double(Jira::Client).
+          as_stubbed_const(transfer_nested_constants: true)
+      allow(jira_class_stub).to receive(:new).and_return(client)
+      client
+    end
 
-  it "changes project_item status into registered on success" do
-    described_class.new(project_item).call
+    it "sets jira error and raises exception on failed jira issue creation" do
+      error = Jira::Client::JIRAIssueCreateError.new(project_item, "key" => "can not have value X")
 
-    expect(project_item).to be_registered
-  end
+      allow(jira_client).to receive(:create_service_issue).with(project_item).and_raise(error)
 
-  it "sent email to project_item owner" do
-    # project_item change email is sent only when there is more than 1 change
-    project_item.new_change(status: :created, message: "ProjectItem created")
-
-    expect { described_class.new(project_item).call }.
-      to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect { described_class.new(project_item).call }.to raise_error(error)
+      expect(project_item.jira_errored?).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
# What is in this PR?

* `ProjectItem::RegisterJob` did not recast exceptions, so if something went wrong sidekiq did not try to restart job, and no errors were logged, exception handles were retained, but error reraising has been added.
* It turned out that `CP-CustomerTypology` field in production JIRA's custom field scheme has "select" type, which requires very specific value handling. It has been added, with appropriate tests.
* Jobs and Services connected to JIRA issues had their tests expanded with failure scenarios

## Why there is no new check in `rake jira:check`?

As far as I know accessing field available option metadata is not possible, at least if you do not
have JIRA admin priviledges.

The issue for that has been created separately here #548 

Fixes: #546 