### PR TITLE
Select research area while ordering the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- User needs to select "Research area" while ordering service (@mkasztelnik)
 
 ### Changed
 

--- a/app/helpers/research_areas_helper.rb
+++ b/app/helpers/research_areas_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ResearchAreasHelper
+  def grouped_research_areas
+    result = []
+    ResearchArea.arrange.
+      each { |k, v| group_research_areas!(result, "/", k, v) }
+
+    result.inject({}) do |acc, record|
+      k, v = record
+      acc[k] ||= []
+      acc[k] << v
+      acc
+    end.map { |k, v| [k, v] }.sort { |v1, v2| v1.first <=> v2.first }
+  end
+
+  private
+
+    def group_research_areas!(result, current_path, key, values)
+      if values.size > 0
+        new_current_path = "#{current_path}#{key.name}/"
+        values.
+          each { |k, v| group_research_areas!(result, new_current_path, k, v) }
+      else
+        result << [current_path, key]
+      end
+    end
+end

--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -58,6 +58,7 @@ class Jira::Client < JIRA::Client
       "CP-ReasonForAccess": fields_config["CP-ReasonForAccess"],
       "CP-UserGroupName": fields_config["CP-UserGroupName"],
       "CP-ProjectInformation": fields_config["CP-ProjectInformation"],
+      "CP-ScientificDiscipline": fields_config["CP-ScientificDiscipline"],
       # For now only single Service Offer is supported
       "SO-ProjectName": fields_config["SO-ProjectName"],
       "SO-1": fields_config["SO-1"]
@@ -142,6 +143,8 @@ private
       project_item.user_group_name
     when "SO-ProjectName"
       "#{project_item.project&.name} (#{project_item.project&.id})"
+    when "CP-ScientificDiscipline"
+      project_item.research_area&.name
     when "SO-1"
       "#{project_item.service.categories.first.name}/" +
       "#{project_item.service.title}/" +

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -31,15 +31,18 @@ class ProjectItem < ApplicationRecord
   belongs_to :offer
   belongs_to :affiliation, required: false
   belongs_to :project
+  belongs_to :research_area, required: false
   has_one :service_opinion, dependent: :restrict_with_error
   has_many :project_item_changes, dependent: :destroy
 
   validates :offer, presence: true
   validates :affiliation, presence: true, unless: :open_access?
+  validates :research_area, presence: true, unless: :open_access?
   validates :project, presence: true
   validates :status, presence: true
   validates :customer_typology, presence: true, unless: :open_access?
   validates :access_reason, presence: true, unless: :open_access?
+  validate :research_area_is_a_leaf
   validates_associated :property_values
   validates :user_group_name, presence: true, if: :research?
   validates :project_name, presence: true, if: :project?
@@ -123,5 +126,9 @@ class ProjectItem < ApplicationRecord
 
       errors.add(:project, :repited_in_project, message: "^You cannot add open access service #{service.title} to project #{project.name} twice") unless !project_items_services.present?
     end
+  end
+
+  def research_area_is_a_leaf
+    errors.add(:research_area_id, "cannot have children") if research_area&.has_children?
   end
 end

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -5,6 +5,7 @@ class ResearchArea < ApplicationRecord
 
   has_many :service_research_areas, autosave: true, dependent: :destroy
   has_many :services, through: :service_research_areas
+  has_many :project_items, dependent: :restrict_with_exception
 
   validates :name, presence: true
 end

--- a/app/policies/project_item_policy.rb
+++ b/app/policies/project_item_policy.rb
@@ -22,9 +22,12 @@ class ProjectItemPolicy < ApplicationPolicy
       (a.value_schema[:type] == "array" || a.type == "select" ? { a.id => [] } : a.id)
       # TODO handle other attribute value types
     }
-    [:service_id, :project_id, :affiliation_id, :customer_typology,
-     :access_reason, :additional_information, :user_group_name,
-     :project_name, :project_website_url, :company_name,
-     :company_website_url, property_values: attributes]
+
+    [
+      :service_id, :project_id, :affiliation_id, :customer_typology,
+      :access_reason, :additional_information, :user_group_name,
+      :project_name, :project_website_url, :company_name, :research_area_id,
+      :company_website_url, property_values: attributes
+    ]
   end
 end

--- a/app/views/project_items/show.html.haml
+++ b/app/views/project_items/show.html.haml
@@ -26,6 +26,9 @@
           %strong Order date:
           = l @project_item.created_at
         %li
+          %strong Research area:
+          = @project_item.research_area.name
+        %li
           %strong Providers:
           :ruby
             providers = @project_item.service.providers.

--- a/app/views/services/configurations/show_normal.html.haml
+++ b/app/views/services/configurations/show_normal.html.haml
@@ -34,6 +34,8 @@
 
   = f.input :access_reason, input_html: { "data-target" => "project-item.reason" }
   = f.input :additional_information
+  = f.input :research_area_id, as: :grouped_select,
+    collection: grouped_research_areas, group_method: :last
 
   %h5.mb-3.font-weight-bold.configuration-title.text-uppercase Affiliation
   = f.association :affiliation,

--- a/app/views/services/summaries/show_normal.html.haml
+++ b/app/views/services/summaries/show_normal.html.haml
@@ -30,6 +30,9 @@
       %dt Additional information
       %dd= @project_item.additional_information
 
+    %dt Research area
+    %dd= @project_item.research_area.name
+
   - if @project_item.affiliation
     %h4 Affiliation
     %dl.mb-4

--- a/config/jira.yml
+++ b/config/jira.yml
@@ -32,6 +32,7 @@ default: &default
     CP-UserGroupName: <%= "'" + (ENV["MP_JIRA_FIELD_CP_UserGroupName"] || "") + "'" %>
     CP-ProjectInformation: <%= "'" + (ENV["MP_JIRA_FIELD_CP_ProjectInformation"] || "") + "'" %>
     SO-ProjectName: <%= "'" + (ENV["MP_JIRA_FIELD_SO_ProjectName"] || "") + "'" %>
+    CP-ScientificDiscipline: <%= "'" + (ENV["MP_JIRA_FIELD_CP_ScientificDiscipline"] || "") + "'" %>
     SO-1: <%= "'" + (ENV["MP_JIRA_FIELD_SO_1"] || "") + "'" %>
 
     select_values:
@@ -74,6 +75,7 @@ test:
     CP-UserGroupName: "CP-UserGroupName-1"
     CP-ProjectInformation: "CP-ProjectInformation-1"
     SO-ProjectName: "SO-ProjectName-1"
+    CP-ScientificDiscipline: "CP-ScientificDiscipline-1"
     SO-1: "SO-1-1"
 
     select_values:

--- a/db/migrate/20190114121032_add_research_area_ref_to_project_item.rb
+++ b/db/migrate/20190114121032_add_research_area_ref_to_project_item.rb
@@ -1,0 +1,5 @@
+class AddResearchAreaRefToProjectItem < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :project_items, :research_area, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_10_111453) do
+ActiveRecord::Schema.define(version: 2019_01_14_121032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,9 +129,11 @@ ActiveRecord::Schema.define(version: 2019_01_10_111453) do
     t.string "project_website_url"
     t.string "company_name"
     t.string "company_website_url"
+    t.bigint "research_area_id"
     t.index ["affiliation_id"], name: "index_project_items_on_affiliation_id"
     t.index ["offer_id"], name: "index_project_items_on_offer_id"
     t.index ["project_id"], name: "index_project_items_on_project_id"
+    t.index ["research_area_id"], name: "index_project_items_on_research_area_id"
   end
 
   create_table "projects", force: :cascade do |t|
@@ -326,6 +328,7 @@ ActiveRecord::Schema.define(version: 2019_01_10_111453) do
   add_foreign_key "project_items", "affiliations"
   add_foreign_key "project_items", "offers"
   add_foreign_key "project_items", "projects"
+  add_foreign_key "project_items", "research_areas"
   add_foreign_key "service_providers", "providers"
   add_foreign_key "service_providers", "services"
   add_foreign_key "service_related_platforms", "platforms"

--- a/docs/jira_integration.md
+++ b/docs/jira_integration.md
@@ -5,17 +5,17 @@ to marketplace via JIRA's webhooks.
 
 ## Overview
 
-JIRA integration require configuring mapping of several key properties. This can be done via ENV variables 
+JIRA integration require configuring mapping of several key properties. This can be done via ENV variables
 (described later on). JIRA instance itself should have workflow and custom fields which corresponds to what
 application itself expects (more in *JIRA instance requirements*), at the end to make marketplace respond to
-changes in JIRA webhook should be added to JIRA instance. 
+changes in JIRA webhook should be added to JIRA instance.
 
 ## How to? Instructions for admins
 
 Here is a step by step tutorial which will teach you how to connect marketplace to JIRA, and how to check whether
 the integration works on the most rudimentary level.
 
-### JIRA instance 
+### JIRA instance
 
 JIRA instance does not require much additional configuration, apart from configuring webhook, but it must
 fulfill certain requirements described below.
@@ -29,7 +29,7 @@ Additionally new service user must be added to JIRA and have following priviledg
 * (optional) delete issue
 * (optional) delete comment
 
-Marketplace will perform all of it's operation as this user, it's credentials will have to be provided to 
+Marketplace will perform all of it's operation as this user, it's credentials will have to be provided to
 the marketplace instance.
 
 #### JIRA instance requirements
@@ -38,7 +38,7 @@ JIRA should fulfill following *workflow* and *custom fields* requirements
 
 ##### Workflow requirements
 
-**TODO** - copy from documentation 
+**TODO** - copy from documentation
 
 ##### Custom Fields requirements
 
@@ -91,7 +91,7 @@ Checking JIRA instance on https://my.jira.net:8080
 Checking connection... OK
 Checking issue type presence... FAIL
   - ERROR: It seems that ticket with id 3 does not exist, make sure to add existing issue type into configuration
-AVAILABLE ISSUE TYPES: 
+AVAILABLE ISSUE TYPES:
   - Task [id: 10100]
   - Sub-task [id: 10101]
   - Request for Change [id: 10302]
@@ -104,13 +104,13 @@ Trying to manipulate issue...
   - create issue... FAIL
     - ERROR: Could not create issue in project: EOSCSOSTAGING and issuetype: 3
   - check workflow transitions... FAIL
-    - ERROR: Could not transition from 'TODO' to 'DONE' state, this will affect open access services 
+    - ERROR: Could not transition from 'TODO' to 'DONE' state, this will affect open access services
   - update issue... FAIL
     - ERROR: Could not update issue description
   - add comment to issue... FAIL
     - ERROR: Could not post comment
   - delete issue... FAIL
-    - ERROR: Could not delete issue, reason: 405: 
+    - ERROR: Could not delete issue, reason: 405:
 Checking workflow...
   - todo [id: 1]... OK
   - in_progress [id: 2]... FAIL
@@ -134,8 +134,9 @@ Checking custom fields mappings... FAIL
     - CI-SupervisorProfile: ✕
     - CP-CustomerTypology: ✕
     - CP-ReasonForAccess: ✕
+    - CP-ScientificDiscipline: ✕
     - SO-1: ✕
-SUGGESTED MAPPINGS ...    
+SUGGESTED MAPPINGS ...
 ```
 
 This means that marketplace could connect to jira, but everything else is not configured yet. If the output says it
@@ -145,12 +146,12 @@ could not connect make sure that you configured user, password, project, and url
 
 #### Issue type
 
-First let's start with setting up issue types. As every JIRA instance can have different IDs for issue types they 
+First let's start with setting up issue types. As every JIRA instance can have different IDs for issue types they
 must be provided manually in the configuration. Marketplace required you to select 1 issue type which will be
-used for creating issues, it shows you all available issue types: 
+used for creating issues, it shows you all available issue types:
 
 ```
-AVAILABLE ISSUE TYPES: 
+AVAILABLE ISSUE TYPES:
   - Task [id: 10100]
   - Sub-task [id: 10101]
   - Request for Change [id: 10302]
@@ -173,7 +174,7 @@ Which means that that issue type has been configured correctly.
 
 #### Permissions
 
-If `jira:check` shows 
+If `jira:check` shows
 ```
 Trying to manipulate issue...
   - create issue... OK
@@ -187,7 +188,7 @@ checks fail (apart from *delete*, which is optional) you should make sure that c
 
 #### Workflow
 
-At this point you should notice, that 
+At this point you should notice, that
 
 ```
   - check workflow transitions... FAIL
@@ -208,7 +209,7 @@ Checking workflow...
 
 ```
 
-Shows that most workflow states are not correctly mapped. You should look for `AVAILABLE ISSUE STATES` 
+Shows that most workflow states are not correctly mapped. You should look for `AVAILABLE ISSUE STATES`
 (should be displayed near the end of the `jira:check` output) All issue states are listed there, make sure you choose
 issue states which are part of the workflow used by the JIRA project to which marketplace is connected!
 
@@ -273,6 +274,7 @@ Checking custom fields mappings... FAIL
     - CI-SupervisorProfile: ✕
     - CP-CustomerTypology: ✕
     - CP-ReasonForAccess: ✕
+    - CP-ScientificDiscipline: ✕
     - SO-1: ✕
 SUGGESTED MAPPINGS
   - Order reference: customfield_10254 (export MP_JIRA_FIELD_Order_reference='customfield_10254')
@@ -288,6 +290,7 @@ SUGGESTED MAPPINGS
   - CI-SupervisorProfile: customfield_10249 (export MP_JIRA_FIELD_CI_SupervisorProfile='customfield_10249')
   - CP-CustomerTypology: customfield_10250 (export MP_JIRA_FIELD_CP_CustomerTypology='customfield_10250')
   - CP-ReasonForAccess: customfield_10251 (export MP_JIRA_FIELD_CP_ReasonForAccess='customfield_10251')
+  - CP-ScientificDiscipline: customfield_10252 (export MP_JIRA_FIELD_CP_ScientificDiscipline='customfield_10252')
   - SO-1: customfield_10400 (export MP_JIRA_FIELD_SO_1='customfield_10400')
 AVAILABLE CUSTOM FIELDS
   ...
@@ -348,6 +351,7 @@ To sum up all the environmetnal variables which you need to make sure to have se
 * `MP_JIRA_FIELD_CI_SupervisorProfile`
 * `MP_JIRA_FIELD_CP_CustomerTypology`
 * `MP_JIRA_FIELD_CP_ReasonForAccess`
+* `MP_JIRA_FIELD_CP_ScientificDiscipline`
 * `MP_JIRA_FIELD_SO_1`
 * `MP_JIRA_FIELD_CI_DepartmentalWebPage`
 * `MP_JIRA_FIELD_SELECT_VALUES_CP_CustomerTypology_single_user`

--- a/spec/factories/project_items.rb
+++ b/spec/factories/project_items.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     project_website_url { "https://project_website.url" }
     company_name { |n| "company name #{n}" }
     company_website_url { "https://company_website.url" }
+    research_area
 
     properties []
 

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Service ordering" do
     scenario "I can order service" do
       offer, _seconds_offer = create_list(:offer, 2, service: service)
       affiliation = create(:affiliation, status: :active, user: user)
+      research_area = create(:research_area)
 
       visit service_path(service)
 
@@ -54,6 +55,7 @@ RSpec.feature "Service ordering" do
 
       select "Services"
       select affiliation.organization
+      select research_area.name, from: "Research area"
       select "Single user", from: "Customer typology"
       fill_in "Access reason", with: "To pass test"
       fill_in "Additional information", with: "Additional information test"
@@ -91,6 +93,7 @@ RSpec.feature "Service ordering" do
       service = create(:service, terms_of_use_url: "")
       offer, _seconds_offer = create_list(:offer, 2, service: service)
       affiliation = create(:affiliation, status: :active, user: user)
+      research_area = create(:research_area)
 
       visit service_path(service)
 
@@ -105,6 +108,7 @@ RSpec.feature "Service ordering" do
 
       select "Services"
       select affiliation.organization
+      select research_area.name, from: "Research area"
       select "Single user", from: "Customer typology"
       fill_in "Access reason", with: "To pass test"
       fill_in "Additional information", with: "Additional information test"

--- a/spec/helpers/research_area_helper_spec.rb
+++ b/spec/helpers/research_area_helper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ResearchAreasHelper, type: :helper do
+  context "#grouped_research_area" do
+    it "groups research areas" do
+      root1, root2 = create_list(:research_area, 2)
+      leaf1, leaf2 = create_list(:research_area, 2, parent: root1)
+
+      groupped = grouped_research_areas
+
+      expect(groupped[0]).to eq(["/", [root2]])
+      expect(groupped[1]).to eq(["/#{root1.name}/", [leaf1, leaf2]])
+    end
+  end
+end

--- a/spec/models/jira/client_spec.rb
+++ b/spec/models/jira/client_spec.rb
@@ -37,6 +37,7 @@ describe Jira::Client do
                           project_name: "My Secret Project",
                           project: create(:project, user: user, name: "My Secret Project"),
                           customer_typology: "single_user",
+                          research_area: create(:research_area, name: "My RA"),
                           access_reason: "some reason", properties: [
             {
                 "id": "id1",
@@ -83,6 +84,7 @@ describe Jira::Client do
                        "CP-UserGroupName-1" => "User Group Name 1",
                        "CP-ProjectInformation-1" => "My Secret Project",
                        "SO-ProjectName-1" => "My Secret Project (#{project_item.project.id})",
+                       "CP-ScientificDiscipline-1" => "My RA",
                        "SO-1-1" => "cat1/s1/off1?Data repository name=aaaaaa&" +
                                    "Harvesting method=OAI-PMH&" +
                                    "Harvesting endpoint=aaaaa" }
@@ -111,6 +113,7 @@ describe Jira::Client do
                                                                  service_type: "open_access",
                                                                  connected_url:  "http://service.org/access",
                                                                  categories: [create(:category, name: "cat1")])),
+                          research_area: nil,
                           project: create(:project, user: user, name: "My Secret Project"))
 
     expected_fields = { summary: "Service order, John Doe, s1",

--- a/spec/models/project_item_spec.rb
+++ b/spec/models/project_item_spec.rb
@@ -17,6 +17,24 @@ RSpec.describe ProjectItem do
   it { should belong_to(:offer) }
   it { should have_many(:project_item_changes).dependent(:destroy) }
 
+  context "#research_area" do
+    it "can be a leaf" do
+      leaf = create(:research_area)
+
+      expect(build(:project_item, research_area: leaf)).to be_valid
+    end
+
+    it "cannot have children" do
+      root = create(:research_area)
+      create(:research_area, parent: root)
+
+      project_item = build(:project_item, research_area: root)
+
+      expect(project_item).to_not be_valid
+      expect(project_item.errors[:research_area_id]).to_not be_empty
+    end
+  end
+
   describe "#new_change" do
     it "change is not created when no message and status is given" do
       project_item = create(:project_item)


### PR DESCRIPTION
While ordering normal service user needs to select mandatory "Research area" value (only research areas leafs can be selected). This value is shown on order summary view, on `project_item#show` and the value is sent to jira as a custom field while registering the service order.

![order-research-area](https://user-images.githubusercontent.com/1265430/51462083-06d1f600-1d60-11e9-955f-c8735d43482c.png)

![summary-research-area](https://user-images.githubusercontent.com/1265430/51462101-0afe1380-1d60-11e9-9bc6-236b383f1c95.png)

![project-item-research-area](https://user-images.githubusercontent.com/1265430/51462108-0f2a3100-1d60-11e9-912e-56dca17bbc94.png)

References #589 

After this is merged following steps are needed:
  * @wziajka needs to set following variable in the dev and prod environments: 
```
export MP_JIRA_FIELD_CP_ScientificDiscipline=10706
```
  * @goreck888 or @agpul should create research areas hierarchy and reassign services into new hierarchy.