### PR TITLE
Add elasticsearch version to .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 ruby 2.5.1
 nodejs 10.1.0
+elasticsearch 5.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - voucher_id in aod_voucher_accepted email (@kmarszalek)
+- `elasticsearch` version added to `.tool-versions` file (@mkasztelnik)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,23 @@ We will need:
   * nodejs (specific version can be found in [.tool-versions](.tool-versions)).
     Recommented way to manage nodejs versions is to use [asdf](https://github.com/asdf-vm/asdf)
     with [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs) plugin.
+  * elasticsearch (specific version can be found in [.tool-versions](.tool-versions)).
+    Recommented way to manage nodejs versions is to use [asdf](https://github.com/asdf-vm/asdf)
+    with [asdf-elasticsearch](https://github.com/asdf-vm/asdf-elasticsearch) plugin.
   * [postgresql](https://www.postgresql.org)
   * redis (https://redis.io)
+
+If you are using [asdf](https://github.com/asdf-vm/asdf) the easiest way to
+install required ruby, nodejs and elasticsearch version is to type
+
+```
+asdf install
+```
+
+in marketplace root directory. Ruby and nodejs versions will be set in automatic
+way. To start correct elasticsearch version type `elasticsearch` in the
+marketplace root directory.
+
 ### Setup
 
   * First time run `/bin/setup`. It will install bundler, foreman,
@@ -76,7 +91,7 @@ to use jira instance provided by atlassian SDK.
 
 ## For Admins
 
-If you are an admin, who wants to integrate production instance of JIRA go to 
+If you are an admin, who wants to integrate production instance of JIRA go to
 [JIRA integration manual](./docs/jira_integration.md) otherwise read on.
 
 ## For Developers
@@ -194,10 +209,10 @@ ENV variables:
     script is added into head section)
   * `PORTAL_BASE_URL` - portal base URL used to generate footer and other static
     links to EOSC portal
-  * `ASSET_HOST` and `ASSET_PROTOCOL` - assets mailer config is mandatory 
+  * `ASSET_HOST` and `ASSET_PROTOCOL` - assets mailer config is mandatory
     (e.g. ASSET_HOST = marketplace.eosc-portal.eu/ and ASSET_PROTOCOL = https )
   * `RATE_AFTER_PERIOD` - number of days after which user can rate service (default is set to 90 days)
-  * ENV Variables connected to JIRA integration are described in [JIRA integration manual](./docs/jira_integration.md)  
+  * ENV Variables connected to JIRA integration are described in [JIRA integration manual](./docs/jira_integration.md)
 
 ## Commits
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_30_130546) do
+ActiveRecord::Schema.define(version: 2019_02_15_073516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,9 +131,9 @@ ActiveRecord::Schema.define(version: 2019_01_30_130546) do
     t.string "project_website_url"
     t.string "company_name"
     t.string "company_website_url"
+    t.bigint "research_area_id"
     t.boolean "request_voucher", default: false, null: false
     t.string "voucher_id", default: "", null: false
-    t.bigint "research_area_id"
     t.index ["affiliation_id"], name: "index_project_items_on_affiliation_id"
     t.index ["offer_id"], name: "index_project_items_on_offer_id"
     t.index ["project_id"], name: "index_project_items_on_project_id"


### PR DESCRIPTION
This is useful to install correct `elasticsearch` version for the
project.

You can now type:

```
asdf install
```

and correct version of the `ruby`, `nodejs` and `elasticsearch` is installed.