### PR TITLE
WIP - backoffice service show

### DIFF
--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -1,70 +1,38 @@
 - breadcrumb :backoffice_service, @service
 .container
-  %h1= @service.title
-  %h2 Status
-  %p= @service.status
-  - if policy([:backoffice, @service]).publish?
-    = link_to "Publish",
-            backoffice_service_publish_path(@service),
-            method: :post,
-            data: { confirm: "Are you sure you want to publish this service?" },
-            class: "btn btn-warning"
-  - if policy([:backoffice, @service]).draft?
-    = link_to "Stop showing in the MP",
-            backoffice_service_draft_path(@service),
-            method: :post,
-            data: { confirm: "Are you sure you want to stop showing this service?" },
-            class: "btn btn-warning"
-  .row
-    .col-3
-      - if @service.logo.attached?
-        = image_tag @service.logo.variant(resize: "200x200")
-    .col-9
-      %p
-        %b= @service.tagline
-      %p= @service.description
+  = render "services/header", service: @service do
+    - if policy([:backoffice, @service]).edit?
+      = link_to "Edit",
+                edit_backoffice_service_path(@service),
+                class: "btn btn-primary"
+    - if policy([:backoffice, @service]).new?
+      = link_to "Add new offer", new_backoffice_service_offer_path(@service),
+        class: "btn btn-primary mt-2"
+    - if policy([:backoffice, @service]).destroy?
+      = link_to "Decommission",
+        backoffice_service_path(@service),
+          method: :delete, data: { confirm: "Are you sure?" },
+            class: "btn btn-danger mt-2"
 
-  %h2 Terms of use
-  = markdown(@service.terms_of_use)
+  .d-flex.my-2.mx-2
+    .flex-grow-1
+      Status:
+      %strong= @service.status
+    .d-inline
+      - if policy([:backoffice, @service]).publish?
+        = link_to "Publish",
+                backoffice_service_publish_path(@service),
+                method: :post,
+                data: { confirm: "Are you sure you want to publish this service?" },
+                class: "btn-sm btn-warning"
+      - if policy([:backoffice, @service]).draft?
+        = link_to "Stop showing in the MP",
+                backoffice_service_draft_path(@service),
+                method: :post,
+                data: { confirm: "Are you sure you want to stop showing this service?" },
+                class: "btn-sm btn-warning"
 
-  %h2 Service website
-  %p= @service.connected_url
 
-  %h2 Service type
-  %p= @service.service_type
-
-  %h2 Activate message
-  %p= @service.activate_message
-
-  %h2 Contact emails
-  - @service.contact_emails.each do |email|
-    %p= email
-
-  %h2 Areas
-  - @service.research_areas.each do |area|
-    %p= area.name
-
-  %h2 Dedicated For
-  - @service.target_groups.each do |group|
-    %p= group.name
-
-  %h2 Providers
-  - @service.providers.each do |provider|
-    %p= provider.name
-
-  %h2 Category
-  - @service.categories.each do |category|
-    %p= category.name
-
-  %h2 Offers
-  = render "backoffice/services/offers/offers", service: @service
-
-  - if policy([:backoffice, @service]).edit?
-    = link_to "Edit",
-              edit_backoffice_service_path(@service),
-              class: "btn btn-warning"
-  - if policy([:backoffice, @service]).destroy?
-    = link_to "Decommission",
-              backoffice_service_path(@service),
-              method: :delete, data: { confirm: "Are you sure?" },
-              class: "btn btn-danger"
+  .tab-content
+    = render "services/about", service: @service, offers: @service.offers
+    = render "services/tags", service: @service

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -16,11 +16,4 @@
                 (#{service.rating} /5)
               = link_to "#{service.service_opinion_count} reviews", service_opinions_path(service), class: "ml-3"
       .col-12.col-lg-3.text-center
-        - if policy(service).order?
-          = link_to t("service.#{service.service_type}.order.title"),
-                    service_offers_path(service),
-                    class: "btn btn-primary d-block mb-4"
-        - if service.open_access? || service.catalog?
-          = link_to "Go to the service", service.connected_url, class: "btn btn-primary d-block mb-4", target: "_blank"
-
-        = render "services/ask_question", service: service, question: question
+        = yield

--- a/app/views/services/_header_buttons.html.haml
+++ b/app/views/services/_header_buttons.html.haml
@@ -1,0 +1,8 @@
+- if policy(service).order?
+  = link_to t("service.#{service.service_type}.order.title"),
+            service_offers_path(service),
+            class: "btn btn-primary d-block mb-4"
+- if service.open_access? || service.catalog?
+  = link_to "Go to the service", service.connected_url, class: "btn btn-primary d-block mb-4", target: "_blank"
+
+= render "services/ask_question", service: service, question: question

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -1,6 +1,8 @@
 - breadcrumb :service, @service
 .container
-  = render "services/header", service: @service, question: @question
+  = render "services/header", service: @service do
+    = render "services/header_buttons", service: @service, question: @question
+
   = render "services/tabs", service: @service
 
 .tab-content

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -46,13 +46,13 @@ RSpec.feature "Services in backoffice" do
       fill_in "Places", with: "Europe"
       fill_in "Languages", with: "English"
       select target_group.name, from: "Dedicated For"
-      fill_in "Terms of use url", with: "https://sample.url"
-      fill_in "Access policies url", with: "https://sample.url"
-      fill_in "Corporate sla url", with: "https://sample.url"
-      fill_in "Webpage url", with: "https://sample.url"
-      fill_in "Manual url", with: "https://sample.url"
-      fill_in "Helpdesk url", with: "https://sample.url"
-      fill_in "Tutorial url", with: "https://sample.url"
+      fill_in "Terms of use url", with: "https://terms.sample.url"
+      fill_in "Access policies url", with: "https://policies.sample.url"
+      fill_in "Corporate sla url", with: "https://sla.sample.url"
+      fill_in "Webpage url", with: "https://webpage.sample.url"
+      fill_in "Manual url", with: "https://manual.sample.url"
+      fill_in "Helpdesk url", with: "https://helpdesk.sample.url"
+      fill_in "Tutorial url", with: "https://tutorial.sample.url"
       fill_in "Restrictions", with: "Reaserch affiliation needed"
       fill_in "Phase", with: "Production"
       fill_in "Activate message", with: "Welcome!!!"
@@ -74,7 +74,7 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_content("service description")
       expect(page).to have_content("service terms of use")
       expect(page).to have_content("service tagline")
-      expect(page).to have_content("https://sample.url")
+      expect(page).to have_link(href: "https://sample.url")
       expect(page).to have_content("open_access")
       expect(page).to have_content("person1@test.ok")
       expect(page).to have_content("person2@test.ok")
@@ -128,18 +128,11 @@ RSpec.feature "Services in backoffice" do
 
     scenario "I can delete offer" do
       service = create(:service, title: "my service", status: :draft)
-      offer = create(:offer, name: "offer1", description: "desc", service: service)
+      _offer = create(:offer, name: "offer1", description: "desc", service: service)
 
       visit backoffice_service_path(service)
       click_on(class: "delete-offer")
 
-      expect(page).to have_content("This service has no offers")
-    end
-
-    scenario "I can delete offer" do
-      service = create(:service, title: "my service")
-
-      visit backoffice_service_path(service)
       expect(page).to have_content("This service has no offers")
     end
 


### PR DESCRIPTION
This is WIP which requires additional work to allow show elements not visible to the normal user but important to service portfolio manager. Currently, it looks as follow:

![backoffice-service-show](https://user-images.githubusercontent.com/1265430/51476384-b53c6200-1d85-11e9-8eb9-968c53d31790.png)

It shows required buttons for edit, add new offer and publish service but it lacks of additional fields which are important to service portfolio manager and for service owner. The example: terms of use, activate message (text which is shown for open access services when an order is complete). 

@abacz please work with me on this PR to improve the layout and improve CSSes a bit (e.g. if the description and right list are not in div with `tab-content` some of the texts are yellow!!!!