### PR TITLE
[#852] Fixed url createion in autocomplete_controller.js

### DIFF
--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -179,8 +179,8 @@ export default class extends Controller {
 
     if (!this.src) return
 
-    const url = new URL(this.src, window.location.href)
-    const params = new URLSearchParams(url.search.slice(1))
+    const url = new URL(this.src, window.location.origin)
+    const params = new URLSearchParams(window.location.search)
     params.append('q', query)
     url.search = params.toString()
 


### PR DESCRIPTION
When user choose category url are changing in search_url_controller.js. That's why autocomplete url looked like  .../services/c/service_autocomplete not .../service_autocomplete and that's why search tips didn't work

Fix #852 