### PR TITLE
[#621] Additional custom fields for voucher in jira

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add voucher support in service ordering (@michal-szostak)
 - Basic CRUD for backoffice Research areas (@mkasztelnik)
 - Basic CRUD for backoffice Categories (@mkasztelnik)
+- New custom fields for voucher in jira (@martaswiatkowska)
 
 ### Changed
 

--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -59,6 +59,9 @@ class Jira::Client < JIRA::Client
       "CP-UserGroupName": fields_config["CP-UserGroupName"],
       "CP-ProjectInformation": fields_config["CP-ProjectInformation"],
       "CP-ScientificDiscipline": fields_config["CP-ScientificDiscipline"],
+      "CP-Platforms": fields_config["CP-Platforms"],
+      "CP-INeedAVoucher": fields_config["CP-INeedAVoucher"],
+      "CP-VoucherID": fields_config["CP-VoucherID"],
       # For now only single Service Offer is supported
       "SO-ProjectName": fields_config["SO-ProjectName"],
       "SO-1": fields_config["SO-1"]
@@ -141,6 +144,12 @@ private
       project_item.project_name
     when "CP-UserGroupName"
       project_item.user_group_name
+    when "CP-Platforms"
+      project_item.offer.service.platforms.pluck(:name).join(", ")
+    when "CP-INeedAVoucher"
+      { "id" => @jira_config["custom_fields"]["select_values"]["CP-INeedAVoucher"][project_item.request_voucher] }
+    when "CP-VoucherID"
+      project_item.voucher_id || nil
     when "SO-ProjectName"
       "#{project_item.project&.name} (#{project_item.project&.id})"
     when "CP-ScientificDiscipline"

--- a/config/jira.yml
+++ b/config/jira.yml
@@ -33,6 +33,9 @@ default: &default
     CP-ProjectInformation: <%= "'" + (ENV["MP_JIRA_FIELD_CP_ProjectInformation"] || "") + "'" %>
     SO-ProjectName: <%= "'" + (ENV["MP_JIRA_FIELD_SO_ProjectName"] || "") + "'" %>
     CP-ScientificDiscipline: <%= "'" + (ENV["MP_JIRA_FIELD_CP_ScientificDiscipline"] || "") + "'" %>
+    CP-Platforms: <%= "'" + (ENV["MP_JIRA_FIELD_CP_Platforms"] || "") + "'" %>
+    CP-INeedAVoucher: <%= "'" + (ENV["MP_JIRA_FIELD_CP_INeedAVoucher"] || "") + "'" %>
+    CP-VoucherID: <%= "'" + (ENV["MP_JIRA_FIELD_CP_VoucherID"] || "") + "'" %>
     SO-1: <%= "'" + (ENV["MP_JIRA_FIELD_SO_1"] || "") + "'" %>
 
     select_values:
@@ -41,6 +44,10 @@ default: &default
         research: <%= "'" + (ENV["MP_JIRA_FIELD_SELECT_VALUES_CP_CustomerTypology_research"] || "") + "'" %>
         private_company: <%= "'" + (ENV["MP_JIRA_FIELD_SELECT_VALUES_CP_CustomerTypology_private_company"] || "") + "'" %>
         project: <%= "'" + (ENV["MP_JIRA_FIELD_SELECT_VALUES_CP_CustomerTypology_project"] || "") + "'" %>
+      CP-INeedAVoucher:
+        yes: <%= "'" + (ENV["MP_JIRA_FIELD_SELECT_VALUES_CP_INeedAVoucher_true"] || "") + "'" %>
+        no: <%= "'" + (ENV["MP_JIRA_FIELD_SELECT_VALUES_CP_INeedAVoucher_false"] || "") + "'" %>
+
 development:
   <<: *default
 
@@ -76,6 +83,10 @@ test:
     CP-ProjectInformation: "CP-ProjectInformation-1"
     SO-ProjectName: "SO-ProjectName-1"
     CP-ScientificDiscipline: "CP-ScientificDiscipline-1"
+    CP-Platforms: "CP-Platforms-1"
+    CP-INeedAVoucher: "CP-INeedAVoucher-1"
+    CP-VoucherID: "CP-VoucherID-1"
+ 
     SO-1: "SO-1-1"
 
     select_values:
@@ -83,6 +94,9 @@ test:
         single_user: '20000'
         research: '20001'
         private_company: '20002'
+      CP-INeedAVoucher:
+        yes: '20003'
+        no: '20004'
 
 production:
   <<: *default

--- a/spec/models/jira/client_spec.rb
+++ b/spec/models/jira/client_spec.rb
@@ -85,6 +85,9 @@ describe Jira::Client do
                        "CP-ProjectInformation-1" => "My Secret Project",
                        "SO-ProjectName-1" => "My Secret Project (#{project_item.project.id})",
                        "CP-ScientificDiscipline-1" => "My RA",
+                       "CP-Platforms-1" => "",
+                       "CP-INeedAVoucher-1" => { "id" => "20004" },
+                       "CP-VoucherID-1" => "",
                        "SO-1-1" => "cat1/s1/off1?Data repository name=aaaaaa&" +
                                    "Harvesting method=OAI-PMH&" +
                                    "Harvesting endpoint=aaaaa" }
@@ -125,6 +128,9 @@ describe Jira::Client do
                         "CI-Surname-1" => "Doe",
                         "CI-DisplayName-1" => "John Doe",
                         "CI-EOSC-UniqueID-1" => "uid2",
+                        "CP-Platforms-1" => "",
+                        "CP-INeedAVoucher-1" => { "id" => "20004" },
+                        "CP-VoucherID-1" => "",
                         "SO-ProjectName-1" => "My Secret Project (#{project_item.project.id})",
                         "SO-1-1" => "cat1/s1/off1?" }
 
@@ -134,4 +140,97 @@ describe Jira::Client do
 
     expect(client.create_service_issue(project_item)).to be(issue)
   end
+
+  it "create_service open access issue should save issue with correct fields" do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("ROOT_URL").and_return("https://mp.edu")
+
+    user = create(:user, first_name: "John", last_name: "Doe", uid: "uid2", affiliations: [])
+    project_item = create(:project_item,
+                          customer_typology: nil,
+                          access_reason: nil,
+                          additional_information: nil,
+                          affiliation: nil,
+                          user_group_name: nil,
+                          project_name: nil,
+                          offer: create(:offer,
+                                        name: "off1",
+                                        voucherable: true,
+                                        service: create(:service,
+                                                                 title: "s1",
+                                                                 service_type: "open_access",
+                                                                 connected_url:  "http://service.org/access",
+                                                                 categories: [create(:category, name: "cat1")])),
+                          research_area: nil,
+                          voucher_id: "123123",
+                          project: create(:project, user: user, name: "My Secret Project"))
+
+    expected_fields = { summary: "Service order, John Doe, s1",
+                        project: { key: "MP" },
+                        issuetype: { id: 10000 },
+                        "Order reference-1" => Rails.application.routes.url_helpers.project_item_url(id: project_item.id,
+                                                                                                     host: "https://mp.edu"),
+                        "CI-Name-1" => "John",
+                        "CI-Surname-1" => "Doe",
+                        "CI-DisplayName-1" => "John Doe",
+                        "CI-EOSC-UniqueID-1" => "uid2",
+                        "CP-Platforms-1" => "",
+                        "CP-INeedAVoucher-1" => { "id" => "20004" },
+                        "CP-VoucherID-1" => "123123",
+                        "SO-ProjectName-1" => "My Secret Project (#{project_item.project.id})",
+                        "SO-1-1" => "cat1/s1/off1?" }
+
+    issue = double(:Issue)
+    expect(issue).to receive("save").with(fields: expected_fields).and_return(true)
+    expect(client).to receive_message_chain("Issue.build").and_return(issue)
+
+    expect(client.create_service_issue(project_item)).to be(issue)
+  end
+
+  it "create_service open access issue should save issue with correct fields" do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("ROOT_URL").and_return("https://mp.edu")
+
+    user = create(:user, first_name: "John", last_name: "Doe", uid: "uid2", affiliations: [])
+    project_item = create(:project_item,
+                          customer_typology: nil,
+                          access_reason: nil,
+                          additional_information: nil,
+                          affiliation: nil,
+                          user_group_name: nil,
+                          project_name: nil,
+                          offer: create(:offer,
+                                        name: "off1",
+                                        voucherable: true,
+                                        service: create(:service,
+                                                                 title: "s1",
+                                                                 service_type: "open_access",
+                                                                 connected_url:  "http://service.org/access",
+                                                                 categories: [create(:category, name: "cat1")])),
+                          research_area: nil,
+                          request_voucher: true,
+                          project: create(:project, user: user, name: "My Secret Project"))
+
+    expected_fields = { summary: "Service order, John Doe, s1",
+                        project: { key: "MP" },
+                        issuetype: { id: 10000 },
+                        "Order reference-1" => Rails.application.routes.url_helpers.project_item_url(id: project_item.id,
+                                                                                                     host: "https://mp.edu"),
+                        "CI-Name-1" => "John",
+                        "CI-Surname-1" => "Doe",
+                        "CI-DisplayName-1" => "John Doe",
+                        "CI-EOSC-UniqueID-1" => "uid2",
+                        "CP-Platforms-1" => "",
+                        "CP-INeedAVoucher-1" => { "id" => "20003" },
+                        "CP-VoucherID-1" => "",
+                        "SO-ProjectName-1" => "My Secret Project (#{project_item.project.id})",
+                        "SO-1-1" => "cat1/s1/off1?" }
+
+    issue = double(:Issue)
+    expect(issue).to receive("save").with(fields: expected_fields).and_return(true)
+    expect(client).to receive_message_chain("Issue.build").and_return(issue)
+
+    expect(client.create_service_issue(project_item)).to be(issue)
+  end
+
 end


### PR DESCRIPTION
Tree additional fields for voucher added to jira 
    CP-Platforms (string, optional)
    CP-INeedAVoucher (boolean, optional)
    CP-VoucherID (string, optional)

Fix #621 