### PR TITLE
[#586] many service owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 ### Added
 - Breadcrumbs for Admin and Back office sections (@mkasztelnik)
+- Add `service_portfolio_manager` role (@mkasztelnik)
 
 ### Changed
 - Unify Back office and Admin layout navbars (@mkasztelnik)
+- Service can have many owners, owners can see but not modify owned services (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -12,7 +12,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
   end
 
   def new
-    @service = Service.new(owner: current_user)
+    @service = Service.new
     authorize(@service)
   end
 
@@ -50,8 +50,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
 
   private
     def service_template
-      Service.new(permitted_attributes(Service).
-                      merge(owner: current_user))
+      Service.new(permitted_attributes(Service))
     end
 
     def find_and_authorize

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -33,6 +33,12 @@ class Service < ApplicationRecord
   has_many :service_target_groups, dependent: :destroy
   has_many :target_groups, through: :service_target_groups
 
+  has_many :service_user_relationships, dependent: :destroy
+  has_many :owners,
+           through: :service_user_relationships,
+           source: :user,
+           class_name: "User"
+
   has_many :source_relationships,
            class_name: "ServiceRelationship",
            foreign_key: "target_id",

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -46,9 +46,6 @@ class Service < ApplicationRecord
   has_many :related_services,
            through: :target_relationships,
            source: :target
-  belongs_to :owner,
-             class_name: "User",
-             optional: true
 
   validates :title, presence: true
   validates :description, presence: true

--- a/app/models/service_user_relationship.rb
+++ b/app/models/service_user_relationship.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ServiceUserRelationship < ApplicationRecord
+  belongs_to :service
+  belongs_to :user, counter_cache: "owned_services_count"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,14 +5,10 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: %i[checkin]
 
   include RoleModel
-  roles :admin, :service_owner
+  roles :admin, :service_portfolio_manager
 
   has_many :projects, dependent: :destroy
   has_many :affiliations, dependent: :destroy
-  has_many :owned_services,
-           class_name: "Service",
-           foreign_key: "owner_id",
-           dependent: :nullify
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,12 @@ class User < ApplicationRecord
   has_many :projects, dependent: :destroy
   has_many :affiliations, dependent: :destroy
 
+  has_many :service_user_relationships, dependent: :destroy
+  has_many :owned_services,
+           through: :service_user_relationships,
+           source: :service,
+           class_name: "Service"
+
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true
@@ -25,5 +31,9 @@ class User < ApplicationRecord
 
   def active_affiliation?
     active_affiliations_count.positive?
+  end
+
+  def service_owner?
+    owned_services_count.positive?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,4 +36,8 @@ class User < ApplicationRecord
   def service_owner?
     owned_services_count.positive?
   end
+
+  def to_s
+    full_name
+  end
 end

--- a/app/policies/backoffice/backoffice_policy.rb
+++ b/app/policies/backoffice/backoffice_policy.rb
@@ -7,6 +7,6 @@
 # methods are overriden to add :backoffice prefix in automatic way.
 class Backoffice::BackofficePolicy < Struct.new(:user, :backoffice)
   def show?
-    user&.service_owner?
+    user&.service_portfolio_manager?
   end
 end

--- a/app/policies/backoffice/backoffice_policy.rb
+++ b/app/policies/backoffice/backoffice_policy.rb
@@ -7,6 +7,7 @@
 # methods are overriden to add :backoffice prefix in automatic way.
 class Backoffice::BackofficePolicy < Struct.new(:user, :backoffice)
   def show?
-    user&.service_portfolio_manager?
+    user&.service_portfolio_manager? ||
+      user&.service_owner?
   end
 end

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -3,7 +3,7 @@
 class Backoffice::ServicePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.where(owner: user)
+      user.service_portfolio_manager? ? scope : Service.none
     end
   end
 
@@ -12,23 +12,23 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   def show?
-    owner?
+    service_portfolio_manager?
   end
 
   def new?
-    true
+    service_portfolio_manager?
   end
 
   def create?
-    true
+    service_portfolio_manager?
   end
 
   def update?
-    owner?
+    service_portfolio_manager?
   end
 
   def destroy?
-    owner? && project_items.count.zero?
+    service_portfolio_manager? && project_items.count.zero?
   end
 
   def permitted_attributes
@@ -46,8 +46,9 @@ class Backoffice::ServicePolicy < ApplicationPolicy
 
   private
 
-    def owner?
-      record.owner == user
+    # shortcat for service portfolio manager
+    def service_portfolio_manager?
+      user.service_portfolio_manager?
     end
 
     def project_items

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -39,16 +39,19 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:title, :description, :terms_of_use,
-     :tagline, :connected_url, :service_type,
-     [provider_ids: []], :places, :languages,
-     [target_group_ids: []], :terms_of_use_url,
-     :access_policies_url, :corporate_sla_url,
-     :webpage_url, :manual_url, :helpdesk_url,
-     :tutorial_url, :restrictions, :phase,
-     :activate_message, :logo,
-     [contact_emails: []], [research_area_ids: []],
-     [platform_ids: []], :tag_list, [category_ids: []]]
+    [
+      :title, :description, :terms_of_use,
+      :tagline, :connected_url, :service_type,
+      [provider_ids: []], :places, :languages,
+      [target_group_ids: []], :terms_of_use_url,
+      :access_policies_url, :corporate_sla_url,
+      :webpage_url, :manual_url, :helpdesk_url,
+      :tutorial_url, :restrictions, :phase,
+      :activate_message, :logo,
+      [contact_emails: []], [research_area_ids: []],
+      [platform_ids: []], :tag_list, [category_ids: []],
+      [owner_ids: []]
+    ]
   end
 
   private

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -29,6 +29,7 @@
   = f.association :platforms, multiple: true
   = f.input :tag_list, input_html: { value: service.tag_list.to_s }
   = f.association :categories, multiple: true
+  = f.association :owners, multiple: true
 
   %a#add-email-field Add additional email
   .invalid-feedback{ styles: "display:block" }

--- a/db/migrate/20190110095634_remove_owner_from_service.rb
+++ b/db/migrate/20190110095634_remove_owner_from_service.rb
@@ -1,0 +1,5 @@
+class RemoveOwnerFromService < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :services, :owner
+  end
+end

--- a/db/migrate/20190110103051_create_service_user_relationships.rb
+++ b/db/migrate/20190110103051_create_service_user_relationships.rb
@@ -1,0 +1,10 @@
+class CreateServiceUserRelationships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :service_user_relationships do |t|
+      t.belongs_to :service, index: true, foreign_key: true
+      t.belongs_to :user, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190110111453_add_owned_services_count_to_user.rb
+++ b/db/migrate/20190110111453_add_owned_services_count_to_user.rb
@@ -1,0 +1,5 @@
+class AddOwnedServicesCountToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :owned_services_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_05_143939) do
+ActiveRecord::Schema.define(version: 2019_01_10_095634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -225,7 +225,6 @@ ActiveRecord::Schema.define(version: 2018_12_05_143939) do
     t.datetime "updated_at", null: false
     t.text "terms_of_use"
     t.text "tagline", null: false
-    t.bigint "owner_id"
     t.decimal "rating", precision: 2, scale: 1, default: "0.0", null: false
     t.text "connected_url"
     t.bigint "provider_id"
@@ -248,7 +247,6 @@ ActiveRecord::Schema.define(version: 2018_12_05_143939) do
     t.string "slug"
     t.string "service_type"
     t.index ["description"], name: "index_services_on_description"
-    t.index ["owner_id"], name: "index_services_on_owner_id"
     t.index ["provider_id"], name: "index_services_on_provider_id"
     t.index ["title"], name: "index_services_on_title"
   end
@@ -318,5 +316,4 @@ ActiveRecord::Schema.define(version: 2018_12_05_143939) do
   add_foreign_key "service_target_groups", "services"
   add_foreign_key "service_target_groups", "target_groups"
   add_foreign_key "services", "providers"
-  add_foreign_key "services", "users", column: "owner_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_10_095634) do
+ActiveRecord::Schema.define(version: 2019_01_10_111453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -218,6 +218,15 @@ ActiveRecord::Schema.define(version: 2019_01_10_095634) do
     t.index ["target_group_id"], name: "index_service_target_groups_on_target_group_id"
   end
 
+  create_table "service_user_relationships", force: :cascade do |t|
+    t.bigint "service_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["service_id"], name: "index_service_user_relationships_on_service_id"
+    t.index ["user_id"], name: "index_service_user_relationships_on_user_id"
+  end
+
   create_table "services", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
@@ -298,6 +307,7 @@ ActiveRecord::Schema.define(version: 2019_01_10_095634) do
     t.string "last_name", null: false
     t.integer "roles_mask"
     t.integer "active_affiliations_count", default: 0
+    t.integer "owned_services_count", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
@@ -315,5 +325,7 @@ ActiveRecord::Schema.define(version: 2019_01_10_095634) do
   add_foreign_key "service_research_areas", "services"
   add_foreign_key "service_target_groups", "services"
   add_foreign_key "service_target_groups", "target_groups"
+  add_foreign_key "service_user_relationships", "services"
+  add_foreign_key "service_user_relationships", "users"
   add_foreign_key "services", "providers"
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -13,12 +13,14 @@ if Rails.env.development?
       target_groups = TargetGroup.all
       puts "Generating #{services_size} new services"
       services_size.times do
+        sample_user = users.sample
+        owners = sample_user ? [sample_user] : []
         Service.create(title: Faker::Lorem.sentence,
                        description: Faker::Lorem.paragraph,
                        terms_of_use: Faker::Lorem.paragraph,
                        tagline: Faker::Lorem.sentence,
                        categories: [Category.all.sample],
-                       owner: users.sample,
+                       owners: owners,
                        rating: Random.rand(5.0),
                        connected_url: Faker::Internet.url,
                        providers: Provider.all.sample(2),

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -5,102 +5,92 @@ require "rails_helper"
 RSpec.feature "Services in backoffice" do
   include OmniauthHelper
 
-  let(:user) { create(:user, roles: [:service_owner]) }
+  context "As a service portolio manager" do
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
 
-  before { checkin_sign_in_as(user) }
+    before { checkin_sign_in_as(user) }
 
-  context "When browsing owned services" do
-    scenario "I can see only owned services" do
-      create(:service, title: "my service", owner: user)
-      create(:service, title: "other owner service")
+    scenario "I can see all services" do
+      create(:service, title: "service1")
+      create(:service, title: "service2")
 
       visit backoffice_services_path
 
-      expect(page).to have_content("my service")
-      expect(page).to_not have_content("other owner service")
+      expect(page).to have_content("service1")
+      expect(page).to have_content("service2")
     end
-  end
 
-  context "Browsing services" do
-    scenario "I can see my service" do
-      service = create(:service, title: "my service", owner: user)
+    scenario "I can see any service" do
+      service = create(:service, title: "service1")
 
       visit backoffice_service_path(service)
 
-      expect(page).to have_content("my service")
+      expect(page).to have_content("service1")
     end
 
-    scenario "It is denied to see not owned service" do
-      service = create(:service, title: "other owner service")
+    scenario "I can create new service", js: true do
+      category = create(:category)
+      provider = create(:provider)
+      research_area = create(:research_area)
+      platform = create(:platform)
+      target_group = create(:target_group)
+
+      visit backoffice_services_path
+      click_on "Create new service"
+
+      fill_in "Title", with: "service title"
+      fill_in "Description", with: "service description"
+      fill_in "Terms of use", with: "service terms of use"
+      fill_in "Tagline", with: "service tagline"
+      fill_in "Service website", with: "https://sample.url"
+      fill_in "Places", with: "Europe"
+      fill_in "Languages", with: "English"
+      select target_group.name, from: "Dedicated For"
+      fill_in "Terms of use url", with: "https://sample.url"
+      fill_in "Access policies url", with: "https://sample.url"
+      fill_in "Corporate sla url", with: "https://sample.url"
+      fill_in "Webpage url", with: "https://sample.url"
+      fill_in "Manual url", with: "https://sample.url"
+      fill_in "Helpdesk url", with: "https://sample.url"
+      fill_in "Tutorial url", with: "https://sample.url"
+      fill_in "Restrictions", with: "Reaserch affiliation needed"
+      fill_in "Phase", with: "Production"
+      fill_in "Activate message", with: "Welcome!!!"
+      select research_area.name, from: "Research areas"
+      select provider.name, from: "Providers"
+      select "open_access", from: "Service type"
+      select platform.name, from: "Platforms"
+      fill_in "service_contact_emails_0", with: "person1@test.ok"
+      page.find("#add-email-field").click
+      fill_in "service_contact_emails_1", with: "person2@test.ok"
+      select category.name, from: "Categories"
+
+      click_on "Create Service"
+
+      expect(page).to have_content("service title")
+      expect(page).to have_content("service description")
+      expect(page).to have_content("service terms of use")
+      expect(page).to have_content("service tagline")
+      expect(page).to have_content("https://sample.url")
+      expect(page).to have_content("open_access")
+      expect(page).to have_content("person1@test.ok")
+      expect(page).to have_content("person2@test.ok")
+      expect(page).to have_content("Welcome!!!")
+      expect(page).to have_content(research_area.name)
+      expect(page).to have_content(target_group.name)
+      expect(page).to have_content(category.name)
+    end
+
+    scenario "I can edit any service" do
+      service = create(:service, title: "my service")
 
       visit backoffice_service_path(service)
+      click_on "Edit"
 
-      expect(page).to have_content("not authorized")
+      fill_in "Title", with: "updated title"
+      click_on "Update Service"
+
+      expect(page).to have_content("updated title")
     end
-  end
-
-  scenario "I can create new service", js: true do
-    category = create(:category)
-    provider = create(:provider)
-    research_area = create(:research_area)
-    platform = create(:platform)
-    target_group = create(:target_group)
-
-    visit backoffice_services_path
-    click_on "Create new service"
-
-    fill_in "Title", with: "service title"
-    fill_in "Description", with: "service description"
-    fill_in "Terms of use", with: "service terms of use"
-    fill_in "Tagline", with: "service tagline"
-    fill_in "Service website", with: "https://sample.url"
-    fill_in "Places", with: "Europe"
-    fill_in "Languages", with: "English"
-    select target_group.name, from: "Dedicated For"
-    fill_in "Terms of use url", with: "https://sample.url"
-    fill_in "Access policies url", with: "https://sample.url"
-    fill_in "Corporate sla url", with: "https://sample.url"
-    fill_in "Webpage url", with: "https://sample.url"
-    fill_in "Manual url", with: "https://sample.url"
-    fill_in "Helpdesk url", with: "https://sample.url"
-    fill_in "Tutorial url", with: "https://sample.url"
-    fill_in "Restrictions", with: "Reaserch affiliation needed"
-    fill_in "Phase", with: "Production"
-    fill_in "Activate message", with: "Welcome!!!"
-    select research_area.name, from: "Research areas"
-    select provider.name, from: "Providers"
-    select "open_access", from: "Service type"
-    select platform.name, from: "Platforms"
-    fill_in "service_contact_emails_0", with: "person1@test.ok"
-    page.find("#add-email-field").click
-    fill_in "service_contact_emails_1", with: "person2@test.ok"
-    select category.name, from: "Categories"
-    expect { click_on "Create Service" }.
-      to change { user.owned_services.count }.by(1)
-
-    expect(page).to have_content("service title")
-    expect(page).to have_content("service description")
-    expect(page).to have_content("service terms of use")
-    expect(page).to have_content("service tagline")
-    expect(page).to have_content("https://sample.url")
-    expect(page).to have_content("open_access")
-    expect(page).to have_content("person1@test.ok")
-    expect(page).to have_content("person2@test.ok")
-    expect(page).to have_content("Welcome!!!")
-    expect(page).to have_content(research_area.name)
-    expect(page).to have_content(target_group.name)
-    expect(page).to have_content(category.name)
-  end
-
-  scenario "I can edit owned service" do
-    service = create(:service, title: "my service", owner: user)
-
-    visit backoffice_service_path(service)
-    click_on "Edit"
-
-    fill_in "Title", with: "updated title"
-    click_on "Update Service"
-
-    expect(page).to have_content("updated title")
   end
 end

--- a/spec/features/backoffice_spec.rb
+++ b/spec/features/backoffice_spec.rb
@@ -38,4 +38,25 @@ RSpec.feature "Backoffice" do
       expect(page).to have_current_path(backoffice_path)
     end
   end
+
+  context "as a service owner" do
+    let(:user) do
+      create(:user).tap do |user|
+        service = create(:service)
+        ServiceUserRelationship.create!(user: user, service: service)
+      end
+    end
+
+    scenario "I see Backoffice link in navbar" do
+      visit root_path
+
+      expect(page).to have_content("Backoffice")
+    end
+
+    scenario "I'm able to enter into backoffice" do
+      visit backoffice_path
+
+      expect(page).to have_current_path(backoffice_path)
+    end
+  end
 end

--- a/spec/features/backoffice_spec.rb
+++ b/spec/features/backoffice_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Backoffice" do
   end
 
   context "as a service owner" do
-    let(:user) { create(:user, roles: [:service_owner]) }
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
 
     scenario "I see Backoffice link in navbar" do
       visit root_path

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -10,9 +10,6 @@ RSpec.describe Service do
   it { should validate_presence_of(:rating) }
   it { should validate_presence_of(:categories) }
 
-
-  it { should belong_to(:owner) }
-
   it { should have_many(:providers) }
   it { should have_many(:service_categories).dependent(:destroy) }
   it { should have_many(:offers).dependent(:restrict_with_error) }

--- a/spec/models/service_user_relationship_spec.rb
+++ b/spec/models/service_user_relationship_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ServiceUserRelationship, type: :model do
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe User do
 
   it { should have_many(:projects).dependent(:destroy) }
   it { should have_many(:affiliations).dependent(:destroy) }
-  it { should have_many(:owned_services).dependent(:nullify) }
 
   context "#full_name" do
     it "is composed from first and last name" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -69,4 +69,20 @@ RSpec.describe User do
       expect(user).to_not be_active_affiliation
     end
   end
+
+  context "#service_owner?" do
+    it "is false when user does not own any services" do
+      user = create(:user)
+
+      expect(user).to_not be_service_owner
+    end
+
+    it "is true when user owns services" do
+      user = create(:user)
+      service = create(:service)
+      ServiceUserRelationship.create!(user: user, service: service)
+
+      expect(user).to be_service_owner
+    end
+  end
 end

--- a/spec/policies/backoffice/backoffice_policy_spec.rb
+++ b/spec/policies/backoffice/backoffice_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Backoffice::BackofficePolicy do
   permissions :show? do
     it "grants access for service owner" do
       expect(subject).
-        to permit(build(:user, roles: [:service_owner]),
+        to permit(build(:user, roles: [:service_portfolio_manager]),
                  [:backoffice, :backoffice])
     end
 

--- a/spec/policies/backoffice/service_policy_spec.rb
+++ b/spec/policies/backoffice/service_policy_spec.rb
@@ -3,33 +3,95 @@
 require "rails_helper"
 
 RSpec.describe Backoffice::ServicePolicy do
-  let(:user) { create(:user, roles: [:service_portfolio_manager]) }
-
-  subject { described_class }
-
-  permissions :index?, :new?, :create? do
-    it "grants access" do
-      expect(subject).to permit(user, build(:service))
+  let(:service_portfolio_manager) { create(:user, roles: [:service_portfolio_manager]) }
+  let(:service_owner) do
+    create(:user).tap do |user|
+      service = create(:service)
+      ServiceUserRelationship.create!(user: user, service: service)
     end
   end
 
+  subject { described_class }
 
-  permissions :update? do
-    it "grants access for all services" do
-      expect(subject).to permit(user, build(:service))
+  permissions :index? do
+    it "grants access for service portfolio manager" do
+      expect(subject).to permit(service_portfolio_manager, build(:service))
+    end
+
+    it "grants access for service owner" do
+      expect(subject).to permit(service_owner, build(:service))
+    end
+  end
+
+  permissions :show? do
+    it "grants access for service portfolio manager" do
+      expect(subject).to permit(service_portfolio_manager, build(:service))
+    end
+
+
+    it "grants access for owned service" do
+      expect(subject).to permit(service_owner, service_owner.owned_services.first)
+    end
+
+    it "denies access for not owned service" do
+      expect(subject).to_not permit(service_owner, build(:service))
+    end
+  end
+
+  permissions :new?, :create?, :update? do
+    it "grants access for service portfolio manager" do
+      expect(subject).to permit(service_portfolio_manager, build(:service))
+    end
+
+    it "denies access for service owner" do
+      expect(subject).to_not permit(service_owner, build(:service))
+    end
+
+    it "grants access for service portfolio manager" do
+      expect(subject).to permit(service_portfolio_manager, build(:service))
     end
   end
 
   permissions :destroy? do
-    it "grants access for all services" do
-      expect(subject).to permit(user, build(:service))
+    it "grants access for service portfolio manager" do
+      expect(subject).to permit(service_portfolio_manager, build(:service))
+    end
+
+    it "denies access for service owner" do
+      expect(subject).to_not permit(service_owner, build(:service))
     end
 
     it "denies when service has project_items attached" do
       service = create(:service)
       create(:project_item, offer: create(:offer, service: service))
 
-      expect(subject).to_not permit(user, service)
+      expect(subject).to_not permit(service_portfolio_manager, service)
+    end
+  end
+
+  context "#scope" do
+    it "returns all services for service portfolio manager" do
+      create_list(:service, 2)
+
+      scope = described_class::Scope.new(service_portfolio_manager, Service.all)
+
+      expect(scope.resolve.count).to eq(2)
+    end
+
+    it "returns only owned services for service owner" do
+      _not_owned = create(:service)
+
+      scope = described_class::Scope.new(service_owner, Service.all)
+
+      expect(scope.resolve).to contain_exactly(*service_owner.owned_services)
+    end
+
+    it "returns nothing for normal user" do
+      create(:service)
+
+      scope = described_class::Scope.new(create(:user), Service.all)
+
+      expect(scope.resolve.count).to be_zero
     end
   end
 end

--- a/spec/policies/backoffice/service_policy_spec.rb
+++ b/spec/policies/backoffice/service_policy_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Backoffice::ServicePolicy do
-  let(:user) { create(:user, roles: [:service_owner]) }
+  let(:user) { create(:user, roles: [:service_portfolio_manager]) }
 
   subject { described_class }
 
@@ -15,29 +15,21 @@ RSpec.describe Backoffice::ServicePolicy do
 
 
   permissions :update? do
-    it "grants access for service owner" do
-      expect(subject).to permit(user, build(:service, owner: user))
-    end
-
-    it "denies access for other users" do
-      expect(subject).to_not permit(user, build(:service))
+    it "grants access for all services" do
+      expect(subject).to permit(user, build(:service))
     end
   end
 
   permissions :destroy? do
-    it "grants access for service owner" do
-      expect(subject).to permit(user, build(:service, owner: user))
-    end
-
-    it "denies access for other users" do
-      expect(subject).to_not permit(user, build(:service))
+    it "grants access for all services" do
+      expect(subject).to permit(user, build(:service))
     end
 
     it "denies when service has project_items attached" do
-      service = create(:service, owner: user)
+      service = create(:service)
       create(:project_item, offer: create(:offer, service: service))
 
-      expect(subject).to_not permit(user, build(:service))
+      expect(subject).to_not permit(user, service)
     end
   end
 end

--- a/spec/requests/backoffice/services_spec.rb
+++ b/spec/requests/backoffice/services_spec.rb
@@ -3,16 +3,16 @@
 require "rails_helper"
 
 RSpec.describe "Backoffice service" do
-  context "as a logged in service owner" do
-    let(:user) { create(:user, roles: [:service_owner]) }
+  context "as a logged in service portfolio manager" do
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
 
     before { login_as(user) }
 
-    it "I can delete owned service when there is no project_items yet" do
-      service = create(:service, owner: user)
+    it "I can delete service when there is no project_items yet" do
+      service = create(:service)
 
       expect { delete backoffice_service_path(service) }.
-        to change { user.owned_services.count }.by(-1)
+        to change { Service.count }.by(-1)
     end
   end
 end

--- a/spec/services/service/create_spec.rb
+++ b/spec/services/service/create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Service::Create do
   let(:user) { create(:user) }
 
   it "saves valid service in db" do
-    service = described_class.new(build(:service, owner: user)).call
+    service = described_class.new(build(:service)).call
 
     expect(service).to be_persisted
   end

--- a/spec/services/service/update_spec.rb
+++ b/spec/services/service/update_spec.rb
@@ -3,10 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Service::Update do
-  let(:user) { create(:user) }
-  let(:service) { create(:service, owner: user) }
-
   it "updates affiliation" do
+    service = create(:service)
+
     described_class.new(service, title: "new title").call
 
     expect(service.title).to eq("new title")


### PR DESCRIPTION
In the scope of this PR roles model was refactored:
  * `service_owner` roles was renamed into `service_portfolio_manager`. The conclusion of this role renaming is that existing service owners (@agpul and @roksanaer) will become members of the service portfolio management team :smile: 
  * N-N relation was added between `Service` and `User` (using `ServiceUserRelationship` join table). This relation is used to dynamically calculate `service_owner` role (using `owned_services_count` counter cache)

`ServiceUserRelationship` joining table is a generic type and can be used to model much more than service ownership. Take a look at this commit comment https://github.com/cyfronet-fid/marketplace/commit/6696eed4bc1717fe615409cc12716361cf4f9b0a for details.

Fixes #586