### PR TITLE
[#593] Add custom field with project name to created issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Breadcrumbs for Admin and Back office sections (@mkasztelnik)
 - Add `service_portfolio_manager` role (@mkasztelnik)
 - Possibility of adding offers to the services (@martaswiatkowska)
+- `SO-ProjectName` to issue created in JIRA (@michal-szostak)
 
 ### Changed
 - Unify Back office and Admin layout navbars (@mkasztelnik)

--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -59,6 +59,7 @@ class Jira::Client < JIRA::Client
       # "CP-UserGroupName": "?", TODO -
       # "CP-ProjectInformation": "?", TODO -
       # For now only single Service Offer is supported
+      "SO-ProjectName": fields_config["SO-ProjectName"],
       "SO-1": fields_config["SO-1"]
     }
 
@@ -135,6 +136,8 @@ private
       end
     when "CP-ReasonForAccess"
       project_item.access_reason
+    when "SO-ProjectName"
+      "#{project_item.project&.name} (#{project_item.project&.id})"
     when "SO-1"
       "#{project_item.service.categories.first.name}/" +
       "#{project_item.service.title}/" +

--- a/config/jira.yml
+++ b/config/jira.yml
@@ -29,6 +29,7 @@ default: &default
     CI-SupervisorProfile: <%= "'" + (ENV["MP_JIRA_FIELD_CI_SupervisorProfile"] || "") + "'" %>
     CP-CustomerTypology: <%= "'" + (ENV["MP_JIRA_FIELD_CP_CustomerTypology"] || "") + "'" %>
     CP-ReasonForAccess: <%= "'" + (ENV["MP_JIRA_FIELD_CP_ReasonForAccess"] || "") + "'" %>
+    SO-ProjectName: <%= "'" + (ENV["MP_JIRA_FIELD_SO_ProjectName"] || "") + "'" %>
     SO-1: <%= "'" + (ENV["MP_JIRA_FIELD_SO_1"] || "") + "'" %>
 
     select_values:
@@ -68,6 +69,7 @@ test:
     CI-SupervisorProfile: "CI-SupervisorProfile-1"
     CP-CustomerTypology: "CP-CustomerTypology-1"
     CP-ReasonForAccess: "CP-ReasonForAccess-1"
+    SO-ProjectName: "SO-ProjectName-1"
     SO-1: "SO-1-1"
 
     select_values:

--- a/spec/models/jira/client_spec.rb
+++ b/spec/models/jira/client_spec.rb
@@ -33,7 +33,7 @@ describe Jira::Client do
                           offer: create(:offer, name: "off1", service: create(:service,
                                                                         title: "s1",
                                                                         categories: [create(:category, name: "cat1")])),
-                          project: create(:project, user: user),
+                          project: create(:project, user: user, name: "My Secret Project"),
                           customer_typology: "single_user",
                           access_reason: "some reason", properties: [
             {
@@ -78,6 +78,7 @@ describe Jira::Client do
                        "CI-SupervisorProfile-1" => "http://jim.supervisor.edu",
                        "CP-CustomerTypology-1" => { "id" => "20000" },
                        "CP-ReasonForAccess-1" => "some reason",
+                       "SO-ProjectName-1" => "My Secret Project (#{project_item.project.id})",
                        "SO-1-1" => "cat1/s1/off1?Data repository name=aaaaaa&" +
                                    "Harvesting method=OAI-PMH&" +
                                    "Harvesting endpoint=aaaaa" }
@@ -104,7 +105,7 @@ describe Jira::Client do
                                                                  service_type: "open_access",
                                                                  connected_url:  "http://service.org/access",
                                                                  categories: [create(:category, name: "cat1")])),
-                          project: create(:project, user: user))
+                          project: create(:project, user: user, name: "My Secret Project"))
 
     expected_fields = { summary: "Service order, John Doe, s1",
                         project: { key: "MP" },
@@ -115,6 +116,7 @@ describe Jira::Client do
                         "CI-Surname-1" => "Doe",
                         "CI-DisplayName-1" => "John Doe",
                         "CI-EOSC-UniqueID-1" => "uid2",
+                        "SO-ProjectName-1" => "My Secret Project (#{project_item.project.id})",
                         "SO-1-1" => "cat1/s1/off1?" }
 
     issue = double(:Issue)


### PR DESCRIPTION
# What is in this PR?

* Add custom field support for `SO-ProjectName`. The field is filled as
  follows: `<project_nanme> (<project_id>)`

Fixes: #593