### PR TITLE
Research areas and Categories backoffice crud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - User needs to select "Research area" while ordering service (@mkasztelnik)
 - Add voucher support in service ordering (@michal-szostak)
 - Basic CRUD for backoffice Research areas (@mkasztelnik)
+- Basic CRUD for backoffice Categories (@mkasztelnik)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 - User needs to select "Research area" while ordering service (@mkasztelnik)
 - Add voucher support in service ordering (@michal-szostak)
+- Basic CRUD for backoffice Research areas (@mkasztelnik)
 
 ### Changed
 

--- a/app/controllers/backoffice/categories_controller.rb
+++ b/app/controllers/backoffice/categories_controller.rb
@@ -5,7 +5,7 @@ class Backoffice::CategoriesController < Backoffice::ApplicationController
 
   def index
     authorize(Category)
-    @categories = policy_scope(Category).page(params[:page])
+    @categories = policy_scope(Category)
   end
 
   def show

--- a/app/controllers/backoffice/categories_controller.rb
+++ b/app/controllers/backoffice/categories_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Backoffice::CategoriesController < Backoffice::ApplicationController
+  before_action :find_and_authorize, only: [:show, :edit, :update, :destroy]
+
+  def index
+    authorize(Category)
+    @categories = policy_scope(Category).page(params[:page])
+  end
+
+  def show
+  end
+
+  def new
+    @category = Category.new
+    authorize(@category)
+  end
+
+  def create
+    @category = Category.new(permitted_attributes(Category))
+    authorize(@category)
+
+    if @category.save
+      redirect_to backoffice_category_path(@category),
+                  notice: "New category created sucessfully"
+    else
+      render :new, status: :bad_request
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @category.update(permitted_attributes(@category))
+      redirect_to backoffice_category_path(@category),
+                  notice: "Category updated correctly"
+    else
+      render :edit, status: :bad_request
+    end
+  end
+
+  def destroy
+    @category.destroy!
+    redirect_to backoffice_categories_path,
+                notice: "Category destroyed"
+  end
+
+  private
+    def find_and_authorize
+      @category = Category.friendly.find(params[:id])
+      authorize(@category)
+    end
+end

--- a/app/controllers/backoffice/research_areas_controller.rb
+++ b/app/controllers/backoffice/research_areas_controller.rb
@@ -5,7 +5,7 @@ class Backoffice::ResearchAreasController < Backoffice::ApplicationController
 
   def index
     authorize(ResearchArea)
-    @research_areas = policy_scope(ResearchArea).page(params[:page])
+    @research_areas = policy_scope(ResearchArea)
   end
 
   def show

--- a/app/controllers/backoffice/research_areas_controller.rb
+++ b/app/controllers/backoffice/research_areas_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Backoffice::ResearchAreasController < Backoffice::ApplicationController
+  before_action :find_and_authorize, only: [:show, :edit, :update, :destroy]
+
+  def index
+    authorize(ResearchArea)
+    @research_areas = policy_scope(ResearchArea).page(params[:page])
+  end
+
+  def show
+  end
+
+  def new
+    @research_area = ResearchArea.new
+    authorize(@research_area)
+  end
+
+  def create
+    @research_area = ResearchArea.new(permitted_attributes(ResearchArea))
+    authorize(@research_area)
+
+    if @research_area.save
+      redirect_to backoffice_research_area_path(@research_area),
+                  notice: "New research_area created sucessfully"
+    else
+      render :new, status: :bad_request
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @research_area.update(permitted_attributes(@research_area))
+      redirect_to backoffice_research_area_path(@research_area),
+                  notice: "Research area updated correctly"
+    else
+      render :edit, status: :bad_request
+    end
+  end
+
+  def destroy
+    @research_area.destroy!
+    redirect_to backoffice_research_areas_path,
+                notice: "Research area destroyed"
+  end
+
+  private
+    def find_and_authorize
+      @research_area = ResearchArea.find(params[:id])
+      authorize(@research_area)
+    end
+end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -108,18 +108,8 @@ module Service::Searchable
       end
     end
 
-    def research_areas_tree(research_areas, parent, level)
-      research_areas.
-          select { |ra| ra.ancestry_depth == level && ra.child_of?(parent) }.
-          map do |ra|
-        [[indented_name(ra.name, level), ra.id],
-         *research_areas_tree(research_areas, ra, level + 1)]
-      end.
-          flatten(1)
-    end
-
     def options_research_area
-      research_areas_tree(ResearchArea.all, ResearchArea.new, 0)
+      ResearchArea.all
     end
 
     def filter_tag(services, tags)
@@ -140,11 +130,6 @@ module Service::Searchable
   include FieldFilterable
 
 private
-
-  def indented_name(name, level)
-    indentation = "&nbsp;&nbsp;" * level
-    "#{indentation}#{ERB::Util.html_escape(name)}".html_safe
-  end
 
   def records
     active_searchable_fields.

--- a/app/helpers/ancestry_helper.rb
+++ b/app/helpers/ancestry_helper.rb
@@ -6,12 +6,16 @@ module AncestryHelper
     first ? create_ancestry_tree(records, first.class.new, 0) : []
   end
 
+  def ancestry_id_tree(records)
+    ancestry_tree(records).map { |r| [r.first, r.last.id] }
+  end
+
   private
 
     def create_ancestry_tree(records, parent, level)
       records.select { |r| r.ancestry_depth == level && r.child_of?(parent) }.
               map do |r|
-                [[indented_name(r.name, level), r.id],
+                [[indented_name(r.name, level), r],
                  *create_ancestry_tree(records, r, level + 1)]
               end.
               flatten(1)

--- a/app/helpers/ancestry_helper.rb
+++ b/app/helpers/ancestry_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AncestryHelper
+  def ancestry_tree(records)
+    first = records.first
+    first ? create_ancestry_tree(records, first.class.new, 0) : []
+  end
+
+  private
+
+    def create_ancestry_tree(records, parent, level)
+      records.select { |r| r.ancestry_depth == level && r.child_of?(parent) }.
+              map do |r|
+                [[indented_name(r.name, level), r.id],
+                 *create_ancestry_tree(records, r, level + 1)]
+              end.
+              flatten(1)
+    end
+
+    def indented_name(name, level)
+      indentation = "&nbsp;&nbsp;" * level
+      "#{indentation}#{ERB::Util.html_escape(name)}".html_safe
+    end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,11 @@ module ApplicationHelper
   def current_action?(*args)
     args.any? { |v| v.to_s.downcase == action_name }
   end
+
+  def back_link_to(title, record, options = {})
+    prefix = options.delete(:prefix)
+    to_obj = record.persisted? ? record : record.class
+    to = prefix ? [prefix, to_obj] : to_obj
+    link_to(title, to, options)
+  end
 end

--- a/app/helpers/research_areas_helper.rb
+++ b/app/helpers/research_areas_helper.rb
@@ -14,10 +14,6 @@ module ResearchAreasHelper
     end.map { |k, v| [k, v] }.sort { |v1, v2| v1.first <=> v2.first }
   end
 
-  def research_areas_tree(research_areas)
-    create_research_areas_tree(research_areas, ResearchArea.new, 0)
-  end
-
   private
 
     def group_research_areas!(result, current_path, key, values)
@@ -28,20 +24,5 @@ module ResearchAreasHelper
       else
         result << [current_path, key]
       end
-    end
-
-    def create_research_areas_tree(research_areas, parent, level)
-      research_areas.
-          select { |ra| ra.ancestry_depth == level && ra.child_of?(parent) }.
-          map do |ra|
-        [[indented_name(ra.name, level), ra.id],
-          *create_research_areas_tree(research_areas, ra, level + 1)]
-      end.
-          flatten(1)
-    end
-
-    def indented_name(name, level)
-      indentation = "&nbsp;&nbsp;" * level
-      "#{indentation}#{ERB::Util.html_escape(name)}".html_safe
     end
 end

--- a/app/helpers/research_areas_helper.rb
+++ b/app/helpers/research_areas_helper.rb
@@ -14,6 +14,10 @@ module ResearchAreasHelper
     end.map { |k, v| [k, v] }.sort { |v1, v2| v1.first <=> v2.first }
   end
 
+  def research_areas_tree(research_areas)
+    create_research_areas_tree(research_areas, ResearchArea.new, 0)
+  end
+
   private
 
     def group_research_areas!(result, current_path, key, values)
@@ -24,5 +28,20 @@ module ResearchAreasHelper
       else
         result << [current_path, key]
       end
+    end
+
+    def create_research_areas_tree(research_areas, parent, level)
+      research_areas.
+          select { |ra| ra.ancestry_depth == level && ra.child_of?(parent) }.
+          map do |ra|
+        [[indented_name(ra.name, level), ra.id],
+          *create_research_areas_tree(research_areas, ra, level + 1)]
+      end.
+          flatten(1)
+    end
+
+    def indented_name(name, level)
+      indentation = "&nbsp;&nbsp;" * level
+      "#{indentation}#{ERB::Util.html_escape(name)}".html_safe
     end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,8 +4,7 @@ class Category < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :slugged
 
-
-  has_ancestry
+  include Parentable
 
   # This callback need to be defined byfore dependent: :destroy
   # relation, because in this case project_item matter. This callback need to be

--- a/app/models/concerns/parentable.rb
+++ b/app/models/concerns/parentable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Parentable
+  extend ActiveSupport::Concern
+
+  included do
+    has_ancestry cache_depth: true
+  end
+
+  def potential_parents
+    persisted? ? self.class.where.not(id: descendant_ids + [id]) : self.class.all
+  end
+end

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 class ResearchArea < ApplicationRecord
-  has_ancestry cache_depth: true
+  include Parentable
 
   has_many :service_research_areas, autosave: true, dependent: :destroy
   has_many :services, through: :service_research_areas
   has_many :project_items, dependent: :restrict_with_exception
 
   validates :name, presence: true
-
-  def potential_parents
-    persisted? ? ResearchArea.where.not(id: descendant_ids + [id]) : ResearchArea.all
-  end
 end

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -8,4 +8,8 @@ class ResearchArea < ApplicationRecord
   has_many :project_items, dependent: :restrict_with_exception
 
   validates :name, presence: true
+
+  def potential_parents
+    persisted? ? ResearchArea.where.not(id: descendant_ids + [id]) : ResearchArea.all
+  end
 end

--- a/app/policies/backoffice/category_policy.rb
+++ b/app/policies/backoffice/category_policy.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Backoffice::CategoryPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+
+  def index?
+    service_portfolio_manager?
+  end
+
+  def show?
+    service_portfolio_manager?
+  end
+
+  def new?
+    service_portfolio_manager?
+  end
+
+  def create?
+    service_portfolio_manager?
+  end
+
+  def update?
+    service_portfolio_manager?
+  end
+
+  def destroy?
+    service_portfolio_manager?
+  end
+
+  def permitted_attributes
+    [
+      :name, :parent_id
+    ]
+  end
+
+  private
+
+    def service_portfolio_manager?
+      user.service_portfolio_manager?
+    end
+end

--- a/app/policies/backoffice/research_area_policy.rb
+++ b/app/policies/backoffice/research_area_policy.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Backoffice::ResearchAreaPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+
+  def index?
+    service_portfolio_manager?
+  end
+
+  def show?
+    service_portfolio_manager?
+  end
+
+  def new?
+    service_portfolio_manager?
+  end
+
+  def create?
+    service_portfolio_manager?
+  end
+
+  def update?
+    service_portfolio_manager?
+  end
+
+  def destroy?
+    service_portfolio_manager?
+  end
+
+  def permitted_attributes
+    [
+      :name, :parent_id
+    ]
+  end
+
+  private
+
+    def service_portfolio_manager?
+      user.service_portfolio_manager?
+    end
+end

--- a/app/views/backoffice/categories/_category.html.haml
+++ b/app/views/backoffice/categories/_category.html.haml
@@ -1,0 +1,1 @@
+%li= link_to category.name, backoffice_category_path(category)

--- a/app/views/backoffice/categories/_category.html.haml
+++ b/app/views/backoffice/categories/_category.html.haml
@@ -1,1 +1,0 @@
-%li= link_to category.name, backoffice_category_path(category)

--- a/app/views/backoffice/categories/_form.html.haml
+++ b/app/views/backoffice/categories/_form.html.haml
@@ -1,13 +1,13 @@
-= simple_form_for [:backoffice, research_area] do |f|
+= simple_form_for [:backoffice, category] do |f|
   = f.input :name
   = f.input :parent_id,
-    collection: ancestry_tree(research_area.potential_parents),
+    collection: ancestry_tree(category.potential_parents),
     label_method: :first, value_method: :last, as: :select, include_blank: true
 
 
   .btn-group
     = f.button :submit, class: "btn btn-success"
     :ruby
-      path = research_area.persisted? && backoffice_research_area_path(research_area) ||
-             backoffice_research_areas_path
+      path = category.persisted? && backoffice_category_path(category) ||
+             backoffice_categories_path
     = link_to "Cancel", path, class: "btn btn-secondary"

--- a/app/views/backoffice/categories/_form.html.haml
+++ b/app/views/backoffice/categories/_form.html.haml
@@ -1,7 +1,7 @@
 = simple_form_for [:backoffice, category] do |f|
   = f.input :name
   = f.input :parent_id,
-    collection: ancestry_tree(category.potential_parents),
+    collection: ancestry_id_tree(category.potential_parents),
     label_method: :first, value_method: :last, as: :select, include_blank: true
 
 

--- a/app/views/backoffice/categories/_form.html.haml
+++ b/app/views/backoffice/categories/_form.html.haml
@@ -7,7 +7,4 @@
 
   .btn-group
     = f.button :submit, class: "btn btn-success"
-    :ruby
-      path = category.persisted? && backoffice_category_path(category) ||
-             backoffice_categories_path
-    = link_to "Cancel", path, class: "btn btn-secondary"
+    = back_link_to "Cancel", category, prefix: :backoffice, class: "btn btn-secondary"

--- a/app/views/backoffice/categories/edit.html.haml
+++ b/app/views/backoffice/categories/edit.html.haml
@@ -1,0 +1,4 @@
+- breadcrumb :backoffice_category_edit, @category
+
+%h2 Edit Category
+= render "form", category: @category

--- a/app/views/backoffice/categories/index.html.haml
+++ b/app/views/backoffice/categories/index.html.haml
@@ -1,0 +1,14 @@
+- breadcrumb :backoffice_categories
+.container
+  %h1
+    Categories
+    - if policy([:backoffice, Category]).new?
+      .float-right
+        = link_to "New Category",
+                  new_backoffice_category_path,
+                  class: "btn btn-success"
+      .clearfix
+  %hr/
+  %ul
+    = render @categories
+  = will_paginate @categories

--- a/app/views/backoffice/categories/index.html.haml
+++ b/app/views/backoffice/categories/index.html.haml
@@ -10,5 +10,5 @@
       .clearfix
   %hr/
   %ul
-    = render @categories
-  = will_paginate @categories
+    - ancestry_tree(@categories).each do |record|
+      %li= link_to record.first, backoffice_category_path(record.last)

--- a/app/views/backoffice/categories/new.html.haml
+++ b/app/views/backoffice/categories/new.html.haml
@@ -1,0 +1,4 @@
+- breadcrumb :backoffice_category_new, @category
+
+%h2 New Category
+= render "form", category: @category

--- a/app/views/backoffice/categories/show.html.haml
+++ b/app/views/backoffice/categories/show.html.haml
@@ -1,0 +1,16 @@
+- breadcrumb :backoffice_category, @category
+
+%h1= @category.name
+%h2= @category.parent ? "Parent: #{@category.parent.name}" : "Root element"
+
+.btn-group
+  - if policy([:backoffice, @category]).edit?
+    = link_to "Edit",
+              edit_backoffice_category_path(@category),
+              class: "btn btn-warning"
+  - if policy([:backoffice, @category]).destroy?
+    = link_to "Delete",
+              backoffice_category_path(@category),
+              method: :delete,
+              data: { confirm: "Are you sure you want to remove this category" },
+              class: "btn btn-danger"

--- a/app/views/backoffice/research_areas/_form.html.haml
+++ b/app/views/backoffice/research_areas/_form.html.haml
@@ -1,0 +1,13 @@
+= simple_form_for [:backoffice, research_area] do |f|
+  = f.input :name
+  = f.input :parent_id,
+    collection: research_areas_tree(research_area.potential_parents),
+    label_method: :first, value_method: :last, as: :select, include_blank: true
+
+
+  .btn-group
+    = f.button :submit, class: "btn btn-success"
+    :ruby
+      path = research_area.persisted? && backoffice_research_area_path(research_area) ||
+             backoffice_research_areas_path
+    = link_to "Cancel", path, class: "btn btn-secondary"

--- a/app/views/backoffice/research_areas/_form.html.haml
+++ b/app/views/backoffice/research_areas/_form.html.haml
@@ -1,7 +1,7 @@
 = simple_form_for [:backoffice, research_area] do |f|
   = f.input :name
   = f.input :parent_id,
-    collection: ancestry_tree(research_area.potential_parents),
+    collection: ancestry_id_tree(research_area.potential_parents),
     label_method: :first, value_method: :last, as: :select, include_blank: true
 
 

--- a/app/views/backoffice/research_areas/_form.html.haml
+++ b/app/views/backoffice/research_areas/_form.html.haml
@@ -7,7 +7,4 @@
 
   .btn-group
     = f.button :submit, class: "btn btn-success"
-    :ruby
-      path = research_area.persisted? && backoffice_research_area_path(research_area) ||
-             backoffice_research_areas_path
-    = link_to "Cancel", path, class: "btn btn-secondary"
+    = back_link_to "Cancel", research_area, prefix: :backoffice, class: "btn btn-secondary"

--- a/app/views/backoffice/research_areas/_research_area.html.haml
+++ b/app/views/backoffice/research_areas/_research_area.html.haml
@@ -1,0 +1,1 @@
+%li= link_to research_area.name, backoffice_research_area_path(research_area)

--- a/app/views/backoffice/research_areas/_research_area.html.haml
+++ b/app/views/backoffice/research_areas/_research_area.html.haml
@@ -1,1 +1,0 @@
-%li= link_to research_area.name, backoffice_research_area_path(research_area)

--- a/app/views/backoffice/research_areas/edit.html.haml
+++ b/app/views/backoffice/research_areas/edit.html.haml
@@ -1,0 +1,4 @@
+- breadcrumb :backoffice_research_area_edit, @research_area
+
+%h2 Edit Research Area
+= render "form", research_area: @research_area

--- a/app/views/backoffice/research_areas/index.html.haml
+++ b/app/views/backoffice/research_areas/index.html.haml
@@ -1,0 +1,14 @@
+- breadcrumb :backoffice_research_areas
+.container
+  %h1
+    Research Areas
+    - if policy([:backoffice, ResearchArea]).new?
+      .float-right
+        = link_to "New Research Area",
+                  new_backoffice_research_area_path,
+                  class: "btn btn-success"
+      .clearfix
+  %hr/
+  %ul
+    = render @research_areas
+  = will_paginate @research_areas

--- a/app/views/backoffice/research_areas/index.html.haml
+++ b/app/views/backoffice/research_areas/index.html.haml
@@ -10,5 +10,5 @@
       .clearfix
   %hr/
   %ul
-    = render @research_areas
-  = will_paginate @research_areas
+    - ancestry_tree(@research_areas).each do |record|
+      %li= link_to record.first, backoffice_research_area_path(record.last)

--- a/app/views/backoffice/research_areas/new.html.haml
+++ b/app/views/backoffice/research_areas/new.html.haml
@@ -1,0 +1,4 @@
+- breadcrumb :backoffice_research_area_new, @research_area
+
+%h2 New Research Area
+= render "form", research_area: @research_area

--- a/app/views/backoffice/research_areas/show.html.haml
+++ b/app/views/backoffice/research_areas/show.html.haml
@@ -1,0 +1,16 @@
+- breadcrumb :backoffice_research_area, @research_area
+
+%h1= @research_area.name
+%h2= @research_area.parent ? "Parent: #{@research_area.parent.name}" : "Root element"
+
+.btn-group
+  - if policy([:backoffice, @research_area]).edit?
+    = link_to "Edit",
+              edit_backoffice_research_area_path(@research_area),
+              class: "btn btn-warning"
+  - if policy([:backoffice, @research_area]).destroy?
+    = link_to "Delete",
+              backoffice_research_area_path(@research_area),
+              method: :delete,
+              data: { confirm: "Are you sure you want to remove this research area?" },
+              class: "btn btn-danger"

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -36,8 +36,7 @@
 
   .btn-group
     = f.button :submit, class: "btn btn-success"
-    - path = service.persisted? ? backoffice_service_path(service) : backoffice_services_path
-    = link_to "Cancel", path, class: "btn btn-secondary"
+    = back_link_to "Cancel", service, prefix: :backoffice, class: "btn btn-secondary"
 
 :javascript
   $(document).ready(function() {

--- a/app/views/layouts/backoffice/_navbar.html.haml
+++ b/app/views/layouts/backoffice/_navbar.html.haml
@@ -17,6 +17,9 @@
           = link_to "Getting Started", backoffice_path, class: "nav-link px-3 py-1"
         = nav_link controller: :services, html_options: { class: "nav-item" } do
           = link_to "Owned Services", backoffice_services_path, class: "nav-link px-3 py-1"
+        - if policy([:backoffice, ResearchArea]).index?
+          = nav_link controller: :research_areas, html_options: { class: "nav-item" } do
+            = link_to "Research Areas", backoffice_research_areas_path, class: "nav-link px-3 py-1"
         %li.nav-item
           = link_to "Logout", destroy_user_session_path, method: :delete, class: "nav-link px-3 py-1"
 

--- a/app/views/layouts/backoffice/_navbar.html.haml
+++ b/app/views/layouts/backoffice/_navbar.html.haml
@@ -20,6 +20,9 @@
         - if policy([:backoffice, ResearchArea]).index?
           = nav_link controller: :research_areas, html_options: { class: "nav-item" } do
             = link_to "Research Areas", backoffice_research_areas_path, class: "nav-link px-3 py-1"
+        - if policy([:backoffice, Category]).index?
+          = nav_link controller: :categories, html_options: { class: "nav-item" } do
+            = link_to "Categories", backoffice_categories_path, class: "nav-link px-3 py-1"
         %li.nav-item
           = link_to "Logout", destroy_user_session_path, method: :delete, class: "nav-link px-3 py-1"
 

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -50,7 +50,7 @@
         %select#research-area.form-control.form-control-sm{ name: "research_area" }
           %option{ value: "", selected: "selected" }
             Any
-          = options_for_select(ancestry_tree(research_areas), params[:research_area])
+          = options_for_select(ancestry_id_tree(research_areas), params[:research_area])
   .row
     .col-md-12
       %button#filter-submit.btn.btn-primary.mt-4.w-100{ type: "submit" }

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -50,7 +50,7 @@
         %select#research-area.form-control.form-control-sm{ name: "research_area" }
           %option{ value: "", selected: "selected" }
             Any
-          = options_for_select(research_areas_tree(research_areas), params[:research_area])
+          = options_for_select(ancestry_tree(research_areas), params[:research_area])
   .row
     .col-md-12
       %button#filter-submit.btn.btn-primary.mt-4.w-100{ type: "submit" }

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -50,7 +50,7 @@
         %select#research-area.form-control.form-control-sm{ name: "research_area" }
           %option{ value: "", selected: "selected" }
             Any
-          = options_for_select(research_areas, params[:research_area])
+          = options_for_select(research_areas_tree(research_areas), params[:research_area])
   .row
     .col-md-12
       %button#filter-submit.btn.btn-primary.mt-4.w-100{ type: "submit" }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -20,6 +20,25 @@
       "note": ""
     },
     {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "5b32fc9858a0588687f0fa6a4b12f5cdf1b34c535157b765fdb5cbe1a83a1bd8",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/backoffice/categories/index.html.haml",
+      "line": 13,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => policy_scope(Category).page(params[:page]), {})",
+      "render_path": [{"type":"controller","class":"Backoffice::CategoriesController","method":"index","line":9,"file":"app/controllers/backoffice/categories_controller.rb","rendered":{"name":"backoffice/categories/index","file":"/home/marek/git/mp/app/views/backoffice/categories/index.html.haml"}}],
+      "location": {
+        "type": "template",
+        "template": "backoffice/categories/index"
+      },
+      "user_input": "params[:page]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "70e7b861d074bffcc48c1852503c02b1d81412d166341e23e4306071c465ddc8",
@@ -154,6 +173,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-01-22 19:50:20 +0100",
+  "updated": "2019-01-22 21:50:06 +0100",
   "brakeman_version": "4.4.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -20,25 +20,6 @@
       "note": ""
     },
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "5b32fc9858a0588687f0fa6a4b12f5cdf1b34c535157b765fdb5cbe1a83a1bd8",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/backoffice/categories/index.html.haml",
-      "line": 13,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => policy_scope(Category).page(params[:page]), {})",
-      "render_path": [{"type":"controller","class":"Backoffice::CategoriesController","method":"index","line":9,"file":"app/controllers/backoffice/categories_controller.rb","rendered":{"name":"backoffice/categories/index","file":"/home/marek/git/mp/app/views/backoffice/categories/index.html.haml"}}],
-      "location": {
-        "type": "template",
-        "template": "backoffice/categories/index"
-      },
-      "user_input": "params[:page]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "70e7b861d074bffcc48c1852503c02b1d81412d166341e23e4306071c465ddc8",
@@ -116,25 +97,6 @@
       "note": ""
     },
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "bf2846b86313d3af3fe09771e32d855f647c5cf28f745a9325a80555219d1921",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/backoffice/research_areas/index.html.haml",
-      "line": 13,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => policy_scope(ResearchArea).page(params[:page]), {})",
-      "render_path": [{"type":"controller","class":"Backoffice::ResearchAreasController","method":"index","line":9,"file":"app/controllers/backoffice/research_areas_controller.rb","rendered":{"name":"backoffice/research_areas/index","file":"/home/marek/git/mp/app/views/backoffice/research_areas/index.html.haml"}}],
-      "location": {
-        "type": "template",
-        "template": "backoffice/research_areas/index"
-      },
-      "user_input": "params[:page]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "df67224e8f04c8de98b6fb0f2df04ed86e92a1dda97ac0d20b950f4a0235b7ea",
@@ -173,6 +135,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-01-22 21:50:06 +0100",
+  "updated": "2019-01-22 23:27:19 +0100",
   "brakeman_version": "4.4.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,10 +7,10 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/projects/index.html.haml",
-      "line": 12,
+      "line": 15,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => policy_scope(Project).order(:name).eager_load(:project_items).where(\"project_items.status = ?\", params[:status]), {})",
-      "render_path": [{"type":"controller","class":"ProjectsController","method":"index","line":9,"file":"app/controllers/projects_controller.rb"}],
+      "render_path": [{"type":"controller","class":"ProjectsController","method":"index","line":9,"file":"app/controllers/projects_controller.rb","rendered":{"name":"projects/index","file":"/home/marek/git/mp/app/views/projects/index.html.haml"}}],
       "location": {
         "type": "template",
         "template": "projects/index"
@@ -29,7 +29,7 @@
       "line": 14,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
-      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":18,"file":"app/controllers/categories_controller.rb"},{"type":"template","name":"categories/show","line":2,"file":"app/views/categories/show.html.haml"},{"type":"template","name":"services/_index","line":29,"file":"app/views/services/_index.html.haml"}],
+      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":21,"file":"app/controllers/categories_controller.rb","rendered":{"name":"categories/show","file":"/home/marek/git/mp/app/views/categories/show.html.haml"}},{"type":"template","name":"categories/show","line":2,"file":"app/views/categories/show.html.haml","rendered":{"name":"services/_index","file":"/home/marek/git/mp/app/views/services/_index.html.haml"}},{"type":"template","name":"services/_index","line":33,"file":"app/views/services/_index.html.haml","rendered":{"name":"services/_paginate","file":"/home/marek/git/mp/app/views/services/_paginate.haml"}}],
       "location": {
         "type": "template",
         "template": "services/_paginate"
@@ -45,10 +45,10 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/backoffice/services/index.html.haml",
-      "line": 11,
+      "line": 12,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => policy_scope(Service).page(params[:page]), {})",
-      "render_path": [{"type":"controller","class":"Backoffice::ServicesController","method":"index","line":9,"file":"app/controllers/backoffice/services_controller.rb"}],
+      "render_path": [{"type":"controller","class":"Backoffice::ServicesController","method":"index","line":9,"file":"app/controllers/backoffice/services_controller.rb","rendered":{"name":"backoffice/services/index","file":"/home/marek/git/mp/app/views/backoffice/services/index.html.haml"}}],
       "location": {
         "type": "template",
         "template": "backoffice/services/index"
@@ -82,17 +82,36 @@
       "warning_code": 4,
       "fingerprint": "b5f47c5cc63d05149ec53c573da4a042d39fcbd89b8925bd371cc4340b80bfd5",
       "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
+      "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/profiles/affiliations/_affiliation.html.haml",
-      "line": 46,
+      "line": 48,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to((Unresolved Model).new.webpage, (Unresolved Model).new.webpage)",
-      "render_path": [{"type":"template","name":"profiles/affiliations/_index","line":3,"file":"app/views/profiles/affiliations/_index.html.haml"}],
+      "render_path": [{"type":"template","name":"profiles/affiliations/_index","line":3,"file":"app/views/profiles/affiliations/_index.html.haml","rendered":{"name":"profiles/affiliations/_affiliation","file":"/home/marek/git/mp/app/views/profiles/affiliations/_affiliation.html.haml"}}],
       "location": {
         "type": "template",
         "template": "profiles/affiliations/_affiliation"
       },
       "user_input": "(Unresolved Model).new.webpage",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "bf2846b86313d3af3fe09771e32d855f647c5cf28f745a9325a80555219d1921",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/backoffice/research_areas/index.html.haml",
+      "line": 13,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => policy_scope(ResearchArea).page(params[:page]), {})",
+      "render_path": [{"type":"controller","class":"Backoffice::ResearchAreasController","method":"index","line":9,"file":"app/controllers/backoffice/research_areas_controller.rb","rendered":{"name":"backoffice/research_areas/index","file":"/home/marek/git/mp/app/views/backoffice/research_areas/index.html.haml"}}],
+      "location": {
+        "type": "template",
+        "template": "backoffice/research_areas/index"
+      },
+      "user_input": "params[:page]",
       "confidence": "Weak",
       "note": ""
     },
@@ -106,7 +125,7 @@
       "line": 11,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
-      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":18,"file":"app/controllers/categories_controller.rb"},{"type":"template","name":"categories/show","line":2,"file":"app/views/categories/show.html.haml"},{"type":"template","name":"services/_index","line":29,"file":"app/views/services/_index.html.haml"}],
+      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":21,"file":"app/controllers/categories_controller.rb","rendered":{"name":"categories/show","file":"/home/marek/git/mp/app/views/categories/show.html.haml"}},{"type":"template","name":"categories/show","line":2,"file":"app/views/categories/show.html.haml","rendered":{"name":"services/_index","file":"/home/marek/git/mp/app/views/services/_index.html.haml"}},{"type":"template","name":"services/_index","line":33,"file":"app/views/services/_index.html.haml","rendered":{"name":"services/_paginate","file":"/home/marek/git/mp/app/views/services/_paginate.haml"}}],
       "location": {
         "type": "template",
         "template": "services/_paginate"
@@ -125,7 +144,7 @@
       "line": 9,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
-      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":18,"file":"app/controllers/categories_controller.rb"},{"type":"template","name":"categories/show","line":2,"file":"app/views/categories/show.html.haml"},{"type":"template","name":"services/_index","line":29,"file":"app/views/services/_index.html.haml"}],
+      "render_path": [{"type":"controller","class":"CategoriesController","method":"show","line":21,"file":"app/controllers/categories_controller.rb","rendered":{"name":"categories/show","file":"/home/marek/git/mp/app/views/categories/show.html.haml"}},{"type":"template","name":"categories/show","line":2,"file":"app/views/categories/show.html.haml","rendered":{"name":"services/_index","file":"/home/marek/git/mp/app/views/services/_index.html.haml"}},{"type":"template","name":"services/_index","line":33,"file":"app/views/services/_index.html.haml","rendered":{"name":"services/_paginate","file":"/home/marek/git/mp/app/views/services/_paginate.haml"}}],
       "location": {
         "type": "template",
         "template": "services/_paginate"
@@ -135,6 +154,6 @@
       "note": ""
     }
   ],
-  "updated": "2018-11-14 09:44:47 +0100",
-  "brakeman_version": "4.3.1"
+  "updated": "2019-01-22 19:50:20 +0100",
+  "brakeman_version": "4.4.0"
 }

--- a/config/breadcrumbs/backoffice.rb
+++ b/config/breadcrumbs/backoffice.rb
@@ -23,3 +23,23 @@ crumb :backoffice_service_edit do |service|
   link "Edit", edit_backoffice_service_path(service)
   parent :backoffice_service, service
 end
+
+crumb :backoffice_research_areas do
+  link "Research Areas", backoffice_research_areas_path
+  parent :backoffice_root
+end
+
+crumb :backoffice_research_area do |research_area|
+  link research_area.name, backoffice_research_area_path(research_area)
+  parent :backoffice_research_areas
+end
+
+crumb :backoffice_research_area_new do |research_area|
+  link research_area.name, new_backoffice_research_area_path(research_area)
+  parent :backoffice_research_areas
+end
+
+crumb :backoffice_research_area_edit do |research_area|
+  link research_area.name, edit_backoffice_research_area_path(research_area)
+  parent :backoffice_research_areas
+end

--- a/config/breadcrumbs/backoffice.rb
+++ b/config/breadcrumbs/backoffice.rb
@@ -35,11 +35,31 @@ crumb :backoffice_research_area do |research_area|
 end
 
 crumb :backoffice_research_area_new do |research_area|
-  link research_area.name, new_backoffice_research_area_path(research_area)
+  link "New", new_backoffice_research_area_path(research_area)
   parent :backoffice_research_areas
 end
 
 crumb :backoffice_research_area_edit do |research_area|
-  link research_area.name, edit_backoffice_research_area_path(research_area)
-  parent :backoffice_research_areas
+  link "Edit", edit_backoffice_research_area_path(research_area)
+  parent :backoffice_research_area, research_area
+end
+
+crumb :backoffice_categories do
+  link "Categories", backoffice_categories_path
+  parent :backoffice_root
+end
+
+crumb :backoffice_category do |category|
+  link category.name, backoffice_category_path(category)
+  parent :backoffice_categories
+end
+
+crumb :backoffice_category_new do |category|
+  link "New", new_backoffice_category_path(category)
+  parent :backoffice_categories
+end
+
+crumb :backoffice_category_edit do |category|
+  link "Edit", edit_backoffice_category_path(category)
+  parent :backoffice_category, category
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
         resource :draft, only: :create
       end
     end
+    resources :research_areas
   end
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
       end
     end
     resources :research_areas
+    resources :categories
   end
 
   namespace :api do

--- a/db/migrate/20190122205054_add_ancestry_depth_to_category.rb
+++ b/db/migrate/20190122205054_add_ancestry_depth_to_category.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAncestryDepthToCategory < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categories, :ancestry_depth, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_17_135718) do
+ActiveRecord::Schema.define(version: 2019_01_22_205054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2019_01_17_135718) do
     t.datetime "updated_at", null: false
     t.integer "services_count", default: 0
     t.string "slug"
+    t.integer "ancestry_depth", default: 0
     t.index ["ancestry"], name: "index_categories_on_ancestry"
     t.index ["description"], name: "index_categories_on_description"
     t.index ["name"], name: "index_categories_on_name"
@@ -130,9 +131,9 @@ ActiveRecord::Schema.define(version: 2019_01_17_135718) do
     t.string "project_website_url"
     t.string "company_name"
     t.string "company_website_url"
+    t.bigint "research_area_id"
     t.boolean "request_voucher", default: false, null: false
     t.string "voucher_id", default: "", null: false
-    t.bigint "research_area_id"
     t.index ["affiliation_id"], name: "index_project_items_on_affiliation_id"
     t.index ["offer_id"], name: "index_project_items_on_offer_id"
     t.index ["project_id"], name: "index_project_items_on_project_id"

--- a/spec/features/backoffice/categories_spec.rb
+++ b/spec/features/backoffice/categories_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Categories in backoffice" do
+  include OmniauthHelper
+
+  context "As a service portolio manager" do
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
+
+    before { checkin_sign_in_as(user) }
+
+    scenario "I can see all categories" do
+      create(:category, name: "c1")
+      create(:category, name: "c2")
+
+      visit backoffice_categories_path
+
+      expect(page).to have_content("c1")
+      expect(page).to have_content("c2")
+    end
+
+    scenario "I can see category details" do
+      parent = create(:category, name: "parent")
+      child = create(:category, name: "child", parent: parent)
+
+      visit backoffice_category_path(child)
+
+      expect(page).to have_content("child")
+      expect(page).to have_content("parent")
+    end
+
+    scenario "I can create new category" do
+      create(:category, name: "parent")
+
+      visit backoffice_categories_path
+      click_on "New Category"
+
+      fill_in "Name", with: "My new category"
+      select "parent", from: "Parent"
+
+      expect { click_on "Create Category" }.
+        to change { Category.count }.by(1)
+
+      expect(page).to have_content("My new category")
+      expect(page).to have_content("parent")
+    end
+
+    scenario "I can edit category" do
+      create(:category, name: "parent")
+      category = create(:category, name: "Old name")
+
+      visit edit_backoffice_category_path(category)
+
+      fill_in "Name", with: "New name"
+      select "parent", from: "Parent"
+      click_on "Update Category"
+
+      expect(page).to have_content("New name")
+      expect(page).to have_content("parent")
+    end
+  end
+end

--- a/spec/features/backoffice/research_areas_spec.rb
+++ b/spec/features/backoffice/research_areas_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Research areas in backoffice" do
+  include OmniauthHelper
+
+  context "As a service portolio manager" do
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
+
+    before { checkin_sign_in_as(user) }
+
+    scenario "I can see all research areas" do
+      create(:research_area, name: "ra1")
+      create(:research_area, name: "ra2")
+
+      visit backoffice_research_areas_path
+
+      expect(page).to have_content("ra1")
+      expect(page).to have_content("ra2")
+    end
+
+    scenario "I can see research area details" do
+      parent = create(:research_area, name: "parent")
+      child = create(:research_area, name: "child", parent: parent)
+
+      visit backoffice_research_area_path(child)
+
+      expect(page).to have_content("child")
+      expect(page).to have_content("parent")
+    end
+
+    scenario "I can create new research area" do
+      create(:research_area, name: "parent")
+
+      visit backoffice_research_areas_path
+      click_on "New Research Area"
+
+      fill_in "Name", with: "My new research area"
+      select "parent", from: "Parent"
+
+      expect { click_on "Create Research area" }.
+        to change { ResearchArea.count }.by(1)
+
+      expect(page).to have_content("My new research area")
+      expect(page).to have_content("parent")
+    end
+
+    scenario "I can edit research area" do
+      create(:research_area, name: "parent")
+      research_area = create(:research_area, name: "Old name")
+
+      visit edit_backoffice_research_area_path(research_area)
+
+      fill_in "Name", with: "New name"
+      select "parent", from: "Parent"
+      click_on "Update Research area"
+
+      expect(page).to have_content("New name")
+      expect(page).to have_content("parent")
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe ApplicationHelper, type: :helper do
-  describe "current_controller?" do
+  context "#current_controller?" do
     before do
       allow(controller).to receive(:controller_name).and_return("foo")
     end
@@ -22,7 +22,7 @@ describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "current_action?" do
+  context "#current_action?" do
     before do
       allow(controller).to receive(:action_name).and_return("foo")
     end
@@ -38,6 +38,32 @@ describe ApplicationHelper, type: :helper do
     it "should take any number of arguments" do
       expect(current_action?(:baz, :bar)).to be_falsy
       expect(current_action?(:baz, :bar, :foo)).to be_truthy
+    end
+  end
+
+  context "#back_link_to" do
+    it "returns to index for not persisted object" do
+      expect(back_link_to("Back", build(:service))).
+        to eq("<a href=\"#{services_path}\">Back</a>")
+    end
+
+    it "returns to show for persisted object" do
+      service = create(:service)
+
+      expect(back_link_to("Back", service)).
+        to eq("<a href=\"#{service_path(service)}\">Back</a>")
+    end
+
+    it "respects prefix" do
+      service = create(:service)
+
+      expect(back_link_to("Back", service, prefix: :backoffice)).
+        to eq("<a href=\"#{backoffice_service_path(service)}\">Back</a>")
+    end
+
+    it "passes html options" do
+      expect(back_link_to("Back", build(:service), class: "btn")).
+        to eq("<a class=\"btn\" href=\"#{services_path}\">Back</a>")
     end
   end
 end

--- a/spec/models/research_area_spec.rb
+++ b/spec/models/research_area_spec.rb
@@ -4,4 +4,34 @@ require "rails_helper"
 
 RSpec.describe ResearchArea, type: :model do
   it { should validate_presence_of(:name) }
+
+  describe "#potential_parents" do
+    it "includes potential parents" do
+      research_area = create(:research_area)
+      other = create(:research_area)
+
+      expect(research_area.potential_parents).to eq([other])
+    end
+
+    it "returns all existing research areas for new record" do
+      research_area = ResearchArea.new
+      other = create(:research_area)
+
+      expect(research_area.potential_parents).to eq([other])
+    end
+
+    it "does not include itself" do
+      research_area = create(:research_area)
+
+      expect(research_area.potential_parents).to eq([])
+    end
+
+    it "does not include children" do
+      research_area = create(:research_area)
+      child = create(:research_area, parent: research_area)
+      create(:research_area, parent: child)
+
+      expect(research_area.potential_parents).to eq([])
+    end
+  end
 end

--- a/spec/policies/backoffice/category_spec.rb
+++ b/spec/policies/backoffice/category_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Backoffice::CategoryPolicy do
+  subject { described_class }
+
+  permissions :index?, :show?, :new?, :create?, :edit?, :destroy? do
+    it "grants access for service portfolio manager" do
+      expect(subject).
+        to permit(build(:user, roles: [:service_portfolio_manager]))
+    end
+
+    it "denies for other users" do
+      expect(subject).to_not permit(build(:user))
+    end
+  end
+end

--- a/spec/policies/backoffice/research_area_policy_spec.rb
+++ b/spec/policies/backoffice/research_area_policy_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Backoffice::ResearchAreaPolicy do
+  subject { described_class }
+
+  permissions :index?, :show?, :new?, :create?, :edit?, :destroy? do
+    it "grants access for service portfolio manager" do
+      expect(subject).
+        to permit(build(:user, roles: [:service_portfolio_manager]))
+    end
+
+    it "denies for other users" do
+      expect(subject).to_not permit(build(:user))
+    end
+  end
+end

--- a/spec/requests/backoffice/categories_spec.rb
+++ b/spec/requests/backoffice/categories_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Backoffice category" do
+  context "as a logged in service portfolio manager" do
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
+
+    before { login_as(user) }
+
+    it "I can delete category" do
+      category = create(:category)
+
+      expect { delete backoffice_category_path(category) }.
+        to change { Category.count }.by(-1)
+    end
+  end
+end

--- a/spec/requests/backoffice/research_areas_spec.rb
+++ b/spec/requests/backoffice/research_areas_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Backoffice research area" do
+  context "as a logged in service portfolio manager" do
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
+
+    before { login_as(user) }
+
+    it "I can delete research area" do
+      research_area = create(:research_area)
+
+      expect { delete backoffice_research_area_path(research_area) }.
+        to change { ResearchArea.count }.by(-1)
+    end
+  end
+end


### PR DESCRIPTION
This adds simple crud for `Research areas` and `Categories` in backoffice. To access these views you need to have `:service_portfolio_manager` role.

Below you can find sample screenshots (views for `Categories` are similar):

![ra-index](https://user-images.githubusercontent.com/1265430/51568594-659b8a80-1e9a-11e9-81ad-312b754ab044.png)

![ra-new](https://user-images.githubusercontent.com/1265430/51568606-6af8d500-1e9a-11e9-8037-fad64a065f9a.png)

![ra-show](https://user-images.githubusercontent.com/1265430/51568615-6df3c580-1e9a-11e9-8e49-c7ac82f82159.png)

![ra-edit](https://user-images.githubusercontent.com/1265430/51568623-721fe300-1e9a-11e9-98ee-5cd4ab209eb9.png)

Fixes #630
Fixes #633 