### PR TITLE
Fix tag_list input for Service form in backoffice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,5 +179,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Open access services transition to "Done" state (@michal-szostak)
 - Affiliations UI on small screens (@jarekzet)
 - Support for Select type custom fields in JIRA (`CP-CustomerTypology`) (@michal-szostak)
+- Input for tag_list for Service form in backoffice (@kmarszalek)
 
 ### Security

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -27,7 +27,7 @@
   = f.input :contact_emails, multiple: true, as: :array
   = f.association :research_areas, input_html: { multiple: true }, include_hidden: false
   = f.association :platforms, multiple: true
-  = f.input :tag_list
+  = f.input :tag_list, input_html: { value: service.tag_list.to_s }
   = f.association :categories, multiple: true
 
   %a#add-email-field Add additional email

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -48,12 +48,6 @@
           %option{ value: "", selected: "selected" }
             Any
           = options_for_select(research_areas, params[:research_area])
-  - if tag_options.present?
-    %h6 Tag
-    .row
-      .col-md-11.offset-md-1
-        .form-group
-          = multi_checkbox :tag, params[:tag], tag_options
   .row
     .col-md-12
       %button#filter-submit.btn.btn-primary.mt-4.w-100{ type: "submit" }


### PR DESCRIPTION
#544 
couldn't replicate situation with wrong input -> db record

fix problem with commas during editing service entry.