### PR TITLE
[#783] Service counters fix. Filters and categories moved to elasticsearch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,18 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Changed
 
 - Redirection to a service upon choice made by autocomplete in search bar (@bwilk)
+- Reimplemented filters and categories after creating indexes in Elasticsearch (@bwilk) 
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
 - Blocked access to the draft service via direct link
+- Category and filter counters (@bwilk)
+- Hierarchical filters deactivation buttons (@bwilk)
+- Choice of "best match" sorting strategy after search (@bwilk)
 
 ### Security
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -13,12 +13,8 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
     if params["service_id"].present?
       redirect_to [:backoffice, Service.find(params["service_id"])]
     end
-    filtered = filter(scope)
-    from_category = category_records(filtered)
-    from_search = search(from_category)
-
-    @services = from_search
-    @highlights = highlights(from_search)
+    @services = search_and_filter(scope)
+    @highlights = highlights(@services)
   end
 
   def show

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -11,6 +11,6 @@ module Paginable
 
     def per_page
       per_page = params[:per_page].to_i
-      per_page == 0 ? 10 : per_page
+      per_page < 1 ? 10 : per_page
     end
 end

--- a/app/controllers/concerns/service/categorable.rb
+++ b/app/controllers/concerns/service/categorable.rb
@@ -32,7 +32,7 @@ module Service::Categorable
     end
 
     def categories_scope
-      @categories_scope ||= search_for_categories(scope)
+      @categories_scope ||= search_for_categories(scope, filters)
     end
 
     def counters

--- a/app/controllers/concerns/service/categorable.rb
+++ b/app/controllers/concerns/service/categorable.rb
@@ -4,6 +4,7 @@ module Service::Categorable
   extend ActiveSupport::Concern
 
   included do
+    include Service::Searchable
     before_action :init_categories_tree, only: :index
   end
 
@@ -11,15 +12,7 @@ module Service::Categorable
     def init_categories_tree
       @siblings = siblings
       @subcategories = category&.children&.order(:name)
-    end
-
-    def category_records(search_scope)
-      if category
-        search_scope.joins(:categorizations).
-          where(categorizations: { category_id: category_and_descendant_ids })
-      else
-        search_scope
-      end
+      @siblings_with_counters = siblings_with_counters
     end
 
     def category
@@ -33,4 +26,20 @@ module Service::Categorable
     def siblings
       category&.ancestry.nil? ? @root_categories : category.parent.children.order(:name)
     end
+
+    def siblings_with_counters
+      siblings.inject({}) { |h, cat| h[cat.id] = {category: cat, counter: counters[cat.id] || 0}; h}
+    end
+
+    def categories_scope
+      @categories_scope ||= search_for_categories(scope)
+    end
+
+    def counters
+      @counters ||= categories_scope.aggregations["categories"]["categories"]["buckets"].
+          inject({}){ |h, e| h[e["key"]]=e["doc_count"]; h}
+      @services_total ||= categories_scope.aggregations["categories"]["doc_count"]
+      @counters
+    end
+
 end

--- a/app/controllers/concerns/service/categorable.rb
+++ b/app/controllers/concerns/service/categorable.rb
@@ -11,35 +11,37 @@ module Service::Categorable
   private
     def init_categories_tree
       @siblings = siblings
-      @subcategories = category&.children&.order(:name)
+      @subcategories = subcategories
       @siblings_with_counters = siblings_with_counters
+      @subcategories_with_counters = subcategories_with_counters
+      @services_total ||= counters[nil]
     end
 
     def category
       @category ||= Category.friendly.find(params[:category_id]) if params[:category_id]
     end
 
-    def category_and_descendant_ids
-      [category] + category.descendant_ids
+    def siblings
+      category&.ancestry.nil? ? @root_categories : category.siblings.order(:name)
     end
 
-    def siblings
-      category&.ancestry.nil? ? @root_categories : category.parent.children.order(:name)
+    def subcategories
+      category&.children&.order(:name)
     end
 
     def siblings_with_counters
-      siblings.inject({}) { |h, cat| h[cat.id] = {category: cat, counter: counters[cat.id] || 0}; h}
+      siblings.inject({}) { |h, cat| h[cat.id] = { category: cat, counter: count_services(cat) }; h }
     end
 
-    def categories_scope
-      @categories_scope ||= search_for_categories(scope, filters)
+    def subcategories_with_counters
+      subcategories&.inject({}) { |h, cat| h[cat.id] = { category: cat, counter: count_services(cat) }; h }
+    end
+
+    def count_services(category)
+      (counters[category.id] || 0) + category.descendants.reduce(0) { |p, c| p + (counters[c.id] || 0) }
     end
 
     def counters
-      @counters ||= categories_scope.aggregations["categories"]["categories"]["buckets"].
-          inject({}){ |h, e| h[e["key"]]=e["doc_count"]; h}
-      @services_total ||= categories_scope.aggregations["categories"]["doc_count"]
-      @counters
+      @counters ||= category_counters(scope, filters)
     end
-
 end

--- a/app/controllers/concerns/service/filterable.rb
+++ b/app/controllers/concerns/service/filterable.rb
@@ -11,8 +11,8 @@ module Service::Filterable
     end
   end
 
-  def filter(search_scope)
-    filters.inject(search_scope) { |filtered, filter| filter.call(filtered) }
+  def search_and_filter(search_scope)
+    search(search_scope, filters)
   end
 
   private
@@ -22,8 +22,12 @@ module Service::Filterable
     end
 
     def filters
-      @all_filters ||= filter_classes.
-                      map { |f| f.new(params: params, category: @category, filter_scope: filter_scope) }
+      if (@all_filters.nil?)
+        @all_filters = filter_classes.
+            map { |f| f.new(params: params) }
+        @all_filters.each { |f| f.filter_scope = search_for_filters(scope, @all_filters, f) }
+      end
+      @all_filters
     end
 
     def active_filters
@@ -42,7 +46,4 @@ module Service::Filterable
       ]
     end
 
-    def filter_scope
-      @filter_scope ||= search_for_filters(scope)
-    end
 end

--- a/app/controllers/concerns/service/filterable.rb
+++ b/app/controllers/concerns/service/filterable.rb
@@ -4,6 +4,7 @@ module Service::Filterable
   extend ActiveSupport::Concern
 
   included do
+    include Service::Searchable
     before_action only: :index do
       @filters = visible_filters
       @active_filters = active_filters
@@ -22,7 +23,7 @@ module Service::Filterable
 
     def filters
       @all_filters ||= filter_classes.
-                      map { |f| f.new(params: params, category: @category) }
+                      map { |f| f.new(params: params, category: @category, filter_scope: filter_scope) }
     end
 
     def active_filters
@@ -31,15 +32,17 @@ module Service::Filterable
 
     def filter_classes
       [
-
         Filter::ResearchArea,
         Filter::Provider,
         Filter::TargetGroup,
         Filter::Platform,
-        # Temporary removed because of #858
-        # Filter::Rating,
+        Filter::Rating,
         Filter::Location,
         Filter::Tag
       ]
+    end
+
+    def filter_scope
+      @filter_scope ||= search_for_filters(scope)
     end
 end

--- a/app/controllers/concerns/service/filterable.rb
+++ b/app/controllers/concerns/service/filterable.rb
@@ -22,12 +22,9 @@ module Service::Filterable
     end
 
     def filters
-      if (@all_filters.nil?)
-        @all_filters = filter_classes.
-            map { |f| f.new(params: params) }
-        @all_filters.each { |f| f.filter_scope = search_for_filters(scope, @all_filters, f) }
-      end
-      @all_filters
+      @all_filters ||= filter_classes.
+        map { |f| f.new(params: params) }.
+        tap { |all| all.each { |f| f.counters = filter_counters(scope, all, f) } }
     end
 
     def active_filters
@@ -40,10 +37,8 @@ module Service::Filterable
         Filter::Provider,
         Filter::TargetGroup,
         Filter::Platform,
-        Filter::Rating,
-        Filter::Location,
+        Filter::Rating, Filter::Location,
         Filter::Tag
       ]
     end
-
 end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -6,18 +6,57 @@ module Service::Searchable
   included do
     include Paginable
     include Service::Sortable
+    include Service::Categorable
   end
 
   def search(search_scope, filters)
-    Service.search *(params_for_search(search_scope, filters))
+    Service.search(query,
+                   fields: [ "title^7", "tagline^3", "description"],
+                   operator: "or",
+                   match: :word_middle,
+                   where: filter_constr(filters, scope_constr(search_scope, category_constr())),
+                   page: params[:page],
+                   per_page: per_page,
+                   order: ordering,
+                   highlight: { fields: [:title], tag: "<b>" },
+                   scope_results: ->(r) { r.includes(:research_areas, :providers, :target_groups).with_attached_logo })
   end
 
   def search_for_filters(search_scope, filters, current_filter)
-    Service.search *(params_for_filters(search_scope, filters, current_filter))
+    Service.search(query,
+                   fields: [ "title^7", "tagline^3", "description"],
+                   operator: "or",
+                   match: :word_middle,
+                   where: filter_constr(filters.reject {|f| f == current_filter}, scope_constr(search_scope, category_constr())),
+                   aggs: (!current_filter.index.blank? ? [current_filter.index] : []),
+                   load: false)
   end
 
   def search_for_categories(search_scope, filters)
-    Service.search *(params_for_categories(search_scope, filters))
+    Service.search(query,
+                   fields: [ "title^7", "tagline^3", "description"],
+                   operator: "or",
+                   match: :word_middle,
+                   where: filter_constr(filters, scope_constr(search_scope)),
+                   aggs: [:categories],
+                   load: false)
+  end
+
+  def filter_counters(search_scope, filters, current_filter)
+    {}.tap do |hash|
+      unless current_filter.index.blank?
+        services = search_for_filters(search_scope, filters, current_filter)
+        services.aggregations[current_filter.index][current_filter.index]["buckets"].
+            inject(hash){ |h, e| h[e["key"]] = e["doc_count"]; h}
+      end
+    end
+  end
+
+  def category_counters(search_scope, filters)
+    services = search_for_categories(search_scope, filters)
+    counters = services.aggregations["categories"]["categories"]["buckets"].
+        inject({}) { |h, e| h[e["key"]] = e["doc_count"]; h }
+    counters.tap { |c| c[nil] = services.aggregations["categories"]["doc_count"] }
   end
 
   private
@@ -30,59 +69,19 @@ module Service::Searchable
       query_present? ? params[:q] : "*"
     end
 
-    def params_for_categories(search_scope, filters)
-      [
-          query,
-          fields: [ "title^7", "tagline^3", "description"],
-          operator: "or",
-          match: :word_middle,
-          where: filter_constr(filters, id_constr(search_scope)),
-          aggs: [:categories],
-          load: false
-      ]
-    end
-
-    def params_for_filters(search_scope, filters, current_filter)
-      [
-          query,
-          fields: [ "title^7", "tagline^3", "description"],
-          operator: "or",
-          match: :word_middle,
-          where: filter_constr(filters.reject {|f| f == current_filter}, id_constr(search_scope, category_constr())),
-          aggs: filters.map(&:index).reject(&:blank?),
-          load: false
-      ]
-    end
-
-    def params_for_search(search_scope, filters)
-      [
-          query,
-          fields: [ "title^7", "tagline^3", "description"],
-          operator: "or",
-          match: :word_middle,
-          where: filter_constr(filters, id_constr(search_scope, category_constr())),
-          page: params[:page],
-          per_page: per_page,
-          order: params[:sort].blank? ? nil : ordering,
-          highlight: { fields: [:title], tag: "<b>" },
-          scope_results: ->(r) { r.includes(:research_areas, :providers, :target_groups).with_attached_logo }
-      ]
-    end
-
-    def id_constr(search_scope, constr = {})
-      constr.merge!({ id: search_scope.ids })
+    def scope_constr(search_scope, constr = {})
+      constr.tap { |c| c[:id] = search_scope.ids.uniq }
     end
 
     def category_constr(constr = {})
-      constr.tap { |c| c[:categories] = category.id unless category.nil? }
+      constr.tap { |c| c[:categories] = category.descendant_ids + [category.id] unless category.nil? }
     end
 
     def filter_constr(filters, constr = {})
-      filters.reduce(constr) { |h, f| h.merge(f.constraint) }
+      filters.reduce(constr) { |c, f| c.merge(f.constraint) }
     end
 
     def highlights(from_search)
       (from_search.try(:with_highlights) || []).map { |s, h| [s.id, h] }.to_h
     end
-
 end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -12,8 +12,8 @@ module Service::Searchable
     query_present? ? (Service.search *(complex_params(search_scope))) : paginate(order(search_scope.distinct))
   end
 
-  def search_simple(search_scope)
-    query_present? ? (Service.search *(simple_params(search_scope))) : search_scope.distinct
+  def search_for_filters(search_scope)
+    Service.search *(params_for_filters(search_scope))
   end
 
   private
@@ -22,19 +22,24 @@ module Service::Searchable
       params[:q].present?
     end
 
-    def simple_params(search_scope)
+    def query
+      params[:q].present? ? params[:q] : "*"
+    end
+
+    def params_for_filters(search_scope)
       [
-          params[:q],
+          query,
           fields: [ "title^7", "tagline^3", "description"],
           operator: "or",
           where: { id: search_scope.ids },
           match: :word_middle,
+          aggs: [:providers]
       ]
     end
 
     def complex_params(search_scope)
       [
-          params[:q],
+          query,
           fields: [ "title^7", "tagline^3", "description"],
           operator: "or",
           where: { id: search_scope.ids },

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -9,7 +9,11 @@ module Service::Searchable
   end
 
   def search(search_scope)
-    query_present? ? search_fields(search_scope) : paginate(order(search_scope.distinct))
+    query_present? ? (Service.search *(complex_params(search_scope))) : paginate(order(search_scope.distinct))
+  end
+
+  def search_simple(search_scope)
+    query_present? ? (Service.search *(simple_params(search_scope))) : search_scope.distinct
   end
 
   private
@@ -18,16 +22,29 @@ module Service::Searchable
       params[:q].present?
     end
 
-    def search_fields(search_scope)
-      Service.search params[:q],
-                     fields: [ "title^7", "tagline^3", "description"],
-                     operator: "or",
-                     where: { id: search_scope.ids },
-                     page: params[:page], per_page: per_page,
-                     order: params[:sort].blank? ? nil : ordering,
-                     match: :word_middle,
-                     highlight: { fields: [:title, :tagline], tag: "<b>" },
-                     scope_results: ->(r) { r.includes(:research_areas, :providers, :target_groups).with_attached_logo }
+    def simple_params(search_scope)
+      [
+          params[:q],
+          fields: [ "title^7", "tagline^3", "description"],
+          operator: "or",
+          where: { id: search_scope.ids },
+          match: :word_middle,
+      ]
+    end
+
+    def complex_params(search_scope)
+      [
+          params[:q],
+          fields: [ "title^7", "tagline^3", "description"],
+          operator: "or",
+          where: { id: search_scope.ids },
+          page: params[:page],
+          per_page: per_page,
+          order: params[:sort].blank? ? nil : ordering,
+          match: :word_middle,
+          highlight: { fields: [:title], tag: "<b>" },
+          scope_results: ->(r) { r.includes(:research_areas, :providers, :target_groups).with_attached_logo }
+      ]
     end
 
     def highlights(from_search)

--- a/app/controllers/concerns/service/sortable.rb
+++ b/app/controllers/concerns/service/sortable.rb
@@ -15,7 +15,7 @@ module Service::Sortable
     def ordering
       {}.tap do |sort_options|
         sort_key = params[:sort]
-        unless params[:sort].blank?
+        unless sort_key.blank?
           if sort_key == "_score"
             return
           else

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
-  include Service::Searchable
-
   before_action :load_services
 
   def index

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -10,11 +10,8 @@ class ServicesController < ApplicationController
     if params["service_id"].present?
       redirect_to Service.find(params["service_id"])
     end
-    filtered = filter(scope)
-    from_search = search(filtered)
-
-    @services = from_search
-    @highlights = highlights(from_search)
+    @services = search_and_filter(scope)
+    @highlights = highlights(@services)
   end
 
   def show

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -11,8 +11,7 @@ class ServicesController < ApplicationController
       redirect_to Service.find(params["service_id"])
     end
     filtered = filter(scope)
-    from_category = category_records(filtered)
-    from_search = search(from_category)
+    from_search = search(filtered)
 
     @services = from_search
     @highlights = highlights(from_search)

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Filter
-  attr_accessor :filter_scope
+  attr_accessor :counters
   attr_reader :title, :field_name, :type, :index
 
   def initialize(params: {}, field_name:, type:, title:, index:)
@@ -45,10 +45,6 @@ class Filter
     end
 
     def where_constraint
-      raise "Need to be implemented in descendent class!!!"
-    end
-
-    def fetch_options
       raise "Need to be implemented in descendent class!!!"
     end
 

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
 class Filter
-  attr_reader :title, :field_name, :type
+  attr_accessor :filter_scope
+  attr_reader :title, :field_name, :type, :index
 
-  def initialize(params: {}, field_name:, type:, title:)
+  def initialize(params: {}, field_name:, type:, title:, index:)
     @params = params
     @field_name = field_name
     @title = title
     @type = type
+    @index = index
   end
 
   def options
     @options ||= fetch_options
-  end
-
-  def call(services)
-    active? ? do_call(services) : services
   end
 
   def active_filters
@@ -36,13 +34,21 @@ class Filter
     (value.is_a?(Array) ? value : [value]).reject(&:blank?)
   end
 
+  def constraint
+    active? ? where_constraint : {}
+  end
+
   protected
 
     def fetch_options
       raise "Need to be implemented in descendent class!!!"
     end
 
-    def do_call(services)
+    def where_constraint
+      raise "Need to be implemented in descendent class!!!"
+    end
+
+    def fetch_options
       raise "Need to be implemented in descendent class!!!"
     end
 

--- a/app/models/filter/ancestry_multiselect.rb
+++ b/app/models/filter/ancestry_multiselect.rb
@@ -4,7 +4,6 @@ class Filter::AncestryMultiselect < Filter
   def initialize(params:, title:, field_name:, model:, joining_model:, index:)
     super(params: params, type: :multiselect,
           field_name: field_name, title: title, index: index)
-
     @model = model
     @joining_model = joining_model
   end
@@ -16,8 +15,6 @@ class Filter::AncestryMultiselect < Filter
     end
 
     def create_ancestry_tree(arranged)
-      @counters ||= @filter_scope.aggregations[@index][@index]["buckets"].
-          inject({}){ |h, e| h[e["key"]] = e["doc_count"]; h}
       arranged.map do |record, children|
         {
           name: record.name,
@@ -25,7 +22,7 @@ class Filter::AncestryMultiselect < Filter
           count: @counters[record.id] || 0,
           children: create_ancestry_tree(children)
         }
-      end.sort_by!{ |e| [-e[:count], e[:name] ] }
+      end.sort_by! { |e| [-e[:count], e[:name] ] }
     end
 
     def children_services(arranged)
@@ -40,20 +37,9 @@ class Filter::AncestryMultiselect < Filter
           inject(Hash.new { |h, k| h[k] = Set.new }) { |h, (k, v)| h[k] << v; h }
     end
 
-
     def where_constraint
       { @index.to_sym => ids }
     end
-
-    # def do_call(services)
-    #   if ids.size.positive?
-    #     joining_table_name = @joining_model.table_name.to_sym
-    #     services.joins(joining_table_name).
-    #       where(joining_table_name => { relation_column_name.to_sym => ids })
-    #   else
-    #     services
-    #   end
-    # end
 
     def relation_column_name
       "#{@model.table_name.singularize}_id"

--- a/app/models/filter/location.rb
+++ b/app/models/filter/location.rb
@@ -1,19 +1,17 @@
 # frozen_string_literal: true
 
 class Filter::Location < Filter
+  #   TODO finish this filter
+
   def initialize(params = {})
     super(params: params.fetch(:params, {}),
           field_name: "location", type: :select,
-          title: "Provider location")
+          title: "Provider location", index: nil)
   end
 
   private
 
     def fetch_options
       [{ name: "Any", id: "" }, { name: "EU", id: "EU" }]
-    end
-
-    def do_call(services)
-      services
     end
 end

--- a/app/models/filter/location.rb
+++ b/app/models/filter/location.rb
@@ -14,4 +14,8 @@ class Filter::Location < Filter
     def fetch_options
       [{ name: "Any", id: "" }, { name: "EU", id: "EU" }]
     end
+
+    def where_constraint
+      {}  # TODO finish this filter
+    end
 end

--- a/app/models/filter/multiselect.rb
+++ b/app/models/filter/multiselect.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 class Filter::Multiselect < Filter
-  def initialize(params:, category:, title:, field_name:, model:, index:, filter_scope:)
+
+  def initialize(params:, title:, field_name:, model:, index:)
     super(params: params, field_name: field_name,
-          type: :multiselect, title: title)
+          type: :multiselect, title: title, index: index)
     @model = model
-    @index = index
-    @category = category
-    @filter_scope = filter_scope
   end
 
   protected
@@ -15,7 +13,13 @@ class Filter::Multiselect < Filter
     def fetch_options
       counters = @filter_scope.aggregations[@index][@index]["buckets"].
           inject({}){ |h, e| h[e["key"]] = e["doc_count"]; h}
-      @model.distinct.map { |e| {name: e.name, id: e.id, count: counters[e.id] || 0} }.sort_by!{ |e| [-e[:count], e[:name] ] }
+      @model.distinct
+          .map { |e| {name: e.name, id: e.id, count: counters[e.id] || 0} }
+          .sort_by!{ |e| [-e[:count], e[:name] ] }
+    end
+
+    def where_constraint
+      { @index.to_sym => values }
     end
 
 end

--- a/app/models/filter/multiselect.rb
+++ b/app/models/filter/multiselect.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Filter::Multiselect < Filter
-
   def initialize(params:, title:, field_name:, model:, index:)
     super(params: params, field_name: field_name,
           type: :multiselect, title: title, index: index)
@@ -11,15 +10,12 @@ class Filter::Multiselect < Filter
   protected
 
     def fetch_options
-      counters = @filter_scope.aggregations[@index][@index]["buckets"].
-          inject({}){ |h, e| h[e["key"]] = e["doc_count"]; h}
       @model.distinct
-          .map { |e| {name: e.name, id: e.id, count: counters[e.id] || 0} }
-          .sort_by!{ |e| [-e[:count], e[:name] ] }
+          .map { |e| { name: e.name, id: e.id, count: @counters[e.id] || 0 } }
+          .sort_by! { |e| [-e[:count], e[:name] ] }
     end
 
     def where_constraint
       { @index.to_sym => values }
     end
-
 end

--- a/app/models/filter/multiselect.rb
+++ b/app/models/filter/multiselect.rb
@@ -14,8 +14,8 @@ class Filter::Multiselect < Filter
 
     def fetch_options
       counters = @filter_scope.aggregations[@index][@index]["buckets"].
-          inject({}){ |h, e| h[e["key"]]=e["doc_count"]; h}
-      entities = @model.order(:name).find(counters.keys)
-      entities.map() {|p| {name: p.name, id: p.id, count: counters[p.id]}}
+          inject({}){ |h, e| h[e["key"]] = e["doc_count"]; h}
+      @model.distinct.map { |e| {name: e.name, id: e.id, count: counters[e.id] || 0} }.sort_by!{ |e| [-e[:count], e[:name] ] }
     end
+
 end

--- a/app/models/filter/platform.rb
+++ b/app/models/filter/platform.rb
@@ -6,7 +6,9 @@ class Filter::Platform < Filter::Multiselect
           category: params[:category],
           field_name: "related_platforms",
           title: "Related Infrastructures and platforms",
-          query: ::Platform.select("platforms.name, platforms.id, COUNT(services.id) as service_count"))
+          model: ::Platform,
+          index: "platforms",
+          filter_scope: params[:filter_scope])
   end
 
   private

--- a/app/models/filter/platform.rb
+++ b/app/models/filter/platform.rb
@@ -3,18 +3,9 @@
 class Filter::Platform < Filter::Multiselect
   def initialize(params = {})
     super(params: params.fetch(:params, {}),
-          category: params[:category],
           field_name: "related_platforms",
           title: "Related Infrastructures and platforms",
           model: ::Platform,
-          index: "platforms",
-          filter_scope: params[:filter_scope])
+          index: "platforms")
   end
-
-  private
-
-    def do_call(services)
-      services.joins(:service_related_platforms).group("services.id").
-          where("service_related_platforms.platform_id IN (?)", value)
-    end
 end

--- a/app/models/filter/provider.rb
+++ b/app/models/filter/provider.rb
@@ -7,9 +7,30 @@ class Filter::Provider < Filter::Multiselect
           field_name: "providers",
           title: "Providers",
           query: ::Provider.select("providers.name, providers.id, count(service_providers.service_id) as service_count"))
+    @filter_scope = params[:filter_scope]
   end
 
   private
+
+    # def fetch_options
+    #   acc = {}
+    #   @filter_scope.each() do |service|
+    #     service.providers.each do |provider|
+    #       if acc[provider.id] == nil
+    #         acc[provider.id] =  { name: provider.name, id: provider.id, count: 0 }
+    #       end
+    #       acc[provider.id][:count] += 1
+    #     end
+    #   end
+    #   acc.values.sort_by{ |provider| provider[:name] }
+    # end
+
+    def fetch_options
+      counters = @filter_scope.aggregations["providers"]["providers"]["buckets"].
+          inject({}){ |h, e| h[e["key"]]=e["doc_count"]; h}
+      providers = ::Provider.order(:name).find(counters.keys)
+      providers.map() {|p| {name: p.name, id: p.id, count: counters[p.id]}}
+    end
 
     def do_call(services)
       services.joins(:service_providers).group("services.id")

--- a/app/models/filter/provider.rb
+++ b/app/models/filter/provider.rb
@@ -6,31 +6,12 @@ class Filter::Provider < Filter::Multiselect
           category: params[:category],
           field_name: "providers",
           title: "Providers",
-          query: ::Provider.select("providers.name, providers.id, count(service_providers.service_id) as service_count"))
-    @filter_scope = params[:filter_scope]
+          model: ::Provider,
+          index: "providers",
+          filter_scope: params[:filter_scope])
   end
 
   private
-
-    # def fetch_options
-    #   acc = {}
-    #   @filter_scope.each() do |service|
-    #     service.providers.each do |provider|
-    #       if acc[provider.id] == nil
-    #         acc[provider.id] =  { name: provider.name, id: provider.id, count: 0 }
-    #       end
-    #       acc[provider.id][:count] += 1
-    #     end
-    #   end
-    #   acc.values.sort_by{ |provider| provider[:name] }
-    # end
-
-    def fetch_options
-      counters = @filter_scope.aggregations["providers"]["providers"]["buckets"].
-          inject({}){ |h, e| h[e["key"]]=e["doc_count"]; h}
-      providers = ::Provider.order(:name).find(counters.keys)
-      providers.map() {|p| {name: p.name, id: p.id, count: counters[p.id]}}
-    end
 
     def do_call(services)
       services.joins(:service_providers).group("services.id")

--- a/app/models/filter/provider.rb
+++ b/app/models/filter/provider.rb
@@ -3,18 +3,9 @@
 class Filter::Provider < Filter::Multiselect
   def initialize(params = {})
     super(params: params.fetch(:params, {}),
-          category: params[:category],
           field_name: "providers",
           title: "Providers",
           model: ::Provider,
-          index: "providers",
-          filter_scope: params[:filter_scope])
+          index: "providers")
   end
-
-  private
-
-    def do_call(services)
-      services.joins(:service_providers).group("services.id")
-          .where("service_providers.provider_id IN (?)", value)
-    end
 end

--- a/app/models/filter/rating.rb
+++ b/app/models/filter/rating.rb
@@ -21,7 +21,6 @@ class Filter::Rating < Filter
     end
 
     def where_constraint
-      { @index.to_sym => {gte: value} }
+      { @index.to_sym => { gte: value } }
     end
-
 end

--- a/app/models/filter/rating.rb
+++ b/app/models/filter/rating.rb
@@ -4,7 +4,7 @@ class Filter::Rating < Filter
   def initialize(params = {})
     super(params: params.fetch(:params, {}),
           field_name: "rating", type: :select,
-          title: "Rating")
+          title: "Rating", index: "rating")
   end
 
   private
@@ -20,7 +20,8 @@ class Filter::Rating < Filter
       ]
     end
 
-    def do_call(services)
-      services.where("rating >= ?", value)
+    def where_constraint
+      { @index.to_sym => {gte: value} }
     end
+
 end

--- a/app/models/filter/research_area.rb
+++ b/app/models/filter/research_area.rb
@@ -4,6 +4,6 @@ class Filter::ResearchArea < Filter::AncestryMultiselect
   def initialize(params = {})
     super(params: params.fetch(:params, {}),
           field_name: "research_areas", title: "Research Area",
-          model: ::ResearchArea, joining_model: ServiceResearchArea)
+          model: ::ResearchArea, joining_model: ServiceResearchArea, index: "research_areas")
   end
 end

--- a/app/models/filter/tag.rb
+++ b/app/models/filter/tag.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 class Filter::Tag < Filter
-  #   TODO finish this filter
-
   def initialize(params = {})
     super(params: params.fetch(:params, {}),
           field_name: "tag", type: :select,
-          title: "Tags", index: nil)
+          title: "Tags", index: "tags")
   end
 
   def visible?
@@ -21,8 +19,7 @@ class Filter::Tag < Filter
         sort { |x, y| x[:name] <=> y[:name] }
     end
 
-    # def do_call(services)
-    #   services.tagged_with(value)
-    # end
-
+    def where_constraint
+      { @index.to_sym => values }
+    end
 end

--- a/app/models/filter/tag.rb
+++ b/app/models/filter/tag.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class Filter::Tag < Filter
+  #   TODO finish this filter
+
   def initialize(params = {})
     super(params: params.fetch(:params, {}),
           field_name: "tag", type: :select,
-          title: "Tags")
+          title: "Tags", index: nil)
   end
 
   def visible?
@@ -19,7 +21,8 @@ class Filter::Tag < Filter
         sort { |x, y| x[:name] <=> y[:name] }
     end
 
-    def do_call(services)
-      services.tagged_with(value)
-    end
+    # def do_call(services)
+    #   services.tagged_with(value)
+    # end
+
 end

--- a/app/models/filter/target_group.rb
+++ b/app/models/filter/target_group.rb
@@ -3,18 +3,9 @@
 class Filter::TargetGroup < Filter::Multiselect
   def initialize(params = {})
     super(params: params.fetch(:params, {}),
-          category: params[:category],
           field_name: "target_groups",
           title: "Dedicated for",
           model: ::TargetGroup,
-          index: "target_groups",
-          filter_scope: params[:filter_scope])
+          index: "target_groups")
   end
-
-  private
-
-    def do_call(services)
-      services.joins(:service_target_groups).
-          where("service_target_groups.target_group_id IN (?)", value)
-    end
 end

--- a/app/models/filter/target_group.rb
+++ b/app/models/filter/target_group.rb
@@ -6,7 +6,9 @@ class Filter::TargetGroup < Filter::Multiselect
           category: params[:category],
           field_name: "target_groups",
           title: "Dedicated for",
-          query: ::TargetGroup.select("target_groups.name, target_groups.id, count(services.id) as service_count"))
+          model: ::TargetGroup,
+          index: "target_groups",
+          filter_scope: params[:filter_scope])
   end
 
   private

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -20,7 +20,7 @@ class Service < ApplicationRecord
       research_areas: research_areas.map(&:id),
       providers: providers.map(&:id),
       platforms: platforms.map(&:id),
-      target_groups: service_target_groups.map(&:id),
+      target_groups: target_groups.map(&:id),
     }
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -15,7 +15,12 @@ class Service < ApplicationRecord
       tagline: tagline,
       description: description,
       status: status,
-      rating: rating
+      rating: rating,
+      categories: categories.map(&:id),
+      research_areas: research_areas.map(&:id),
+      providers: providers.map(&:id),
+      platforms: platforms.map(&:id),
+      target_groups: service_target_groups.map(&:id),
     }
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -21,6 +21,7 @@ class Service < ApplicationRecord
       providers: providers.map(&:id),
       platforms: platforms.map(&:id),
       target_groups: target_groups.map(&:id),
+      tags: tag_list
     }
   end
 

--- a/app/views/backoffice/categories/nav/_category.html.haml
+++ b/app/views/backoffice/categories/nav/_category.html.haml
@@ -1,4 +1,4 @@
 - active = "font-weight-bolder" if local_assigns[:current] && current == category
 %li{ class: "d-flex justify-content-between align-items-center #{active}" }
   = link_to category.name, backoffice_category_services_path(category, category_query_params)
-  %span= category.services_count
+  %span= counter

--- a/app/views/backoffice/services/index.html.haml
+++ b/app/views/backoffice/services/index.html.haml
@@ -7,7 +7,7 @@
                            category: @category,
                            services_count: @services_total,
                            categories: @siblings_with_counters,
-                           subcategories: @subcategories,
+                           subcategories: @subcategories_with_counters,
                            provider_options: @provider_options,
                            research_areas: @research_areas,
                            target_groups_options: @target_groups_options,

--- a/app/views/backoffice/services/index.html.haml
+++ b/app/views/backoffice/services/index.html.haml
@@ -5,7 +5,8 @@
 
 = render "services/index", services: @services,
                            category: @category,
-                           categories: @siblings,
+                           services_count: @services_total,
+                           categories: @siblings_with_counters,
                            subcategories: @subcategories,
                            provider_options: @provider_options,
                            research_areas: @research_areas,

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -3,7 +3,8 @@
     .col-lg-3.mb-5
       = render "services/nav/categories", current: category,
                                           categories: categories,
-                                          subcategories: subcategories
+                                          subcategories: subcategories,
+                                          services_count: services_count
       = render "services/filters", provider_options: provider_options,
                                    research_areas: research_areas,
                                    target_groups_options: target_groups_options,

--- a/app/views/services/filters/_multiselect_level.html.haml
+++ b/app/views/services/filters/_multiselect_level.html.haml
@@ -1,12 +1,12 @@
 %ul{ class: html_classes }
   - options.each do |option|
-    - disabled = option[:count].to_i.zero?
+    - muted = option[:count].to_i.zero?
     %li{ root ? { data: { target: "multicheckbox.element" } } : {} }
-      %label{ class: ("text-muted" if disabled) }
-        %input.form-check-input{ type: "checkbox", disabled: disabled, name: "#{name}[]",
+      %label{ class: ("text-muted" if muted) }
+        %input.form-check-input{ type: "checkbox", name: "#{name}[]",
           multiple: true, checked: values.include?(option[:id].to_s), value: option[:id] }
         %span= option[:name]
-      %span.float-right.small{ class: ("text-muted" if disabled) }= option[:count]
+      %span.float-right.small{ class: ("text-muted" if muted) }= option[:count]
       - if option[:children]
         = render "services/filters/multiselect_level",
           options: option[:children], html_classes: "pl-3 pr-0",

--- a/app/views/services/filters/_wrapper.html.haml
+++ b/app/views/services/filters/_wrapper.html.haml
@@ -10,5 +10,5 @@
 
 .row
   .col-md-12.panel-collapse.collapse{ "id": "collapse_#{filter.field_name}",
-    "data-target": "filters.filter", class: ("show" if filter.present?) }
+    "data-target": "filters.filter", class: "show" }
     = yield

--- a/app/views/services/filters/_wrapper.html.haml
+++ b/app/views/services/filters/_wrapper.html.haml
@@ -10,5 +10,5 @@
 
 .row
   .col-md-12.panel-collapse.collapse{ "id": "collapse_#{filter.field_name}",
-    "data-target": "filters.filter", class: "show" }
+    "data-target": "filters.filter", class: ("show" if filter.present?) }
     = yield

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -4,7 +4,7 @@
                            category: @category,
                            services_count: @services_total,
                            categories: @siblings_with_counters,
-                           subcategories: @subcategories,
+                           subcategories: @subcategories_with_counters,
                            provider_options: @provider_options,
                            research_areas: @research_areas,
                            target_groups_options: @target_groups_options,

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -2,7 +2,8 @@
 
 = render "services/index", services: @services,
                            category: @category,
-                           categories: @siblings,
+                           services_count: @services_total,
+                           categories: @siblings_with_counters,
                            subcategories: @subcategories,
                            provider_options: @provider_options,
                            research_areas: @research_areas,

--- a/app/views/services/nav/_categories.html.haml
+++ b/app/views/services/nav/_categories.html.haml
@@ -7,10 +7,11 @@
 %h5.text-uppercase.underline-light.mb-2.pb-2 Categories
 %ul.categories-list
   - view = content_for(:category_view) || "services/nav/category"
-  - categories.each do |id, category|
+  - categories.each do |cid, category|
     = render view, category: category[:category], current: current, counter: category[:counter]
-    - if current == category && !subcategories.empty?
+    - if current == category[:category] && !subcategories.empty?
       %ul.ml-3
-        = render partial: view, collection: subcategories, as: :category
+        - subcategories.each do |sid, subcategory|
+          = render view, category: subcategory[:category], current: current, counter: subcategory[:counter]
 
 = yield :test

--- a/app/views/services/nav/_categories.html.haml
+++ b/app/views/services/nav/_categories.html.haml
@@ -1,15 +1,14 @@
 - active = "font-weight-bolder" unless local_assigns[:current]
 
-%h5.text-uppercase.underline-light.mb-2.pb-2 Categories
 #all-services-link{ class: "d-flex justify-content-between mb-4 align-items-center #{active}" }
   = link_to "All Services", content_for(:all_services) || services_path(category_query_params.merge(page: nil).permit!)
-  %span= Service.published.count
+  %span= services_count
 
 %h5.text-uppercase.underline-light.mb-2.pb-2 Categories
 %ul.categories-list
   - view = content_for(:category_view) || "services/nav/category"
-  - categories.each do |category|
-    = render view, category: category, current: current
+  - categories.each do |id, category|
+    = render view, category: category[:category], current: current, counter: category[:counter]
     - if current == category && !subcategories.empty?
       %ul.ml-3
         = render partial: view, collection: subcategories, as: :category

--- a/app/views/services/nav/_category.html.haml
+++ b/app/views/services/nav/_category.html.haml
@@ -1,4 +1,4 @@
 - active = "font-weight-bolder" if local_assigns[:current] && current == category
 %li{ class: "d-flex justify-content-between align-items-center #{active}" }
   = link_to category.name, category_services_path(category, category_query_params.merge(page: nil).permit!)
-  %span= category.services_count
+  %span= counter

--- a/spec/controllers/concerns/searchable_spec.rb
+++ b/spec/controllers/concerns/searchable_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   context "#search" do
+    before { Searchkick.enable_callbacks }
+    after { Searchkick.disable_callbacks }
+
     it "don't duplicate results when service belongs to many providers" do
+      Searchkick.enable_callbacks
       provider1, provider2 = create_list(:provider, 2)
       create(:service, providers: [provider1, provider2])
 
@@ -17,7 +21,7 @@ RSpec.describe ApplicationController, type: :controller do
       scope = Service.joins(:service_providers).
         where(service_providers: { provider_id: [provider1.id, provider2.id] })
 
-      expect(controller.search(scope).count).to eq(1)
+      expect(controller.search(scope, []).count).to eq(1)
     end
   end
 end

--- a/spec/controllers/concerns/searchable_spec.rb
+++ b/spec/controllers/concerns/searchable_spec.rb
@@ -8,20 +8,229 @@ RSpec.describe ApplicationController, type: :controller do
     include Service::Searchable
   end
 
-  context "#search" do
-    before { Searchkick.enable_callbacks }
-    after { Searchkick.disable_callbacks }
+  let!(:providers) { create_list(:provider, 2) }
+  let!(:categories) { create_list(:category, 2) }
 
-    it "don't duplicate results when service belongs to many providers" do
-      Searchkick.enable_callbacks
-      provider1, provider2 = create_list(:provider, 2)
-      create(:service, providers: [provider1, provider2])
+  let!(:service1) { create(:service, title: "duper super name", providers: providers,
+                           categories: [categories.first], tag_list: "tag1, tag2") }
+  let!(:service2) { create(:service, title: "very different title", providers: [providers.first],
+                           categories: categories, tag_list: "tag2") }
 
-      # scope.count == 2 => results are duplicated
-      scope = Service.joins(:service_providers).
-        where(service_providers: { provider_id: [provider1.id, provider2.id] })
+  let!(:params) { ActionController::Parameters.new }
+  let!(:provider_filter) { Filter::Provider.new(params: params) }
+  let!(:tag_filter) { Filter::Tag.new(params: params) }
+  let!(:filters) { [ provider_filter, tag_filter ] }
 
-      expect(controller.search(scope, []).count).to eq(1)
+  before(:each) do
+    controller.params = params
+  end
+
+  context "#search " do
+    context "without filters set" do
+      let!(:params) { ActionController::Parameters.new }
+      it "returns correct service list" do
+        results = controller.search(Service.all, filters).results
+        expect(results.size).to eq(2)
+        expect(results).to contain_exactly(service1, service2)
+      end
+    end
+
+    context "with filters set" do
+      let!(:params) { ActionController::Parameters.new("providers" => providers.second.id) }
+      it "returns correct service list" do
+        results = controller.search(Service.all, filters).results
+        expect(results.size).to eq(1)
+        expect(results).to include(service1)
+        expect(results).not_to include(service2)
+      end
+    end
+
+    context "with filters and category set" do
+      let!(:params) { ActionController::Parameters.new("providers" => providers.second.id,
+                                                       "category_id" => categories.second.id) }
+      it "returns empty service list when category contradicts provider filter" do
+        results = controller.search(Service.all, filters).results
+        expect(results.size).to eq(0)
+      end
+    end
+
+    context "with filters and category set" do
+      let!(:params) { ActionController::Parameters.new("providers" => providers.first.id,
+                                                       "category_id" => categories.second.id) }
+      it "returns correct service list" do
+        results = controller.search(Service.all, filters).results
+        expect(results.size).to eq(1)
+        expect(results).to include(service2)
+        expect(results).not_to include(service1)
+      end
+    end
+
+    context "with query" do
+      let!(:params) { ActionController::Parameters.new("q" => "duper super") }
+      it "returns correct service list" do
+        results = controller.search(Service.all, filters).results
+        expect(results.size).to eq(1)
+        expect(results).to include(service1)
+        expect(results).not_to include(service2)
+      end
+    end
+  end
+
+  context "#filter_counters" do
+    context "provider set" do
+      let!(:params) { ActionController::Parameters.new("providers" => providers.first.id) }
+      it "returns counters for providers when tag filter not set" do
+        expect(controller.filter_counters(Service.all, filters, provider_filter)).
+            to eq(providers.first.id => 2, providers.second.id => 1)
+      end
+    end
+
+    context "tag set" do
+      let!(:params) { ActionController::Parameters.new("tag" => "tag1") }
+      it "returns counters for providers when tag filter set and limits results" do
+        expect(controller.filter_counters(Service.all, filters, provider_filter)).
+            to eq(providers.first.id => 1, providers.second.id => 1)
+      end
+    end
+
+    context "provider set" do
+      let!(:params) { ActionController::Parameters.new("providers" => providers.first.id) }
+      it "returns counters for tags when provider filter set but does not limit results" do
+        expect(controller.filter_counters(Service.all, filters, tag_filter)).
+            to eq("tag1" => 1, "tag2" => 2)
+      end
+    end
+
+    context "provider set" do
+      let!(:params) { ActionController::Parameters.new("providers" => providers.second.id) }
+      it "returns counters for tags when provider filter set and limits results" do
+        expect(controller.filter_counters(Service.all, filters, tag_filter)).
+            to eq("tag1" => 1, "tag2" => 1)
+      end
+    end
+  end
+
+  context "#category_counters" do
+    context "category_id set" do
+      let!(:params) { ActionController::Parameters.new("category_id" => categories.first.id) }
+      it "checks if set category_id doesn't affect counters" do
+        counters = controller.category_counters(Service.all, filters)
+        expect(counters.class).to eq Hash
+        expect(counters).to eq(categories.first.id => 2, categories.second.id => 1, nil => 2)
+      end
+    end
+
+    context "#category_counters and #filter counters interrelationship" do
+      let!(:params) { ActionController::Parameters.new("providers" => providers.second.id) }
+      it "checks category counters validity" do
+        counters = controller.category_counters(Service.all, filters)
+        expect(counters.class).to eq Hash
+        expect(counters).to eq(categories.first.id => 1, nil => 1)
+      end
+    end
+
+    context "with query" do
+      let!(:params) { ActionController::Parameters.new("q" => "duper super") }
+      it "checks if correct counters are returned" do
+        counters = controller.category_counters(Service.all, filters)
+        expect(counters.class).to eq Hash
+        expect(counters).to eq(categories.first.id => 1, nil => 1)
+      end
+    end
+
+    context "with query and filter" do
+      let!(:params) { ActionController::Parameters.new("q" => "very different",
+                                                       "providers" => providers.second.id) }
+      it "checks if query, filters, and categories counters work together" do
+        counters = controller.category_counters(Service.all, filters)
+        expect(counters.class).to eq Hash
+        expect(counters).to eq(nil => 0)
+      end
+    end
+  end
+
+  context "filter type tests" do
+    let!(:collection) { create_list(:provider, 3) }
+    let!(:field_name) { :providers }
+    let!(:param_name) { :providers }
+    let!(:filter_class) { Filter::Provider }
+
+    let!(:service1) { create(:service, field_name => [collection.first]) }
+    let!(:service2) { create(:service, field_name => [collection.second]) }
+    let!(:service4) { create(:service, field_name => [collection.third]) }
+
+    let!(:value_method) { :id }
+    let!(:values) { [collection.first.send(value_method), collection.second.send(value_method)] }
+    let!(:params) { ActionController::Parameters.new(param_name => values) }
+    let!(:filters) { [filter_class.new(params: params)] }
+
+    def basic_test
+      results = controller.search(Service.all, filters).results
+      expect(results.size).to eq(2)
+      expect(results).to include(service1)
+      expect(results).to include(service2)
+    end
+
+    context Filter::Provider do
+      it "checks if provider filter works" do
+        basic_test
+      end
+    end
+
+    context Filter::Tag do
+      let!(:collection) { ["tag1", "tag2", "tag3"] }
+      let!(:field_name) { :tag_list }
+      let!(:param_name) { :tag }
+      let!(:filter_class) { Filter::Tag }
+      let!(:value_method) { :itself }
+      it "checks if tag filter works" do
+        basic_test
+      end
+    end
+
+    context Filter::Platform do
+      let!(:collection) { create_list(:platform, 3) }
+      let!(:field_name) { :platforms }
+      let!(:param_name) { :related_platforms }
+      let!(:filter_class) { Filter::Platform }
+      it "checks if platform filter works" do
+        basic_test
+      end
+    end
+
+    context Filter::ResearchArea do
+      let!(:collection) { create_list(:research_area, 3) }
+      let!(:field_name) { :research_areas }
+      let!(:param_name) { :research_areas }
+      let!(:filter_class) { Filter::ResearchArea }
+      it "checks if research area filter works" do
+        basic_test
+      end
+    end
+
+    context Filter::TargetGroup do
+      let!(:collection) { create_list(:target_group, 3) }
+      let!(:field_name) { :target_groups }
+      let!(:param_name) { :target_groups }
+      let!(:filter_class) { Filter::TargetGroup }
+      it "checks if target group filter works" do
+        basic_test
+      end
+    end
+
+    context Filter::Rating do
+      let!(:collection) { [5.0, 4.0, 1.0] }
+      let!(:service1) { create(:service).tap { |s| s.rating = collection.first; s.save } }
+      let!(:service2) { create(:service).tap { |s| s.rating = collection.second; s.save } }
+      let!(:service4) { create(:service).tap { |s| s.rating = collection.third; s.save } }
+      let!(:field_name) { :rating }
+      let!(:param_name) { :rating }
+      let!(:values) { 2.0 }
+      let!(:filter_class) { Filter::Rating }
+      it "checks if rating filter works" do
+        Service.reindex
+        basic_test
+      end
     end
   end
 end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -31,5 +31,9 @@ FactoryBot.define do
     sequence(:status) { :published }
 
     upstream { nil }
+
+    after(:create) do |service, _evaluator|
+      service.reindex(refresh: true)
+    end
   end
 end

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -48,9 +48,12 @@ RSpec.feature "Service filtering" do
     expect(page).to have_selector(".media", count: 2)
 
     visit services_path(tag: ["a", "b"])
-    expect(page).to have_selector(".media", count: 1)
+    expect(page).to have_selector(".media", count: 2)
 
     visit services_path(tag: ["a", "b", "c"])
+    expect(page).to have_selector(".media", count: 3)
+
+    visit services_path(tag: ["d"])
     expect(page).to have_selector(".media", count: 0)
   end
 end

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -355,7 +355,6 @@ RSpec.feature "Service filtering and sorting" do
     # collapse all
     find(:css, ".collapseall").click
 
-    save_and_open_screenshot
     expect(page).to_not have_selector("input[name='providers[]'][value='#{provider_id}']")
     expect(page).to_not have_selector("input[name='target_groups[]'][value='#{target_group_id}']")
   end
@@ -372,8 +371,6 @@ RSpec.feature "Service filtering and sorting" do
   end
 
   scenario "searching via rating", js: true do
-    pending "Temporary rating filter was removed from the view, see #858"
-
     visit services_path
 
     find(:css, "a[href=\"#collapse_rating\"][role=\"button\"] h6").click

--- a/spec/models/filter/platform_spec.rb
+++ b/spec/models/filter/platform_spec.rb
@@ -9,31 +9,14 @@ RSpec.describe Filter::Platform do
     let!(:service1)  { create(:service, platforms: [platform1]) }
     let!(:service2)  { create(:service, platforms: [platform1, platform2]) }
     let!(:category)  { create(:category, services: [service1]) }
-
-    it "returns platforms with services count depending on the category service belongs to" do
-      filter = described_class.new(category: category)
-
-      expect(filter.options).
-        to contain_exactly(name: platform1.name, id: platform1.id, count: 1)
-    end
+    let!(:counters) { { platform1.id => 2, platform2.id => 1 } }
 
     it "returns all platforms with services count if no category is specified" do
       filter = described_class.new
-
+      filter.counters = counters
       expect(filter.options).
         to contain_exactly({ name: platform1.name, id: platform1.id, count: 2 },
                            { name: platform2.name, id: platform2.id, count: 1 })
-    end
-  end
-
-  context "call" do
-    it "filters services basing on selected platforms" do
-      platform = create(:platform)
-      service = create(:service, platforms: [platform])
-      _other_service = create(:service)
-      filter = described_class.new(params: { "related_platforms" => platform.id.to_s })
-
-      expect(filter.call(Service.all)).to contain_exactly(service)
     end
   end
 end

--- a/spec/models/filter/provider_spec.rb
+++ b/spec/models/filter/provider_spec.rb
@@ -9,31 +9,15 @@ RSpec.describe Filter::Provider do
     let!(:service1)  { create(:service, providers: [provider1]) }
     let!(:service2)  { create(:service, providers: [provider1, provider2]) }
     let!(:category)  { create(:category, services: [service1]) }
-
-    it "returns providers with services count depending on the category service belongs to" do
-      filter = described_class.new(category: category)
-
-      expect(filter.options).
-        to contain_exactly(name: provider1.name, id: provider1.id, count: 1)
-    end
+    let!(:counters) { { provider1.id => 2, provider2.id => 1 } }
 
     it "returns all providers with services count if no category is specified" do
       filter = described_class.new
+      filter.counters = counters
 
       expect(filter.options).
         to contain_exactly({ name: provider1.name, id: provider1.id, count: 2 },
                            { name: provider2.name, id: provider2.id, count: 1 })
-    end
-  end
-
-  context "call" do
-    it "filters services basing on selected provider" do
-      provider = create(:provider)
-      service = create(:service, providers: [provider])
-      _other_service = create(:service)
-      filter = described_class.new(params: { "providers" => provider.id.to_s })
-
-      expect(filter.call(Service.all)).to contain_exactly(service)
     end
   end
 end

--- a/spec/models/filter/rating_spec.rb
+++ b/spec/models/filter/rating_spec.rb
@@ -3,13 +3,4 @@
 require "rails_helper"
 
 RSpec.describe Filter::Rating do
-  context "call" do
-    it "filters services basing on ranking" do
-      high_ranking = create(:service, rating: 3)
-      create(:service, rating: 1)
-      filter = described_class.new(params: { "rating" => "2" })
-
-      expect(filter.call(Service.all)).to contain_exactly(high_ranking)
-    end
-  end
 end

--- a/spec/models/filter/research_area_spec.rb
+++ b/spec/models/filter/research_area_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Filter::ResearchArea do
       create(:service, research_areas: [child1, child2])
       create(:service, research_areas: [child2])
 
-      counters = { root.id => 3, child1.id => 1, child2.id => 2 }
+      counters = { root.id => 1, child1.id => 1, child2.id => 2 }
       subject.counters = counters
 
       options = subject.options
@@ -22,13 +22,30 @@ RSpec.describe Filter::ResearchArea do
       first_option = options.first
       expect(first_option[:name]).to eq(root.name)
       expect(first_option[:id]).to eq(root.id)
-      expect(first_option[:count]).to eq(3)
+      expect(first_option[:count]).to eq(1)
 
       expect(first_option[:children]).to contain_exactly(
         { name: child1.name, id: child1.id, count: 1, children: [] },
         { name: child2.name, id: child2.id, count: 2, children: [] })
     end
   end
+
+  context "#active filters" do
+    it "returns correct active filters" do
+      parent = create(:research_area)
+      child1, child2 = create_list(:research_area, 2, parent: parent)
+      create(:service, research_areas: [child2])
+
+      params = ActionController::Parameters.new("research_areas" => [child1.id.to_s, parent.id.to_s])
+
+      filter = described_class.new(params: params)
+      filter.counters = { child2.id => 1 }
+
+      expect(filter.active_filters).
+          to include([parent.name, "research_areas" => [child1.id.to_s]], [child1.name, "research_areas" => [parent.id.to_s]])
+    end
+  end
+
   context "#constraint" do
     it "use parent and all children when parent is selected" do
       parent = create(:research_area)

--- a/spec/models/filter/research_area_spec.rb
+++ b/spec/models/filter/research_area_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Filter::ResearchArea do
       create(:service, research_areas: [child1, child2])
       create(:service, research_areas: [child2])
 
+      counters = { root.id => 3, child1.id => 1, child2.id => 2 }
+      subject.counters = counters
+
       options = subject.options
 
       expect(options.count).to eq(1)
@@ -26,31 +29,27 @@ RSpec.describe Filter::ResearchArea do
         { name: child2.name, id: child2.id, count: 2, children: [] })
     end
   end
-  context "#call" do
+  context "#constraint" do
     it "use parent and all children when parent is selected" do
       parent = create(:research_area)
       child = create(:research_area, parent: parent)
-      service = create(:service, research_areas: [parent])
-      child_research_area_service = create(:service, research_areas: [child])
       create(:service)
 
-      filter = described_class.new(params: { "research_areas" => [parent.id.to_s] })
+      filter = described_class.new(params: { "research_areas" => [child.id.to_s] })
 
-      expect(filter.call(Service.all)).
-        to contain_exactly(service, child_research_area_service)
+      expect(filter.constraint).
+         to eq(research_areas: [child.id])
     end
 
     it "use only parent and selected children when parent and children is selected" do
       parent = create(:research_area)
       child1, child2 = create_list(:research_area, 2, parent: parent)
-      service = create(:service, research_areas: [parent])
-      child_research_area_service = create(:service, research_areas: [child1])
       create(:service, research_areas: [child2])
 
       filter = described_class.new(params: { "research_areas" => [parent.id.to_s, child1.id.to_s] })
 
-      expect(filter.call(Service.all)).
-        to contain_exactly(service, child_research_area_service)
+      expect(filter.constraint).
+          to eq(research_areas: [parent.id, child1.id])
     end
   end
 end

--- a/spec/models/filter/tag_spec.rb
+++ b/spec/models/filter/tag_spec.rb
@@ -14,14 +14,4 @@ RSpec.describe Filter::Tag do
                                                 { name: "tag3", id: "tag3" })
     end
   end
-
-  context "call" do
-    it "filters services basing on selected tag" do
-      service = create(:service, tag_list: ["foo bar"])
-      _other_service = create(:service)
-      filter = described_class.new(params: { "tag" => "foo bar" })
-
-      expect(filter.call(Service.all)).to contain_exactly(service)
-    end
-  end
 end

--- a/spec/models/filter/target_group_spec.rb
+++ b/spec/models/filter/target_group_spec.rb
@@ -9,31 +9,15 @@ RSpec.describe Filter::TargetGroup do
     let!(:service1)  { create(:service, target_groups: [target_group1]) }
     let!(:service2)  { create(:service, target_groups: [target_group1, target_group2]) }
     let!(:category)  { create(:category, services: [service1]) }
-
-    it "returns target_groups with services count depending on the category service belongs to" do
-      filter = described_class.new(category: category)
-
-      expect(filter.options).
-        to contain_exactly(name: target_group1.name, id: target_group1.id, count: 1)
-    end
+    let!(:counters) { { target_group1.id => 2, target_group2.id => 1 } }
 
     it "returns all target_groups with services count if no category is specified" do
       filter = described_class.new
+      filter.counters = counters
 
       expect(filter.options).
         to contain_exactly({ name: target_group1.name, id: target_group1.id, count: 2 },
                            { name: target_group2.name, id: target_group2.id, count: 1 })
-    end
-  end
-
-  context "call" do
-    it "filters services basing on selected target_groups" do
-      target_group = create(:target_group)
-      service = create(:service, target_groups: [target_group])
-      _other_service = create(:service)
-      filter = described_class.new(params: { "target_groups" => target_group.id.to_s })
-
-      expect(filter.call(Service.all)).to contain_exactly(service)
     end
   end
 end

--- a/spec/models/filter_spec.rb
+++ b/spec/models/filter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Filter do
     def initialize(params = {})
       super(params: params.fetch(:params, {}),
             field_name: "my_filter", type: :select,
-            title: "My Filter")
+            title: "My Filter", index: "test")
     end
 
     protected
@@ -20,8 +20,8 @@ RSpec.describe Filter do
         end
       end
 
-      def do_call(services)
-        services.select { |s| s == value }
+      def where_constraint
+        { key: :value }
       end
   end
 
@@ -41,17 +41,17 @@ RSpec.describe Filter do
     end
   end
 
-  context "#call" do
+  context "#constraints" do
     it "is invoked when filter is active" do
       filter = MyFilter.new(params: { "my_filter" => "s2" })
 
-      expect(filter.call(["s1", "s2"])).to contain_exactly("s2")
+      expect(filter.constraint).to eq(key: :value)
     end
 
     it "returns all records when filter is not active" do
       filter = MyFilter.new
 
-      expect(filter.call(["s1", "s2"])).to eq(["s1", "s2"])
+      expect(filter.constraint).to eq({})
     end
   end
 


### PR DESCRIPTION
Fixes #783 
Description in the ticket itself

Changed:
- Reimplemented filters and categories after creating indexes in Elasticsearch 

Fixed:
- Category and filter counters 
- Hierarchical filters deactivation buttons
- Choice of "best match" sorting strategy after search 

Moved redirect after selecting a service in the search field after autocompletion: https://github.com/cyfronet-fid/marketplace/pull/916 