### PR TITLE
[#716] Fix project_item details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 
+- Small view error in my order detail page 
+
 ### Security
 
 ## [1.4.0] - 2019-02-26

--- a/app/views/project_items/show.html.haml
+++ b/app/views/project_items/show.html.haml
@@ -86,26 +86,6 @@
 
         = render "project_items/attributes", property_values: @project_item.property_values
 
-      - if ratingable?
-        %h3.mb-3 Rate this service
-        %ul
-          %li
-            Share your opinion with others.
-          %li
-            = link_to "Rate",
-              new_project_item_service_opinion_path(@project_item),
-              class: "btn btn-primary"
-
-
-
-          %dl
-            %dt
-              Voucher:
-            %dd
-              - if @project_item.voucher_id.blank?
-                Requested
-              - else
-                = @project_item.voucher_id
       - unless @project_item.voucher_id.blank? && !@project_item.request_voucher
         %h2.mb-
           Vouchers
@@ -120,14 +100,17 @@
               Your voucher ID
               %br
               %span.voucher-name= @project_item.voucher_id
-
-      %h2.mb-3
-        Your review
-      .blue-row.form-inline.mb-3
-        .d-inline.mr-4
-          %i.fas.fa-star.fa-pull-left
-          You have been using this service from 3 months. Please share your opinion with others EOSC Marketplace users.
-      %button.btn.btn-primary.btn-sm{ type: "submit" } Review service
+      - if ratingable?
+        %h2.mb-3
+          Your review
+        .blue-row.form-inline.mb-3
+          .d-inline.mr-4
+            %i.fas.fa-star.fa-pull-left
+            You have been using this service for #{distance_of_time_in_words(@project_item.created_at, DateTime.now)}.
+            Please share your opinion with others EOSC Marketplace users.
+        = link_to "Review service",
+            new_project_item_service_opinion_path(@project_item),
+            class: "btn btn-primary btn-sm"
     .col-md-6
       = render "project_items/project_item_changes",
                 project_item_changes: @project_item.project_item_changes.order("updated_at DESC").to_a,

--- a/spec/features/my_services_spec.rb
+++ b/spec/features/my_services_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "My Services" do
       expect(page).to have_text("Service is ready")
     end
 
-    scenario "I can voucher id" do
+    scenario "I can see voucher id" do
       project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: create(:offer, voucherable: true),
                             voucher_id: "V123V")
@@ -95,7 +95,7 @@ RSpec.feature "My Services" do
       expect(page).to have_text(project_item.voucher_id)
     end
 
-    scenario "I cannot voucher entry" do
+    scenario "I cannot see voucher entry" do
       project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer)
 
@@ -112,6 +112,25 @@ RSpec.feature "My Services" do
       visit project_item_path(project_item)
 
       expect(page).to have_text("Vouchers\nRequested")
+    end
+
+    scenario "I cannot see review section" do
+      project = create(:project, user: user)
+      project_item = create(:project_item, project: project, offer: offer)
+
+      visit project_item_path(project_item)
+
+      expect(page).to_not have_text("Your review")
+    end
+
+    scenario "I can see review section" do
+      project = create(:project, user: user)
+      project_item = create(:project_item, project: project, offer: offer, status: :ready)
+      travel 1.day
+      visit project_item_path(project_item)
+
+      expect(page).to have_text("Your review")
+      expect(page).to have_text("You have been using this service for 1 day.")
     end
 
     scenario "I can ask question about my project_item" do


### PR DESCRIPTION
# What is in this PR?

* If `project_item.status == 'ready'` some old and no more needed
  information about voucher / rating were visible - it has been removed

* Make Your review button work, replace static timelapse
  ('You have been using this service for 8 days. ') text to dynamic one
  based on `project_item.crated_at`

# Notes for testers

Check `http://localhost:5000/project_items/<id>` view after accepting voucherable service in jira. 
If there are no double voucher / rating entries then it's all good.

After accepting service in jira check timelapse counter in 'Your review' section (it should be dynamic)

Fixes #716