### PR TITLE
Expand all projects on projects index view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Changed
 
 - Redirection to a service upon choice made by autocomplete in search bar (@bwilk)
-- Reimplemented filters and categories after creating indexes in Elasticsearch (@bwilk) 
+- Reimplemented filters and categories after creating indexes in Elasticsearch (@bwilk)
+- Expand all projects on projects index view (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/views/projects/_project.html.haml
+++ b/app/views/projects/_project.html.haml
@@ -1,5 +1,5 @@
 .row.list-group-item
-  %a.collapsed{ "href": "#collapse_#{project.id}", "aria-controls": "collapse_#{project.id}",
+  %a{ "href": "#collapse_#{project.id}", "aria-controls": "collapse_#{project.id}",
       "data-toggle": "collapse", "role": "tab", "aria-expanded": "false" }
     .collapse-icon.d-inline
       %i.fas.fa-chevron-down
@@ -9,5 +9,5 @@
       = link_to "Details", project_url(project),
         class: "float-right btn-sm btn btn-secondary d-inline"
 
-.row.align-items-center.border.panel-collapse.collapse.p-3{ "id": "collapse_#{project.id}" }
+.row.align-items-center.border.panel-collapse.collapse.show.p-3{ "id": "collapse_#{project.id}" }
   = render "projects/details_box", project: project


### PR DESCRIPTION
By default, all projects are expanded now on projects index view.

Fixes #924 
