### PR TITLE
Maintaining sort order when filters are applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Category and filter counters (@bwilk)
 - Hierarchical filters deactivation buttons (@bwilk)
 - Choice of "best match" sorting strategy after search (@bwilk)
+- Maintaining sort order when filters are applied (@bwilk)
 
 ### Security
 

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -15,6 +15,7 @@
 
   = form_tag "", method: :get, role: "search", class: "filters"  do
     = hidden_field_tag :q, params[:q] if params[:q].present?
+    = hidden_field_tag :sort, params[:sort] if params[:sort].present?
     - @filters.each do |filter|
       = render "services/filters/#{filter.type}", filter: filter
 


### PR DESCRIPTION
When a filter is applied sort order is maintained. 

Fixes #922