### PR TITLE
Initial usage of searchkick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 - Link to the tutorial of creating attributes in backoffice (@goreck888)
 - External ID input to backoffice provider's form (@michal-szostak)
+- Initial implementation of usage Searchkik (@martaswiatkowska)
 
 ### Changed
 - Filters refactored and moved into `Service::Filterable` concern (@mkasztelnik)

--- a/Gemfile
+++ b/Gemfile
@@ -36,9 +36,7 @@ gem "counter_culture", "~> 2.0"
 gem "valid_email2"
 gem "json-schema"
 
-gem "elasticsearch-model"
-gem "elasticsearch-rails"
-
+gem "searchkick"
 gem "devise"
 gem "omniauth"
 gem "omniauth_openid_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,17 +100,12 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
-    elasticsearch (5.0.5)
-      elasticsearch-api (= 5.0.5)
-      elasticsearch-transport (= 5.0.5)
-    elasticsearch-api (5.0.5)
+    elasticsearch (6.2.0)
+      elasticsearch-api (= 6.2.0)
+      elasticsearch-transport (= 6.2.0)
+    elasticsearch-api (6.2.0)
       multi_json
-    elasticsearch-model (5.0.2)
-      activesupport (> 3)
-      elasticsearch (~> 5)
-      hashie
-    elasticsearch-rails (5.0.2)
-    elasticsearch-transport (5.0.5)
+    elasticsearch-transport (6.2.0)
       faraday
       multi_json
     erubi (1.8.0)
@@ -359,6 +354,10 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    searchkick (3.1.2)
+      activemodel (>= 4.2)
+      elasticsearch (>= 5)
+      hashie
     selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
@@ -457,8 +456,6 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
-  elasticsearch-model
-  elasticsearch-rails
   factory_bot_rails
   faker
   friendly_id (~> 5.2.0)
@@ -491,6 +488,7 @@ DEPENDENCIES
   rubocop-rails (>= 1.5.0)
   sass-rails (~> 5.0)
   scss_lint
+  searchkick
   selenium-webdriver
   sentry-raven
   shoulda-matchers

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -11,11 +11,10 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
   prepend_before_action :index_authorize, only: :index
 
   def index
-    searched = search(scope)
-    filtered = filter(searched)
+    filtered = filter(scope)
     from_category = category_records(filtered)
 
-    @services = paginate(from_category.order(ordering))
+    @services = search(from_category.order(ordering))
   end
 
   def show

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -19,11 +19,12 @@ module Service::Searchable
 
     def search_fields(search_scope)
       Service.search params[:q],
-                     fields: ["title^10", "description"],
+                     fields: [ "title^5", "description"],
                      operator: "or",
                      where: { id: search_scope.ids },
                      page: params[:page], per_page: per_page,
                      order: ordering,
+                     match: :text_middle,
                      scope_results: ->(r) { r.includes(:research_areas, :providers, :target_groups).with_attached_logo }
     end
 end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -6,14 +6,23 @@ module Service::Searchable
   private
 
     def search(search_scope)
-      query_present? ? search_scope.where(id: search_ids(search_scope)) : search_scope
+      query_present? ? search_fields(search_scope) : search_scope
     end
 
     def query_present?
       params[:q].present?
     end
 
-    def search_ids(search_scope)
-      search_scope.search(params[:q]).records.ids
+    def search_fields(search_scope)
+      result = Service.search(params[:q],
+                            fields: ["title^10", "description"],
+                            operator: "or",
+                            where: { id: search_scope.ids })
+
+      # By default, ids are fetched from
+      # Elasticsearch and records are fetched from database.
+      # For now we need it here to not mixing concerns
+      ids = result.map(&:id).to_a
+      ids.blank? ? Service.where(id: ids) : Service.where(id: ids).order_by_ids(ids)
     end
 end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -23,7 +23,7 @@ module Service::Searchable
                      operator: "or",
                      where: { id: search_scope.ids },
                      page: params[:page], per_page: per_page,
-                     order: ordering,
+                     order: params[:sort].blank? ? nil : ordering,
                      match: :text_middle,
                      scope_results: ->(r) { r.includes(:research_areas, :providers, :target_groups).with_attached_logo }
     end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -22,6 +22,8 @@ module Service::Searchable
                      fields: ["title^10", "description"],
                      operator: "or",
                      where: { id: search_scope.ids },
-                     page: params[:page], per_page: per_page
+                     page: params[:page], per_page: per_page,
+                     order: ordering,
+                     scope_results: ->(r) { r.includes(:research_areas, :providers, :target_groups).with_attached_logo }
     end
 end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -3,10 +3,14 @@
 module Service::Searchable
   extend ActiveSupport::Concern
 
+  included do
+    include Paginable
+  end
+
   private
 
     def search(search_scope)
-      query_present? ? search_fields(search_scope) : search_scope
+      query_present? ? search_fields(search_scope) : paginate(search_scope)
     end
 
     def query_present?
@@ -14,15 +18,10 @@ module Service::Searchable
     end
 
     def search_fields(search_scope)
-      result = Service.search(params[:q],
-                            fields: ["title^10", "description"],
-                            operator: "or",
-                            where: { id: search_scope.ids })
-
-      # By default, ids are fetched from
-      # Elasticsearch and records are fetched from database.
-      # For now we need it here to not mixing concerns
-      ids = result.map(&:id).to_a
-      ids.blank? ? Service.where(id: ids) : Service.where(id: ids).order_by_ids(ids)
+      Service.search params[:q],
+                     fields: ["title^10", "description"],
+                     operator: "or",
+                     where: { id: search_scope.ids },
+                     page: params[:page], per_page: per_page
     end
 end

--- a/app/controllers/concerns/service/sortable.rb
+++ b/app/controllers/concerns/service/sortable.rb
@@ -4,22 +4,30 @@ module Service::Sortable
   extend ActiveSupport::Concern
 
   private
+    def order(scope)
+      if params[:q].present? && params[:sort].blank?
+        scope
+      else
+        scope.order(ordering)
+      end
+    end
+
     def ordering
       {}.tap do |sort_options|
         sort_key = params[:sort]
         unless params[:sort].blank?
-          if sort_key[0] == "-"
-            sort_key = sort_key[1..-1]
-            sort_options[sort_key] = :desc
-          else
-            sort_options[sort_key] = :asc
-          end
-        else
-          if params[:q].present?
+          if sort_key == "_score"
             return
           else
-            sort_options[:title] = :asc
+            if sort_key[0] == "-"
+              sort_key = sort_key[1..-1]
+              sort_options[sort_key] = :desc
+            else
+              sort_options[sort_key] = :asc
+            end
           end
+        else
+          sort_options[:title] = :asc
         end
       end
     end

--- a/app/controllers/concerns/service/sortable.rb
+++ b/app/controllers/concerns/service/sortable.rb
@@ -15,7 +15,11 @@ module Service::Sortable
             sort_options[sort_key] = :asc
           end
         else
-          sort_options[:title] = :asc
+          if params[:q].present?
+            return
+          else
+            sort_options[:title] = :asc
+          end
         end
       end
     end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -5,13 +5,12 @@ class ServicesController < ApplicationController
   include Service::Searchable
   include Service::Categorable
   include Service::Sortable
-  include Paginable
 
   def index
     filtered = filter(scope)
-    searched = search(filtered)
-    from_category = category_records(searched)
-    @services = paginate(ordering.nil? ? from_category : from_category.order(ordering))
+    from_category = category_records(filtered)
+
+    @services = search(from_category)
   end
 
   def show

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -10,7 +10,7 @@ class ServicesController < ApplicationController
     filtered = filter(scope)
     from_category = category_records(filtered)
 
-    @services = search(from_category)
+    @services = search(from_category.order(ordering))
   end
 
   def show

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -10,7 +10,7 @@ class ServicesController < ApplicationController
     filtered = filter(scope)
     from_category = category_records(filtered)
 
-    @services = search(from_category.order(ordering))
+    @services = search(order(from_category))
   end
 
   def show

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -8,11 +8,10 @@ class ServicesController < ApplicationController
   include Paginable
 
   def index
-    searched = search(scope)
-    filtered = filter(searched)
-    from_category = category_records(filtered)
-
-    @services = paginate(from_category.order(ordering))
+    filtered = filter(scope)
+    searched = search(filtered)
+    from_category = category_records(searched)
+    @services = paginate(ordering.nil? ? from_category : from_category.order(ordering))
   end
 
   def show

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -46,8 +46,4 @@ module ServiceHelper
   def providers_text(service)
     service.providers.map { |target| target.name }
   end
-
-  def total_services(services)
-    params[:q].present? ? services.total_count : services.total_entries
-  end
 end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -46,4 +46,8 @@ module ServiceHelper
   def providers_text(service)
     service.providers.map { |target| target.name }
   end
+
+  def total_services(services)
+    params[:q].present? ? services.total_count : services.total_entries
+  end
 end

--- a/app/javascript/controllers/order_controller.js
+++ b/app/javascript/controllers/order_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["select"]
+
+  connect(){}
+
+  initialize(){
+    let url = new URL(window.location.href)
+    if(url.searchParams.has("q") && !url.searchParams.has("sort"))
+      this.selectTarget.value = "_score"
+  }
+}

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -7,6 +7,8 @@ class Service < ApplicationRecord
   # and define which services are indexed in elasticsearch
   searchkick
   scope :search_import, -> { where(status: :published) }
+  # search_data are definition whitch
+  # fields are mapped to elasticsearch
   def search_data
     {
       title: title,

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,7 +5,7 @@ class Service < ApplicationRecord
   # ELASTICSEARCH
   # scope :search_import working with should_indexe?
   # and define which services are indexed in elasticsearch
-  searchkick
+  searchkick text_middle: [:title, :description]
   scope :search_import, -> { where(status: :published) }
   # search_data are definition whitch
   # fields are mapped to elasticsearch

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -135,15 +135,6 @@ class Service < ApplicationRecord
     published?
   end
 
-  def self.order_by_ids(ids)
-    order_by = ["CASE"]
-    ids.each_with_index do |id, index|
-      order_by << "WHEN id='#{id}' THEN #{index}"
-    end
-    order_by << "END"
-    order(Arel.sql(order_by.join(" ")))
-  end
-
   private
 
     def main_category_missing?

--- a/app/views/services/_order.html.haml
+++ b/app/views/services/_order.html.haml
@@ -3,4 +3,5 @@
     = options_for_select([["by name A-Z", "title"],
                           ["by name Z-A", "-title"],
                           ["by rate 1-5", "rating"],
-                          ["by rate 5-1", "-rating"]], params[:sort])
+                          ["by rate 5-1", "-rating"],
+                          [" ", nil]], params[:sort])

--- a/app/views/services/_order.html.haml
+++ b/app/views/services/_order.html.haml
@@ -1,7 +1,8 @@
-= form_tag url_for, method: :get, role: "search" do
-  %select#sort.query-sort.form-control.form-control-sm{ "data-submit-on-change": "data-submit-on-change" }
+= form_tag url_for, method: :get, role: "search", "data-controller": "order" do
+  %select#sort.query-sort.form-control.form-control-sm{ "data-target": "order.select",
+                                                        "data-submit-on-change": "data-submit-on-change" }
     = options_for_select([["by name A-Z", "title"],
                           ["by name Z-A", "-title"],
                           ["by rate 1-5", "rating"],
                           ["by rate 5-1", "-rating"],
-                          [" ", nil]], params[:sort])
+                          ["Best match", "_score"]], params[:sort])

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,1 +1,0 @@
-# frozen_string_literal: true

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,7 +1,1 @@
 # frozen_string_literal: true
-
-require "elasticsearch/model"
-
-if ENV["ELASTICSEARCH_URL"]
-  Elasticsearch::Model.client = Elasticsearch::Client.new(url: ENV["ELASTICSEARCH_URL"])
-end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require "elasticsearch/rails/tasks/import"

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -247,7 +247,7 @@ RSpec.feature "Service filtering and sorting" do
     expect(page).to have_selector(".media", count: 3)
   end
 
-  scenario "selecting sorting will set query param and preserve existing ones", js: true, search: true do
+  scenario "selecting sorting will set query param and preserve existing ones", js: true do
     visit services_path(q: "DDDD Something", utf8: "✓")
 
     select "by rate 1-5", from: "sort"

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -219,10 +219,12 @@ RSpec.feature "Service filtering and sorting" do
     create(:service, title: "DDDD Something 2", rating: 4.0, platforms: [platform_2], categories: [category_1])
     create(:service, title: "DDDD Something 3", rating: 3.9, platforms: [platform_2], categories: [category_1])
 
+    Service.reindex
+
     sleep(1)
   end
 
-  scenario "searching in top bar will preserve existing query params", js: true do
+  scenario "searching in top bar will preserve existing query params", js: true, search: true do
     visit services_path(sort: "title")
 
     fill_in "q", with: "DDDD Something"
@@ -234,7 +236,7 @@ RSpec.feature "Service filtering and sorting" do
     expect(page).to have_selector(".media", count: 3)
   end
 
-  scenario "clicking filter button in side bar will preserve existing query params", js: true do
+  scenario "clicking filter button in side bar will preserve existing query params", js: true, search: true do
     visit services_path(sort: "title", q: "DDDD Something", utf8: "✓")
 
     click_on(id: "filter-submit")
@@ -245,7 +247,7 @@ RSpec.feature "Service filtering and sorting" do
     expect(page).to have_selector(".media", count: 3)
   end
 
-  scenario "selecting sorting will set query param and preserve existing ones", js: true do
+  scenario "selecting sorting will set query param and preserve existing ones", js: true, search: true do
     visit services_path(q: "DDDD Something", utf8: "✓")
 
     select "by rate 1-5", from: "sort"
@@ -253,8 +255,8 @@ RSpec.feature "Service filtering and sorting" do
     # For turbolinks to load
     sleep(1)
 
-    expect(page.body.index("DDDD Something 3")).to be < page.body.index("DDDD Something 2")
-    expect(page.body.index("DDDD Something 2")).to be < page.body.index("DDDD Something 1")
+    expect(page.body.index("DDDD Something 3")).to be > page.body.index("DDDD Something 2")
+    expect(page.body.index("DDDD Something 2")).to be > page.body.index("DDDD Something 1")
   end
 
   scenario "limit number of services per page" do

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -255,8 +255,8 @@ RSpec.feature "Service filtering and sorting" do
     # For turbolinks to load
     sleep(1)
 
-    expect(page.body.index("DDDD Something 3")).to be > page.body.index("DDDD Something 2")
-    expect(page.body.index("DDDD Something 2")).to be > page.body.index("DDDD Something 1")
+    expect(page.body.index("DDDD Something 3")).to be < page.body.index("DDDD Something 2")
+    expect(page.body.index("DDDD Something 2")).to be < page.body.index("DDDD Something 1")
   end
 
   scenario "limit number of services per page" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,20 @@ require "support/tasks"
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+
+  config.before(:suite) do
+    # reindex models
+    Service.reindex
+
+    # and disable callbacks
+    Searchkick.disable_callbacks
+  end
+
+  config.around(:each, search: true) do |example|
+    Searchkick.callbacks(true) do
+      example.run
+    end
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Added searchkick as gem to elasticsearch. 
In elastic search are stored title, descriprion, status and rating. 
Services are searched based on title and description. Title is boosted.
Misspelling is set by default. Also added search by substring. 
Changed order of filtering and searching. Now services are firstly filtered.  

Fixed: #756, #757, #758
