### PR TITLE
Deleted elasticsearch scope_import and use pundit scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Don't add `+` instead of space to query value during filtering (@mkasztelnik)
+- Showing draft services on search in backoffice (@martaswiatkowska)
 
 ### Security
 

--- a/app/controllers/concerns/service/autocomplete.rb
+++ b/app/controllers/concerns/service/autocomplete.rb
@@ -10,6 +10,7 @@ module Service::Autocomplete
       match: :word_middle,
       limit: 5,
       load: false,
+      where: { id: scope.ids },
       highlight: { tag: "<b>" }
     )
 
@@ -19,7 +20,6 @@ module Service::Autocomplete
   end
 
   private
-
     def generate_html(query)
       html_results = query.highlights.map.with_index { |s, i| "<li class=\"dropdown-item\" role=\"option\" data-autocomplete-value=\"#{i}\">#{s[:title]}</li>" }.join
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,7 +6,6 @@ class Service < ApplicationRecord
   # scope :search_import working with should_indexe?
   # and define which services are indexed in elasticsearch
   searchkick word_middle: [:title, :tagline, :description], highlight: [:title, :tagline]
-  scope :search_import, -> { where(status: :published) }
 
   # search_data are definition whitch
   # fields are mapped to elasticsearch
@@ -130,12 +129,6 @@ class Service < ApplicationRecord
 
   def aod?
     platforms.pluck(:name).include?("EGI Applications on Demand")
-  end
-
-  # should_index? define
-  # which records are indexed in elasticsearch
-  def should_index?
-    published?
   end
 
   private

--- a/app/views/backoffice/services/_search.html.haml
+++ b/app/views/backoffice/services/_search.html.haml
@@ -2,7 +2,7 @@
   = form_tag url_for, method: :get, role: "search",
              "data-target": "autocomplete.form",
              "data-controller": "autocomplete",
-             "data-autocomplete-url": "service_autocomplete" do
+             "data-autocomplete-url": "backoffice/service_autocomplete" do
 
     .input-group
       %label.sr-only{ for: "search" } Search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
         resource :draft, only: :create
       end
     end
+    get "service_autocomplete", to: "services#autocomplete", as: :service_autocomplete
     get "services/c/:category_id" => "services#index", as: :category_services
     resources :research_areas
     resources :categories


### PR DESCRIPTION
The pundit scope was used instead of searchkick scope to resolve problems with not showing draft services after search in backoffice. That's why, the autocomplete concer was turned into a helper.