### PR TITLE
[#555] Every open access service can be added to project only once 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem "jira-ruby"
 gem "redis-rails"
 gem "sidekiq"
 
+gem "custom_error_message", git: "https://github.com/thethanghn/custom-err-msg.git"
+
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/thethanghn/custom-err-msg.git
+  revision: b913309360995472507ea444c6f1a80315b99d28
+  specs:
+    custom_error_message (1.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -447,6 +453,7 @@ DEPENDENCIES
   capybara
   colorize (>= 0.8.1)
   counter_culture (~> 2.0)
+  custom_error_message!
   database_cleaner
   devise
   dotenv-rails

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -119,6 +119,35 @@ RSpec.feature "Service ordering" do
       end.to change { ProjectItem.count }.by(1)
     end
 
+    scenario "I cannot order open_access service twice in one project" do
+      open_access_service = create(:open_access_service)
+      offer = create(:offer, service: open_access_service)
+      default_project = user.projects.find_by(name: "Services")
+
+      visit service_path(open_access_service)
+
+      click_on "Add to my services"
+
+      # Project selection
+      select "Services", from: "project_item_project_id"
+      click_on "Next", match: :first
+
+      expect do
+        check "Accept terms and conditions"
+        click_on "Add to my services", match: :first
+      end.to change { ProjectItem.count }.by(1)
+
+      visit service_path(open_access_service)
+
+      click_on "Add to my services"
+
+      select "Services", from: "project_item_project_id"
+      click_on "Next", match: :first
+
+      expect(page).to have_current_path(service_configuration_path(open_access_service))
+      expect(page).to have_text("You cannot add open access service #{open_access_service.title} to project Services twice")
+    end
+
     scenario "Skip offers selection when only one offer" do
       create(:offer, service: service)
 


### PR DESCRIPTION
Before going to the last step (summaries) service are checked if it's already added to selected project.   
If it's already added it's shown message and user are redirected to the configuration page

Fix #555 