### PR TITLE
Offer type with service type taken as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 - voucher_id in aod_voucher_accepted email (@kmarszalek)
 - voucher_id updates from jira (@michal-szostak)
 - `elasticsearch` version added to `.tool-versions` file (@mkasztelnik)
+- Offer type (`normal`, `open_access`, `catalog`) with service type taken as
+  default (@mkasztelnik)
 
 ### Changed
 - Change service phase values into keys (@mkasztelnik)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - `elasticsearch` version added to `.tool-versions` file (@mkasztelnik)
 - Offer type (`normal`, `open_access`, `catalog`) with service type taken as
   default (@mkasztelnik)
+- Offer can be selected from `service#show` (@mkasztelnik)
 
 ### Changed
 - Change service phase values into keys (@mkasztelnik)

--- a/app/controllers/services/offers_controller.rb
+++ b/app/controllers/services/offers_controller.rb
@@ -37,7 +37,7 @@ class Services::OffersController < Services::ApplicationController
     end
 
     def init_offer_selection!
-      @offers = @service.offers
+      @offers = @service.offers.reject { |o| o.catalog? }
       @project_item = ProjectItem.new(session[session_key])
     end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Offer < ApplicationRecord
+  enum offer_type: {
+    normal: "normal",
+    open_access: "open_access",
+    catalog: "catalog"
+  }
+
   belongs_to :service,
              counter_cache: true
 
@@ -19,6 +25,22 @@ class Offer < ApplicationRecord
 
   def attributes
     (parameters || []).map { |param| Attribute.from_json(param) }
+  end
+
+  def offer_type
+    super || service.service_type
+  end
+
+  def open_access?
+    offer_type == "open_access"
+  end
+
+  def normal?
+    offer_type == "normal"
+  end
+
+  def catalog?
+    offer_type == "catalog"
   end
 
   private

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -37,7 +37,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name, :description]
+    [:name, :description, :offer_type]
   end
 
   private

--- a/app/services/project_item/create.rb
+++ b/app/services/project_item/create.rb
@@ -26,8 +26,10 @@ class ProjectItem::Create
   private
 
     def open_access?
-      Service.joins(:offers).
-        find_by(offers: { id: @project_item.offer_id })&.
-        open_access?
+      @project_item.offer.open_access?
+    end
+
+    def normal?
+      @project_item.offer.normal?
     end
 end

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -1,6 +1,7 @@
 = simple_form_for [:backoffice, service, offer]  do |f|
   = f.input :name
   = f.input :description, input_html: { rows: 10 }
+  = f.input :offer_type, collection: Offer.offer_types.keys.map(&:to_sym)
 
   .btn-group
     = f.button :submit, class: "btn btn-success"

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -1,4 +1,4 @@
-.col-md-6.d-flex.align-items-stretch.mb-4{ "data-controller" => "service-offer" }
+.col-md-6.d-flex.align-items-stretch.mb-5{ "data-controller" => "service-offer" }
   .card.offers
     .card-body.pt-4.collapse-group
       - if offer.voucherable
@@ -18,3 +18,13 @@
             = markdown(offer.description)
       %h5.text-uppercase.parameters-title.mb-0= "Technical parameters"
       = render "services/parameters", parameters: offer.attributes
+    .card-button.text-center
+      %label
+        - if offer.catalog?
+          = link_to offer.service.connected_url do
+            %span.btn.btn-light.border.border-secondary.font-weight-bold
+              = t("offer.order_text.#{offer.offer_type}")
+        - else
+          = link_to service_offers_path(offer.service, project_item: { offer_id: offer.iid }), method: :put do
+            %span.btn.btn-light.border.border-secondary.font-weight-bold
+              = t("offer.order_text.#{offer.offer_type}")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,11 @@ en:
       description: |
         You can organize your services in projects.
         Add this service to a specific project or create a new one.
+  offer:
+    order_text:
+      normal: Order
+      open_access: Add to my services
+      catalog: Go to the service
 
   affiliation_confirmations:
     index:

--- a/db/migrate/20190215114245_add_offer_type_to_offer.rb
+++ b/db/migrate/20190215114245_add_offer_type_to_offer.rb
@@ -1,0 +1,5 @@
+class AddOfferTypeToOffer < ActiveRecord::Migration[5.2]
+  def change
+    add_column :offers, :offer_type, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2019_02_15_073516) do
     t.datetime "updated_at", null: false
     t.jsonb "parameters"
     t.boolean "voucherable", default: false, null: false
+    t.string "offer_type"
     t.index ["iid"], name: "index_offers_on_iid"
     t.index ["service_id", "iid"], name: "index_offers_on_service_id_and_iid", unique: true
     t.index ["service_id"], name: "index_offers_on_service_id"

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Service ordering" do
 
       visit service_path(service)
 
-      click_on "Order"
+      click_on "Order", match: :first
 
       # Step 1
       expect(page).to have_current_path(service_offers_path(service))
@@ -97,7 +97,7 @@ RSpec.feature "Service ordering" do
 
       visit service_path(service)
 
-      click_on "Order"
+      click_on "Order", match: :first
 
       # Step 1
 
@@ -125,8 +125,8 @@ RSpec.feature "Service ordering" do
 
     scenario "I cannot order open_access service twice in one project" do
       open_access_service = create(:open_access_service)
-      offer = create(:offer, service: open_access_service)
-      default_project = user.projects.find_by(name: "Services")
+      _offer = create(:offer, service: open_access_service)
+      _default_project = user.projects.find_by(name: "Services")
 
       visit service_path(open_access_service)
 
@@ -380,7 +380,7 @@ RSpec.feature "Service ordering" do
 
       expect(page).to have_selector(:link_or_button, "Order", exact: true)
 
-      click_on "Order"
+      click_on "Order", match: :first
 
       checkin_sign_in_as(user)
 

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe Offer do
   it { should belong_to(:service) }
 
   it { should have_many(:project_items).dependent(:restrict_with_error) }
+
+  context "#offer_type" do
+    it "takes default from service if not set" do
+      service = create(:service, service_type: :catalog)
+      offer = create(:offer, service: service)
+
+      expect(offer.offer_type).to eq "catalog"
+    end
+  end
 end


### PR DESCRIPTION
Starting from now offer can define customized ordering type (one of `normal`, `open_access`, `catalog`). If a type is `nil` in the offer than default is taken from the `Service::service_type`. On the first order wizard view (offer selection) only `normal` and `open_access` offers are presented - `catalog`ues are filtered out.

After this was added it was possible to add dedicated select offer buttons directly on `service#show` view:

![screenshot from 2019-02-15 14-38-38](https://user-images.githubusercontent.com/1265430/52860324-6937cf80-312f-11e9-9e77-9562837fb62b.png)

For now, the first ordering step is not removed (so we have responsibility duplication!). I did not remove this view because it is required for "main" `Order` button to work. This is task for @abacz, @roksanaer and @toszep to agree if this should stay of some redesign of this button will be performed.

Fixes #687