### PR TITLE
[#779] Provider external ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - Link to the tutorial of creating attributes in backoffice (@goreck888)
+- External ID input to backoffice provider's form (@michal-szostak)
 
 ### Changed
 - Filters refactored and moved into `Service::Filterable` concern (@mkasztelnik)
 - Filters cleared when user type new query (@mkasztelnik)
 - Filters not cleared when changing category (@mkasztelnik)
+- Button styling in backoffice provider form (@michal-szostak)
 
 ### Deprecated
 

--- a/app/controllers/backoffice/providers_controller.rb
+++ b/app/controllers/backoffice/providers_controller.rb
@@ -13,6 +13,7 @@ class Backoffice::ProvidersController < Backoffice::ApplicationController
 
   def new
     @provider = Provider.new
+    @provider.sources.build source_type: "eic"
     authorize(@provider)
   end
 
@@ -29,6 +30,9 @@ class Backoffice::ProvidersController < Backoffice::ApplicationController
   end
 
   def edit
+    if @provider.sources.empty?
+      @provider.sources.build source_type: "eic"
+    end
   end
 
   def update

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -7,4 +7,10 @@ class Provider < ApplicationRecord
   has_many :categories, through: :service_categories
 
   validates :name, presence: true
+
+  has_many :sources, source: :provider_sources, class_name: "ProviderSource", dependent: :destroy
+
+  accepts_nested_attributes_for :sources,
+                                reject_if: lambda { |attributes| attributes["eid"].blank? || attributes["source_type"].blank? },
+                                allow_destroy: true
 end

--- a/app/models/provider_source.rb
+++ b/app/models/provider_source.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ProviderSource < ApplicationRecord
+  enum source_type: { eic: "eic" }
+  belongs_to :provider, inverse_of: :sources
+
+  validates :eid, presence: true
+  validates :source_type, presence: true
+
+  def to_s
+    "#{source_type}: #{eid}"
+  end
+end

--- a/app/policies/backoffice/provider_policy.rb
+++ b/app/policies/backoffice/provider_policy.rb
@@ -32,7 +32,7 @@ class Backoffice::ProviderPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name]
+    [:name, sources_attributes: [:id, :source_type, :eid, :_destroy]]
   end
 
   private

--- a/app/views/backoffice/providers/_form.html.haml
+++ b/app/views/backoffice/providers/_form.html.haml
@@ -1,6 +1,21 @@
 = simple_form_for [:backoffice, provider] do |f|
   = f.input :name
 
-  .btn-group
-    = f.button :submit, class: "btn btn-success"
-    = back_link_to "Cancel", provider, prefix: :backoffice, class: "btn btn-secondary"
+  %h3 External Sources
+
+  = f.fields_for :sources do |sources_form|
+    = sources_form.hidden_field :id
+    = sources_form.input :source_type, collection: ProviderSource.source_types.keys.map(&:to_sym)
+    = sources_form.input :eid, label: "eInfraCentral External ID"
+    - unless sources_form.object.id.nil?
+      = sources_form.check_box :_destroy
+      = sources_form.label :_destroy, "Remove external source"
+
+
+  %hr.bottom-hr.mt-5.mb-4
+  .row.mt-5
+    .col-12
+
+      = f.button :submit, class: "btn btn-primary pl-5 pr-5 mr-5"
+      = back_link_to "Cancel and back to previous page", provider, prefix: :backoffice,
+        class: "text-left flex-grow-1 text-uppercase"

--- a/app/views/backoffice/providers/show.html.haml
+++ b/app/views/backoffice/providers/show.html.haml
@@ -2,6 +2,12 @@
 
 %h1= @provider.name
 
+- unless @provider.sources.empty?
+  %h3 External Sources:
+  %ul
+    - @provider.sources.each do |source|
+      %li "#{source.source_type}: #{source.eid}"
+
 .btn-group
   - if policy([:backoffice, @provider]).edit?
     = link_to "Edit",

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -59,6 +59,9 @@
     .col-12.col-md-5
       = f.input :upstream_id, collection: f.object.sources.reject { |source| source.id.nil? },
                               include_blank: "MP", label: "Service Upstream"
+
+      %h3 External Sources
+
       = f.fields_for :sources do |sources_form|
         = sources_form.hidden_field :id
         = sources_form.input :source_type, collection: ServiceSource.source_types.keys.map(&:to_sym)

--- a/db/migrate/20190326203609_create_provider_sources_table.rb
+++ b/db/migrate/20190326203609_create_provider_sources_table.rb
@@ -1,0 +1,11 @@
+class CreateProviderSourcesTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :provider_sources do |t|
+      t.string :eid, null: false
+      t.string :source_type, null: false
+      t.belongs_to :provider, index: true, null: false
+      t.timestamps
+    end
+    add_index :provider_sources, [:eid, :source_type, :provider_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_06_111257) do
+ActiveRecord::Schema.define(version: 2019_03_26_203609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,11 +90,34 @@ ActiveRecord::Schema.define(version: 2019_03_06_111257) do
     t.datetime "updated_at", null: false
     t.jsonb "parameters"
     t.boolean "voucherable", default: false, null: false
-    t.string "status"
     t.string "offer_type"
+    t.string "status"
     t.index ["iid"], name: "index_offers_on_iid"
     t.index ["service_id", "iid"], name: "index_offers_on_service_id_and_iid", unique: true
     t.index ["service_id"], name: "index_offers_on_service_id"
+  end
+
+  create_table "order_changes", force: :cascade do |t|
+    t.string "status"
+    t.text "message"
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "author_id"
+    t.index ["author_id"], name: "index_order_changes_on_author_id"
+    t.index ["order_id"], name: "index_order_changes_on_order_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.string "status", null: false
+    t.bigint "service_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "issue_id"
+    t.integer "issue_status", default: 2, null: false
+    t.index ["service_id"], name: "index_orders_on_service_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "platforms", force: :cascade do |t|
@@ -154,6 +177,16 @@ ActiveRecord::Schema.define(version: 2019_03_06_111257) do
     t.string "company_website_url"
     t.index ["name", "user_id"], name: "index_projects_on_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_projects_on_user_id"
+  end
+
+  create_table "provider_sources", force: :cascade do |t|
+    t.string "eid", null: false
+    t.string "source_type", null: false
+    t.bigint "provider_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["eid", "source_type", "provider_id"], name: "index_provider_sources_on_eid_and_source_type_and_provider_id", unique: true
+    t.index ["provider_id"], name: "index_provider_sources_on_provider_id"
   end
 
   create_table "providers", force: :cascade do |t|

--- a/spec/factories/provider_sources.rb
+++ b/spec/factories/provider_sources.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :provider_source do
+    source_type { ProviderSource.source_types.keys.sample }
+    sequence(:eid) { |n| n }
+  end
+end

--- a/spec/features/backoffice/providers_spec.rb
+++ b/spec/features/backoffice/providers_spec.rb
@@ -50,5 +50,41 @@ RSpec.feature "Providers in backoffice" do
 
       expect(page).to have_content("New name")
     end
+
+    scenario "I can create provider with external source" do
+      visit backoffice_providers_path
+      click_on "New Provider"
+
+      fill_in "Name", with: "My new provider"
+      fill_in "provider_sources_attributes_0_eid", with: "12345a"
+
+      expect { click_on "Create Provider" }.
+          to change { Provider.count }.by(1)
+
+      expect(page).to have_content("My new provider")
+      expect(page).to have_content("eic: 12345a")
+    end
+
+    scenario "I can change external id of the provider" do
+      provider = create(:provider, name: "Old name")
+      external_source = create(:provider_source, eid: "777abc", source_type: "eic", provider: provider)
+
+      visit edit_backoffice_provider_path(provider)
+
+      expect(page).to have_selector("input[value='777abc']")
+      fill_in "provider_sources_attributes_0_eid", with: "12345a"
+      click_on "Update Provider"
+      expect(page).to have_content("eic: 12345a")
+    end
+
+    scenario "I can delete external source" do
+      provider = create(:provider)
+      external_source = create(:provider_source, eid: "777abc", source_type: "eic", provider: provider)
+
+      visit edit_backoffice_provider_path(provider)
+      find(:css, "#provider_sources_attributes_0__destroy").set(true)
+      expect { click_on "Update Provider" }.to change { ProviderSource.count }.by(-1)
+
+    end
   end
 end

--- a/spec/models/provider_source_spec.rb
+++ b/spec/models/provider_source_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProviderSource, type: :model do
+  it { should validate_presence_of(:eid) }
+  it { should validate_presence_of(:source_type) }
+
+  it { should belong_to(:provider) }
+end


### PR DESCRIPTION
## What is in this PR?

* Add DB table storing provider's external IDs
* Add form controls to provider's backoffice form allowing setting of
  external sources
* Update backoffice provider form's buttons styling to match services
* Add information about external sources to backoffice provider's detail
  view

## How does it look like?

![image](https://user-images.githubusercontent.com/13235269/55036160-0a148700-501a-11e9-83a9-3d9d4cb4681f.png)

**NOTE** this feature is a blocker for #658 

Closes: #779