### PR TITLE
[#891] Block access to the draft service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Blocked access to the draft service via direct link
 
 ### Security
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -19,6 +19,7 @@ class ServicesController < ApplicationController
     @service = Service.
                includes(:offers, related_services: :providers).
                friendly.find(params[:id])
+    authorize @service
     @offers = policy_scope(@service.offers)
     @related_services = @service.related_services
 

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -8,7 +8,7 @@ class ServicePolicy < ApplicationPolicy
   end
 
   def show?
-    true
+    record.published?
   end
 
   def order?

--- a/config/locales/pundit.en.yml
+++ b/config/locales/pundit.en.yml
@@ -4,3 +4,7 @@ en:
     affiliation_policy:
       "edit?": "You cannot edit an affiliation which has been activated"
       "destroy?": "You cannot remove an affiliation which has a project item"
+    service_policy:
+      "show?": "This service is not published in the Marketplace yet, therefore it cannot be accessed.
+        If you are the Service Owner or Service Portfolio Manager and wish to manage this service,
+        please log in and go to the Backoffice tab."

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -21,6 +21,16 @@ RSpec.feature "Service browsing" do
       expect(body).to have_content "my-tag"
     end
 
+    scenario "not allows to see draft service via direct link for default user" do
+      service = create(:service, status: :draft)
+      visit service_path(service)
+
+      expect(page).to have_content("This service is not published in the Marketplace yet, " +
+      "therefore it cannot be accessed. If you are the Service Owner or Service Portfolio Manager and wish " +
+      "to manage this service, please log in and go to the Backoffice tab.")
+      expect(current_path).to eq(root_path)
+    end
+
     scenario "I see Ask Question" do
       service = create(:service)
 


### PR DESCRIPTION
**What's in this PR?**
This PR fixes bug which is described in https://app.zenhub.com/workspaces/cyfronet-fid-5b1e4b786c29461038c37df5/issues/cyfronet-fid/marketplace/891 

Changes:
Add authorization for services
Add policy blocking access to the draft if user isn't service_portfolio_manager, 
because this is a kind of sample service view and I won't block to allow managers to get this view.