### PR TITLE
Remove unused `orders` and `order_changes` from schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Removed
 
+- Remove unused `orders` and `order_changes` tables from `db/schema.rb` (@mkasztelnik)
+
 ### Fixed
 - service creation bug (@martaswiatkowska)
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,34 +90,11 @@ ActiveRecord::Schema.define(version: 2019_03_06_111257) do
     t.datetime "updated_at", null: false
     t.jsonb "parameters"
     t.boolean "voucherable", default: false, null: false
-    t.string "offer_type"
     t.string "status"
+    t.string "offer_type"
     t.index ["iid"], name: "index_offers_on_iid"
     t.index ["service_id", "iid"], name: "index_offers_on_service_id_and_iid", unique: true
     t.index ["service_id"], name: "index_offers_on_service_id"
-  end
-
-  create_table "order_changes", force: :cascade do |t|
-    t.string "status"
-    t.text "message"
-    t.bigint "order_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "author_id"
-    t.index ["author_id"], name: "index_order_changes_on_author_id"
-    t.index ["order_id"], name: "index_order_changes_on_order_id"
-  end
-
-  create_table "orders", force: :cascade do |t|
-    t.string "status", null: false
-    t.bigint "service_id", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "issue_id"
-    t.integer "issue_status", default: 2, null: false
-    t.index ["service_id"], name: "index_orders_on_service_id"
-    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "platforms", force: :cascade do |t|


### PR DESCRIPTION
These old tables were introduced most probably by mistake in the scope of #713, now it is time to remove it once again :smile: 