### PR TITLE
Remove shell command invocation in one of the test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - RWD for offer selection (@jarekzet)
 - Show `*` near order research area field, show errors when research area is not
   selected (@mkasztelnik)
+- Remove shell command invocation in one of the test (@mkasztelnik)
 
 ### Security
 

--- a/spec/models/service_relationship_spec.rb
+++ b/spec/models/service_relationship_spec.rb
@@ -3,5 +3,5 @@
 require "rails_helper"
 
 RSpec.describe ServiceRelationship, type: :model do
-  `pending "add some examples to (or delete) #{__FILE__}"`
+  'pending "add some examples to (or delete) #{__FILE__}"'
 end


### PR DESCRIPTION
\`` is used in ruby to invoke shell command. This should not be used to define string or comment something.