### PR TITLE
[#653] Offer attribute in backoffice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 - Offer status (@martaswiatkowska)
 - markdown rendering in offer's description (@goreck888)
+- Offers parameters in backoffice - initial (@martaswiatkowska)
 
 ### Changed
 

--- a/app/controllers/backoffice/services/offers_controller.rb
+++ b/app/controllers/backoffice/services/offers_controller.rb
@@ -27,7 +27,8 @@ class Backoffice::Services::OffersController < Backoffice::ApplicationController
   end
 
   def update
-    if Offer::Update.new(@offer, permitted_attributes(@offer)).call
+    template = permitted_attributes(Offer.new)
+    if Offer::Update.new(@offer, without_blank_parameters(template)).call
       redirect_to backoffice_service_path(@service, @offer),
                   notice: "Offer updated correctly"
     else
@@ -43,8 +44,15 @@ class Backoffice::Services::OffersController < Backoffice::ApplicationController
 
   private
     def offer_template
-      Offer.new(permitted_attributes(Offer).
-                                  merge(service: @service, status: :draft))
+      temp = without_blank_parameters(permitted_attributes(Offer))
+      Offer.new(temp.merge(service: @service, status: :draft))
+    end
+
+    def without_blank_parameters(template)
+      if template["parameters_as_string"]
+        template["parameters_as_string"] = template["parameters_as_string"].reject(&:empty?)
+      end
+      template
     end
 
     def find_service

--- a/app/inputs/array_input.rb
+++ b/app/inputs/array_input.rb
@@ -3,7 +3,6 @@
 class ArrayInput < SimpleForm::Inputs::StringInput
   def input(wrapper_options)
     input_html_options[:type] ||= input_type
-
     existing_value = Array(object.public_send(attribute_name)).map.with_index do |array_el, index|
       @builder.text_field(nil, input_html_options.merge(value: array_el,
                                                         name: "#{object_name}[#{attribute_name}][]",

--- a/app/inputs/attributes_input.rb
+++ b/app/inputs/attributes_input.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class AttributesInput < SimpleForm::Inputs::TextInput
+  def input(wrapper_options)
+    input_html_options[:type] ||= input_type
+
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+    existing_value = Array(object.public_send(attribute_name)).map.with_index do |array_el, index|
+
+
+      merged_options = merged_input_options.merge(value: array_el,
+                                                  name: "#{object_name}[#{attribute_name}][]",
+                                                  id: "#{object_name}_#{attribute_name}_#{index}",
+                                                  class: "form-control ")
+
+      if input_has_errors?(index)
+        error = @builder.full_error("#{attribute_name}_#{index}",
+                                    class: "invalid-feedback d-block")
+        merged_options = merged_options.merge(class: "is-invalid form-control text")
+      end
+
+      input = @builder.text_area(nil, merged_options)
+      input + error
+    end
+
+    unless object.errors.present?
+      number = Array(object.public_send(attribute_name)).length
+      existing_value.push @builder.text_area(nil, merged_input_options.merge(value: nil,
+                                                                           name: "#{object_name}[#{attribute_name}][]",
+                                                                           id: "#{object_name}_#{attribute_name}_#{number}",
+                                                                           class: "form-control text"))
+    end
+    existing_value.join.html_safe
+  end
+
+  def input_has_errors?(index)
+    object.errors["#{attribute_name}_#{index}"].present?
+  end
+
+  def input_type
+    :text
+  end
+end

--- a/app/javascript/controllers/offer_controller.js
+++ b/app/javascript/controllers/offer_controller.js
@@ -1,0 +1,22 @@
+import {Controller} from 'stimulus'
+
+export default class extends Controller {
+  static targets = ["parameters"];
+
+  connect() {}
+
+  initialize() {}
+
+  addField(event) {
+    event.preventDefault();
+    var child = document.createElement("textarea")
+
+    child.setAttribute("class", "form-control json")
+    child.setAttribute("name", "offer[parameters_as_string][]")
+    child.id = "offer_parameters_as_string_"+(this.parametersTarget.children.length-1)
+    child.setAttribute("type", "text")
+    child.setAttribute("rows", 10)
+
+    this.parametersTarget.appendChild(child)
+  }
+}

--- a/app/models/attribute.rb
+++ b/app/models/attribute.rb
@@ -101,6 +101,7 @@ class Attribute
 
   def self.from_json(json)
     JSON::Validator.validate!(ATTRIBUTE_SCHEMA, json)
+
     case json["type"]
     when "input"
       attr = Attribute::Input.new

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -28,6 +28,10 @@ class ProjectItem < ApplicationRecord
   enum issue_status: ISSUE_STATUSES
   enum customer_typology: CUSTOMER_TYPOLOGIES
 
+  attribute :property_values
+
+  before_save :map_properties
+
   belongs_to :offer
   belongs_to :affiliation, required: false
   belongs_to :project
@@ -53,16 +57,13 @@ class ProjectItem < ApplicationRecord
   validates :request_voucher, absence: true, unless: :vaucherable?
   validates :voucher_id, absence: true, if: :voucher_id_unwanted?
   validates :voucher_id, presence: true, allow_blank: false, if: :voucher_id_required?
+  validate :one_per_project?, on: :create
 
   delegate :user, to: :project
 
   def service
     offer.service unless offer.nil?
   end
-
-  before_save :map_properties
-
-  validate :one_per_project?, on: :create
 
   def open_access?
     @is_open_access ||= service&.open_access?
@@ -109,8 +110,6 @@ class ProjectItem < ApplicationRecord
   def map_properties
     self.properties = property_values.map(&:to_json)
   end
-
-  attribute :property_values
 
   def property_values
     if !@property_values

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -46,7 +46,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name, :description, :offer_type]
+    [:name, :description, :offer_type, [parameters_as_string: []]]
   end
 
   private

--- a/app/validators/attribute_id_unique_validator.rb
+++ b/app/validators/attribute_id_unique_validator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AttributeIdUniqueValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless record.errors.blank?
+
+    arry = (record.parameters_as_string || []).map { |p| JSON.parse(p)["id"] }
+    arry.each_with_index do |e, i|
+      if arry.count(e) > 1
+        record.errors.add("parameters_as_string_#{i}", "Id must be unique")
+      end
+    end
+  end
+end

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -1,9 +1,18 @@
-= simple_form_for [:backoffice, service, offer]  do |f|
+= simple_form_for [:backoffice, service, offer], html: { "data-controller": "offer" } do |f|
+  = f.error_notification
   = f.input :name
   = f.input :description, input_html: { rows: 10 }
   = f.input :offer_type, collection: Offer.offer_types.keys.map(&:to_sym)
+  = f.input :parameters_as_string,
+      as: :attributes,
+      multiple: true,
+      wrapper_html: { "data-target": "offer.parameters" },
+      input_html: { rows: 10 }
 
+  %div
+    %a#add-parameter-field{ "data-action": "click->offer#addField", class: "btn btn-secondary" }
+      Add additional parameters
+  %hr.bottom-hr.mb-4
   .btn-group
     = f.button :submit, class: "btn btn-success"
     = link_to "Cancel", backoffice_service_path(service), class: "btn btn-secondary"
-

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature "Service browsing" do
                                           "value_type": "integer",
                                           "description": "Amount of local disk space" },
                                         { "id": "id4",
-                                          "type": "input",
+                                          "type": "range",
                                           "label": "Number of VM instances",
                                           "config": { "maximum": 50, "minimum": 1 },
                                           "value_type": "integer",
@@ -143,6 +143,7 @@ RSpec.feature "Service browsing" do
                                           "label": "Start of service",
                                           "value_type": "string",
                                           "description": "Please choose start date" }])
+
 
     checkin_sign_in_as(user)
     visit service_path(offer.service)

--- a/spec/models/attribute_spec.rb
+++ b/spec/models/attribute_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Attribute do
 
-  it "creates correct string select with value from json", focus: true do
+  it "creates correct string select with value from json" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "select",
@@ -17,7 +17,7 @@ RSpec.describe Attribute do
     expect(attr.value_valid?).to be true
   end
 
-  it "sets value of correct select from request param", focus: true do
+  it "sets value of correct select from request param" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "select",
@@ -28,7 +28,7 @@ RSpec.describe Attribute do
     attr.value_from_param(["a"])
   end
 
-  it "creates correct non changable attribute with unit from string", focus: true do
+  it "creates correct non changable attribute with unit from string" do
     attr = Attribute.from_json("id" => "id7",
                                "label" => "Attribute non changable",
                                "type" => "attribute",
@@ -39,7 +39,7 @@ RSpec.describe Attribute do
   end
 
   # TODO - known issue for now. Rails auto-coerces to numeric types. Bring this test back once fixed
-  # it "creates attribute number string assigned to string", focus: true do
+  # it "creates attribute number string assigned to string" do
   #   attr = Attribute.from_json({
   #                                  "id" => "id7",
   #                                  "label" => "Attribute non changable",
@@ -51,7 +51,7 @@ RSpec.describe Attribute do
   #   expect(attr.value_valid?).to be true
   # end
 
-  it "fails on wrong value type", focus: true do
+  it "fails on wrong value type" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "attribute",
@@ -60,7 +60,7 @@ RSpec.describe Attribute do
     expect(attr.value_valid?).to be true
   end
 
-  it "creates correct date property from json", focus: true do
+  it "creates correct date property from json" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "date",
@@ -69,20 +69,22 @@ RSpec.describe Attribute do
     expect(attr.value_valid?).to be true
   end
 
-  it "fails on invalid attribute type", focus: true do
+  it "fails on invalid attribute type" do
+
     expect {
       Attribute.from_json("id" => "id1",
-                           "label" => "Attribute 1",
-                           "type" => "select",
-                           "value_type" => "fail",
-                           "value" => "b",
-                           "config" => {
-                               "values" => ["a", "b", "c"]
+                          "label" => "Attribute 1",
+                          "type" => "select",
+                          "value_type" => "fail",
+                          "value" => "b",
+                          "config" => {
+                              "values" => ["a", "b", "c"]
                            })
+
     }.to raise_exception(JSON::Schema::ValidationError)
   end
 
-  it "creates correct integer select with value from json", focus: true do
+  it "creates correct integer select with value from json" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "select",
@@ -95,7 +97,7 @@ RSpec.describe Attribute do
     expect(attr.value_valid?).to be true
   end
 
-  it "creates correct integer multiselectselect with value from json", focus: true do
+  it "creates correct integer multiselectselect with value from json" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "multiselect",
@@ -108,7 +110,7 @@ RSpec.describe Attribute do
     expect(attr.value_valid?).to be true
   end
 
-  it "does anything", focus: true do
+  it "does anything" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "multiselect",
@@ -121,7 +123,7 @@ RSpec.describe Attribute do
     expect(attr.value_valid?).to be true
   end
 
-  it "creates correct range property from json", focus: true do
+  it "creates correct range property from json" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "range-property",
@@ -134,7 +136,7 @@ RSpec.describe Attribute do
   end
 
 
-  it "creates correct number range with value from json", focus: true do
+  it "creates correct number range with value from json" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "range",
@@ -147,7 +149,7 @@ RSpec.describe Attribute do
     expect(attr.value_valid?).to be true
   end
 
-  it "creates correct number range with invalid value from json", focus: true do
+  it "creates correct number range with invalid value from json" do
     attr = Attribute.from_json("id" => "id1",
                                "label" => "Attribute 1",
                                "type" => "range",
@@ -161,7 +163,7 @@ RSpec.describe Attribute do
     expect(attr.value_valid?).to be false
   end
 
-  it "fails to create dummy attribute", focus: true do
+  it "fails to create dummy attribute" do
     expect { Attribute.from_json("id" => "id1") }.to raise_exception(JSON::Schema::ValidationError)
   end
 


### PR DESCRIPTION
SPM can add offer parameters in backoffice. 
Exemplary json to tests:
{
	"id":"id1",
	"type":"select", 
	"label":"Number of CPU Cores",
	"config":{"mode":"buttons", "values":[1, 2, 4, 8]},	
	"value_type":"integer",
	"description":"Select number of cores you want"
}

Fix: #653 