### PR TITLE
Don't close filter in the test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Don't close already opened filter in test (@mkasztelnik)
 
 ### Security
 

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -287,7 +287,6 @@ RSpec.feature "Service filtering and sorting" do
     expect(page).to have_selector("input[name='providers[]']", count: 7)
     find(:css, "input[name='providers[]'][value='#{Provider.order(:name).last.id}']").set(true)
     click_on(id: "filter-submit")
-    find(:css, "a[href=\"#collapse_providers\"][role=\"button\"] h6").click
 
     expect(page).to have_selector("input[name='providers[]']", count: 6)
   end


### PR DESCRIPTION
When a filter is selected it is by default opened, clicking on the collapse button will close it. This triggers an error in the spec (what worse this was random failing test - it seems like from time to time JS was not quick enough to add hide class and this test passed).