### PR TITLE
[#804] Add constrains disallowing null in attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Use searchkick reindex in setup instead of elasticsearch import (@martaswiatkowska)
 - Show 404 error page when affiliation is not found (@mkasztelnik)
 - Use custom error pages with webpage layout in production environment (@mkasztelnik)
+- Fix bug with JIRA issue creation (attribute mapping to SO-1) (@michal-szostak)
 
 ### Security
 

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -31,6 +31,7 @@ class Offer < ApplicationRecord
   validates :status, presence: true
   validate :parameters_are_valid_attributes, on: [:create, :update]
   validates :parameters_as_string, attribute_id_unique: true
+  validate :parameters_not_nil
 
   attr_writer :parameters_as_string
 
@@ -94,5 +95,11 @@ class Offer < ApplicationRecord
 
     def offers_count
       service && service.offers.maximum(:iid).to_i || 0
+    end
+
+    def parameters_not_nil
+      if self.parameters.nil?
+        errors.add :parameters, "cannot be nil"
+      end
     end
 end

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -55,6 +55,7 @@ class ProjectItem < ApplicationRecord
   validates :voucher_id, absence: true, if: :voucher_id_unwanted?
   validates :voucher_id, presence: true, allow_blank: false, if: :voucher_id_required?
   validate :one_per_project?, on: :create
+  validate :properties_not_nil
 
   delegate :user, to: :project
 
@@ -127,5 +128,11 @@ class ProjectItem < ApplicationRecord
 
   def voucher_id_unwanted?
     created? && !voucher_id_required?
+  end
+
+  def properties_not_nil
+    if self.properties.nil?
+      errors.add :properties, "cannot be nil"
+    end
   end
 end

--- a/app/models/project_item/attributes.rb
+++ b/app/models/project_item/attributes.rb
@@ -5,7 +5,10 @@ class ProjectItem::Attributes
 
   def initialize(offer:, parameters: nil)
     @offer = offer
-    @attributes = attributes_from_params(parameters || offer.parameters.dup || [])
+    if parameters.blank?
+      parameters = offer.parameters.dup
+    end
+    @attributes = attributes_from_params(parameters)
   end
 
   def update(values)

--- a/db/migrate/20190408130702_update_nil_parameters.rb
+++ b/db/migrate/20190408130702_update_nil_parameters.rb
@@ -1,0 +1,6 @@
+class UpdateNilParameters < ActiveRecord::Migration[5.2]
+  def up
+    execute("UPDATE offers set parameters = '[]' where parameters IS NULL;")
+    execute("UPDATE project_items set properties = '[]' where properties IS NULL;")
+  end
+end

--- a/db/migrate/20190408131319_change_offers_parameters_default.rb
+++ b/db/migrate/20190408131319_change_offers_parameters_default.rb
@@ -1,0 +1,9 @@
+class ChangeOffersParametersDefault < ActiveRecord::Migration[5.2]
+  def up
+    change_column :offers, :parameters, :jsonb, default: [], null: false
+  end
+
+  def down
+    change_column :offers, :parameters, :jsonb, default: nil, null: true
+  end
+end

--- a/db/migrate/20190408131604_change_project_item_properties_default.rb
+++ b/db/migrate/20190408131604_change_project_item_properties_default.rb
@@ -1,0 +1,9 @@
+class ChangeProjectItemPropertiesDefault < ActiveRecord::Migration[5.2]
+  def up
+    change_column :project_items, :properties, :jsonb, default: [], null: false
+  end
+
+  def down
+    change_column :project_items, :properties, :jsonb, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_26_203609) do
+ActiveRecord::Schema.define(version: 2019_04_08_131604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,7 +88,7 @@ ActiveRecord::Schema.define(version: 2019_03_26_203609) do
     t.bigint "service_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.jsonb "parameters"
+    t.jsonb "parameters", default: [], null: false
     t.boolean "voucherable", default: false, null: false
     t.string "offer_type"
     t.string "status"
@@ -150,7 +150,7 @@ ActiveRecord::Schema.define(version: 2019_03_26_203609) do
     t.text "access_reason"
     t.text "additional_information"
     t.bigint "affiliation_id"
-    t.jsonb "properties"
+    t.jsonb "properties", default: [], null: false
     t.text "user_group_name"
     t.string "project_name"
     t.string "project_website_url"

--- a/spec/factories/project_items.rb
+++ b/spec/factories/project_items.rb
@@ -14,7 +14,6 @@ FactoryBot.define do
 
     voucher_id { "" }
     request_voucher { false }
-    properties { [] }
 
     offer
     project

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -74,6 +74,7 @@ RSpec.feature "Service ordering" do
       end.to change { ProjectItem.count }.by(1)
       project_item = ProjectItem.last
       expect(project_item.offer_id).to eq(offer.id)
+      expect(project_item.properties).to eq([])
 
       # Summary
       expect(page).to have_current_path(service_summary_path(service))

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -19,4 +19,14 @@ RSpec.describe Offer do
       expect(offer.offer_type).to eq "catalog"
     end
   end
+
+  context "#parameters" do
+    it "should disallow null" do
+      expect(build(:offer, parameters: nil).valid?).to be_falsey
+    end
+
+    it "should defaults to []" do
+      expect(create(:offer).reload.parameters).to eq([])
+    end
+  end
 end

--- a/spec/models/project_item_spec.rb
+++ b/spec/models/project_item_spec.rb
@@ -125,4 +125,14 @@ RSpec.describe ProjectItem do
       expect(subject).to validate_absence_of(:request_voucher)
     end
   end
+
+  context "#properties" do
+    it "should disallow null" do
+      expect(build(:project_item, properties: nil).valid?).to be_falsey
+    end
+
+    it "should defaults to []" do
+      expect(create(:project_item).reload.properties).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
## What is in this PR?

* Add constraints to disallow null in properties and parameters
  (project_item, offer)

* Add data migration to change all nulls in those columns to `[]`

Closes: #804