### PR TITLE
Improve empty project description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 
 ### Changed
+- Improve empty project description (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/views/projects/_empty_project.html.haml
+++ b/app/views/projects/_empty_project.html.haml
@@ -1,2 +1,3 @@
 %li.list-group-item
-  Empty project
+  You have no services in this project.
+  = link_to "Use our catalogue to add one", services_path


### PR DESCRIPTION
Right now it looks like that

![new-project-description](https://user-images.githubusercontent.com/1265430/58001139-eed66d00-7ada-11e9-9dd5-927a9b071aee.png)

Fixes #839 