### PR TITLE
Link to all services should contain all filter params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Link to all services should contain filter params (@mkasztelnik)
 
 ### Security
 

--- a/app/views/services/nav/_categories.html.haml
+++ b/app/views/services/nav/_categories.html.haml
@@ -2,7 +2,7 @@
 
 %h5.text-uppercase.underline-light.mb-2.pb-2 Categories
 #all-services-link{ class: "d-flex justify-content-between align-items-center #{active}" }
-  = link_to "All Services", content_for(:all_services) || services_path
+  = link_to "All Services", content_for(:all_services) || services_path(category_query_params)
   %span= Service.published.count
 %ul.categories-list
   - view = content_for(:category_view) || "services/nav/category"


### PR DESCRIPTION
Filter query params were removed by @jarekzet during #775, here I'm restoring original behavior.