### PR TITLE
[#803] Fix edit and delete affiliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Fix bug with JIRA issue creation (attribute mapping to SO-1) (@michal-szostak)
 - Remove std out/err logs from test suite output (@mkasztelnik)
 - Fix show opinions for open access services (@mkasztelnik)
+- Fix authorising affiliation from user affiliations, not affiliations at all (@goreck888)
 
 ### Security
 

--- a/app/controllers/profiles/affiliations_controller.rb
+++ b/app/controllers/profiles/affiliations_controller.rb
@@ -52,7 +52,7 @@ class Profiles::AffiliationsController < ApplicationController
     end
 
     def find_and_authorize
-      @affiliation = Affiliation.find_by!(iid: params[:id])
+      @affiliation = current_user.affiliations.find_by!(iid: params[:id])
       authorize(@affiliation)
     end
 end


### PR DESCRIPTION
From now query for user affiliations includes user id.

Before this fix query for edit and delete affiliation included just iid which is counted from 1 for every user, so query has returned all affiliations with current iid.