### PR TITLE
Remove rating filter from the view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Deprecated
 
 ### Removed
+- Remove rating filter from the view until we have enough ratings to show it (@mkasztelnik)
 
 ### Fixed
 

--- a/app/controllers/concerns/service/filterable.rb
+++ b/app/controllers/concerns/service/filterable.rb
@@ -36,7 +36,8 @@ module Service::Filterable
         Filter::Provider,
         Filter::TargetGroup,
         Filter::Platform,
-        Filter::Rating,
+        # Temporary removed because of #858
+        # Filter::Rating,
         Filter::Location,
         Filter::Tag
       ]

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -335,6 +335,8 @@ RSpec.feature "Service filtering and sorting" do
   end
 
   scenario "searching via rating", js: true do
+    pending "Temporary rating filter was removed from the view, see #858"
+
     visit services_path
 
     find(:css, "a[href=\"#collapse_rating\"][role=\"button\"] h6").click
@@ -391,15 +393,10 @@ RSpec.feature "Service filtering and sorting" do
   end
 
   scenario "delete all filters", js: true do
-    visit services_path
+    visit services_path(target_groups: [target_group.id])
 
-    # set filters
-    find(:css, "a[href=\"#collapse_rating\"][role=\"button\"] h6").click
-    select "★★★★★", from: "rating"
-
-    click_on(id: "filter-submit")
-
-    expect(page).to have_selector(".media", count: 1)
+    # With filters applied
+    expect(page).to have_selector(".media", count: 3)
 
     # click clear filters
     click_on("Clear all filters")


### PR DESCRIPTION
It was removed because we don't have enough service ratings yet.

Fixes #858 