### PR TITLE
Do not duplicate presented services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Don't close already opened filter in test (@mkasztelnik)
+- Don't duplicate results when service belongs to e.g. 2 selected in filter
+  providers (@mkasztelnik)
 
 ### Security
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -4,8 +4,6 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
   include Service::Filterable
   include Service::Searchable
   include Service::Categorable
-  include Service::Sortable
-  include Paginable
   include Service::Autocomplete
 
   before_action :find_and_authorize, only: [:show, :edit, :update, :destroy]
@@ -14,8 +12,8 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
   def index
     filtered = filter(scope)
     from_category = category_records(filtered)
+    from_search = search(from_category)
 
-    from_search = search(order(from_category))
     @services = from_search
     @highlights = highlights(from_search)
   end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -5,13 +5,14 @@ module Service::Searchable
 
   included do
     include Paginable
+    include Service::Sortable
+  end
+
+  def search(search_scope)
+    query_present? ? search_fields(search_scope) : paginate(order(search_scope.distinct))
   end
 
   private
-
-    def search(search_scope)
-      query_present? ? search_fields(search_scope) : paginate(search_scope)
-    end
 
     def query_present?
       params[:q].present?

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -4,14 +4,13 @@ class ServicesController < ApplicationController
   include Service::Filterable
   include Service::Searchable
   include Service::Categorable
-  include Service::Sortable
   include Service::Autocomplete
 
   def index
     filtered = filter(scope)
     from_category = category_records(filtered)
+    from_search = search(from_category)
 
-    from_search = search(order(from_category))
     @services = from_search
     @highlights = highlights(from_search)
   end

--- a/spec/controllers/concerns/searchable_spec.rb
+++ b/spec/controllers/concerns/searchable_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    attr_accessor :params
+    include Service::Searchable
+  end
+
+  context "#search" do
+    it "don't duplicate results when service belongs to many providers" do
+      provider1, provider2 = create_list(:provider, 2)
+      create(:service, providers: [provider1, provider2])
+
+      # scope.count == 2 => results are duplicated
+      scope = Service.joins(:service_providers).
+        where(service_providers: { provider_id: [provider1.id, provider2.id] })
+
+      expect(controller.search(scope).count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Results were duplicated in the following scenario:
  * only the filter was used (no elasticsearch) to limit shown services
  * service belongs to 2 or more selected elements in the multi-select filter

`distinct` solves this issue.