### PR TITLE
[#798] omniauth.origin is used when applicable to redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 
+- Wrong redirection after logging in while browsing the portal (@bwilk)
+
 ### Security
 
 ## [1.12.0] 2019-06-17

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -24,4 +24,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def after_omniauth_failure_path_for(scope)
     root_path
   end
+
+  def after_sign_in_path_for(scope)
+    request.env["omniauth.origin"] || super(scope)
+  end
 end

--- a/spec/support/helpers/omniauth_helper.rb
+++ b/spec/support/helpers/omniauth_helper.rb
@@ -6,6 +6,7 @@ module OmniauthHelper
     last_name = options.fetch(:last_name, "Doe"),
     email = options.fetch(:email, "#{first_name}.#{last_name}@email.pl")
     uid = options.fetch(:uid, 123)
+    origin = options.fetch(:origin, current_path)
 
     OmniAuth.config.add_mock(
       provider,
@@ -17,6 +18,9 @@ module OmniauthHelper
       provider: provider,
       uid: uid
     )
+    OmniAuth.config.before_callback_phase do |env|
+      env["omniauth.origin"] = origin
+    end
   end
 
   def stub_checkin(user)


### PR DESCRIPTION
Fixes redirect to the root page after logging in
Fixes #798 