### PR TITLE
[#662] Offers improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 
 ### Changed
+- Offers displaying on backoffice and portal view (@martaswiatkowska)
+- Height of the textarea in the ofers form (@martaswiatkowska)
 
 ### Deprecated
 

--- a/app/javascript/controllers/service_offer_controller.js
+++ b/app/javascript/controllers/service_offer_controller.js
@@ -11,6 +11,6 @@ export default class extends Controller {
   showMore(event){
     const element = event.target
     event.preventDefault()
-    this.showMoreTarget.parentElement.textContent = element.dataset.text
+    this.showMoreTarget.parentElement.innerHTML = element.dataset.text
   }
 }

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -1,6 +1,6 @@
 = simple_form_for [:backoffice, service, offer]  do |f|
   = f.input :name
-  = f.input :description
+  = f.input :description, input_html: { rows: 10 }
 
   .btn-group
     = f.button :submit, class: "btn btn-success"

--- a/app/views/backoffice/services/offers/_offer.html.haml
+++ b/app/views/backoffice/services/offers/_offer.html.haml
@@ -1,7 +1,7 @@
 .card.col-md-4
   .card-body
     %h4.card-title= offer.name
-    %p.card-text.mb-4= offer.description
+    %p.card-text.mb-4= markdown(offer.description)
   .card-footer
     - if policy([:backoffice, offer]).edit?
       = link_to "Edit",

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -6,14 +6,15 @@
           %i.fas.fa-ticket-alt
           %span Voucher
       %h4.card-title= offer.name
-      %p.card-text.mb-2
-        - if offer.description.size > 200
-          = offer.description.truncate(200, separator: " ")
-          = link_to "Show more", "#", class: "show-more-#{offer.id}",
+      %p
+        .card-text.mb-2
+          - if offer.description.size > 200
+            = markdown(offer.description.truncate(200, separator: " "))
+            = link_to "Show more", "#", class: "show-more-#{offer.id}",
                                   data: { "target" => "service-offer.showMore",
                                           "action" => "click->service-offer#showMore",
-                                          "text": "#{offer.description}" }
-        - else
-          = offer.description
+                                          "text": markdown(offer.description) }
+          - else
+            = markdown(offer.description)
       %h5.text-uppercase.parameters-title.mb-0= "Technical parameters"
       = render "services/parameters", parameters: offer.attributes

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -107,12 +107,24 @@ RSpec.feature "Services in backoffice" do
       click_on "Add new offer"
 
       expect {
-        fill_in "Name", with: "new offer"
+        fill_in "Name", with: "new offer 1"
         fill_in "Description", with: "test offer"
         click_on "Create Offer"
       }.to change { service.offers.count }.by(1)
 
-      expect(service.offers.last.name).to eq("new offer")
+      expect(page).to have_content("test offer")
+      expect(service.offers.last.name).to eq("new offer 1")
+    end
+
+    scenario "Offer are converted from markdown to html on service view" do
+      offer = create(:offer,
+                     name: "offer1",
+                     description: "# Test offer\r\n\rDescription offer")
+
+      visit backoffice_service_path(offer.service)
+
+      find(".card-body h1", text: "Test offer")
+      find(".card-body p", text: "Description offer")
     end
 
     scenario "I can edit offer" do

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -76,6 +76,7 @@ RSpec.feature "Service browsing" do
 
     expect(page.body).to_not have_content "Suggested compatible services"
   end
+
   context "service has no offers" do
     scenario "service offers section are not displayed" do
       service = create(:service)
@@ -85,6 +86,16 @@ RSpec.feature "Service browsing" do
       expect(page.body).not_to have_content("Service offers")
     end
   end
+
+  scenario "Offer are converted from markdown to html on service view" do
+    offer = create(:offer, description: "# Test offer\r\n\rDescription offer")
+
+    visit service_path(offer.service)
+
+    find(".card-body h1", text: "Test offer")
+    find(".card-body p", text: "Description offer")
+  end
+
 
   scenario "show technical parameters in service view" do
     offer = create(:offer, parameters: [{ "id": "id1",


### PR DESCRIPTION
Higher offer description textarea on edit view
Offers on views (backoffice and portal) are displayed in markdown  

Fix #662 