### PR TITLE
Fix spaces included instead of spaces when filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Don't add `+` instead of space to query value during filtering (@mkasztelnik)
 
 ### Security
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,7 +24,7 @@ library.add(fas, far);
 import { Application } from "stimulus"
 import { definitionsFromContext } from "stimulus/webpack-helpers"
 import "./sort_filter"
-import initSortingAndFiltering from "./sort_filter";
+import initSorting from "./sort_filter";
 import initFlash from "./flash";
 import initChoises from "./choises";
 
@@ -38,7 +38,7 @@ document.addEventListener("turbolinks:before-render", function(event) {
         node: event.data.newBody
     });
     starsOnClick(event.data.newBody);
-    initSortingAndFiltering(event.data.newBody);
+    initSorting(event.data.newBody);
     dom.watch();
 });
 
@@ -52,7 +52,7 @@ document.addEventListener("turbolinks:load", function(event) {
 document.addEventListener('DOMContentLoaded', function () {
     dom.i2svg();
     starsOnClick();
-    initSortingAndFiltering();
+    initSorting();
     initFlash();
     dom.watch();
 });

--- a/app/javascript/packs/sort_filter.js
+++ b/app/javascript/packs/sort_filter.js
@@ -40,22 +40,6 @@ function setSearchParams(search, params) {
     return parts.join('&');
 }
 
-export function syncQueryForm(node) {
-    let params = searchToObj(window.location.search);
-    $(node || 'body').find("[data-sync-query-form]").each(function() {
-        let _params = {...params};
-        $(this).find("input").add($(this).find("select")).each(function() {
-            let encodedName = encodeURI($(this).attr('name'));
-            if(encodedName in _params)
-                delete _params[encodedName];
-        });
-
-        for(let key in _params) {
-            $(this).append($(`<input type="hidden" id="${decodeURI(key)}" name="${decodeURI(key)}" value="${_params[key]}" />`));
-        }
-    });
-}
-
 export function registerSubmitOnChange(node) {
     $(node || 'body').find("[data-submit-on-change]").on('change', function () {
         let id = $(this).attr('id');
@@ -66,7 +50,6 @@ export function registerSubmitOnChange(node) {
     });
 }
 
-export default function initSortingAndFiltering(node) {
-    syncQueryForm(node);
+export default function initSorting(node) {
     registerSubmitOnChange(node);
 }

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -8,7 +8,8 @@
         Collapse All
 
 
-  = form_tag "", method: :get, role: "search", class: "filters", "data-sync-query-form": "data-sync-query-form" do
+  = form_tag "", method: :get, role: "search", class: "filters"  do
+    = hidden_field_tag :q, params[:q] if params[:q].present?
     - @filters.each do |filter|
       = render "services/filters/#{filter.type}", filter: filter
 

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -16,7 +16,7 @@
   .col-md-12.mb-2
     %h1.categories
       - unless params[:q].blank?
-        Looking for: #{CGI.unescape(params[:q])}
+        Looking for: #{params[:q]}
       - else
         = @category&.name || "Services"
     .col-md-12.mb-1


### PR DESCRIPTION
The bug was connected with a difference in how rails and js escaping query params. This issue was solved by simplifying the way how hidden query value param is added to the filtering section. Previously it was done using JS, not it is done while rendering the page.

Fixes #826