### PR TITLE
[#919] Stay in project modal when project empty while ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Hierarchical filters deactivation buttons (@bwilk)
 - Choice of "best match" sorting strategy after search (@bwilk)
 - Maintaining sort order when filters are applied (@bwilk)
+- Redirection to project edit view on project creation failure while ordering (@bwilk) 
 
 ### Security
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -33,11 +33,8 @@ class ProjectsController < ApplicationController
     @project = Project.new(user: current_user)
 
     respond_to do |format|
-      format.html do
-        @show_as_modal = false
-      end
+      format.html
       format.js do
-        @show_as_modal = true
         render_modal_form
       end
     end
@@ -69,7 +66,6 @@ class ProjectsController < ApplicationController
   end
 
   def edit
-    @show_as_modal = false
   end
 
   def update
@@ -93,6 +89,7 @@ class ProjectsController < ApplicationController
     end
 
     def render_modal_form
+      @show_as_modal = true
       render "layouts/show_modal",
               locals: {
                 title: "New project",

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -261,6 +261,26 @@ RSpec.feature "Service ordering" do
       expect(user.projects.find { |project| project.name == "New project" }).to_not be_nil
     end
 
+    scenario "I will stay in project edit modal while trying to create empty project", js: true do
+      service = create(:service)
+      create(:offer, service: service)
+
+      visit service_path(service)
+
+      click_on "Order"
+      click_on "Add new project"
+
+      click_on "Create new project"
+      within("#ajax-modal") do
+        expect(page).to have_button("Create new project")
+      end
+
+      click_on "Create new project"
+      within("#ajax-modal") do
+        expect(page).to have_button("Create new project")
+      end
+    end
+
     scenario "I can create new project for private company typology", js: true do
       service = create(:service)
       create(:offer, service: service)


### PR DESCRIPTION
Redirection to project edit view on project creation failure while ordering is fixed. User stays in this modal after fix:

![Zrzut ekranu 2019-06-24 o 12 14 47](https://user-images.githubusercontent.com/2674939/60011264-b564c480-9679-11e9-8270-dc11bb03ea2e.png)

Fixes #919 