### PR TITLE
Project list view redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Reimplemented filters and categories after creating indexes in Elasticsearch (@bwilk)
 - Expand all projects on projects index view (@mkasztelnik)
 - Improvements for project box views (@mkasztelnik)
+- Project card redesigned (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/helpers/project_items_helper.rb
+++ b/app/helpers/project_items_helper.rb
@@ -22,4 +22,12 @@ module ProjectItemsHelper
   def ratingable?
     (@project_item.ready? && @project_item.service_opinion.nil?)
   end
+
+  def project_item_status(project_item)
+    if project_item.in_progress?
+      content_tag(:i, nil, class: "fas fa-spinner")
+    else
+      content_tag(:i, nil, class: "fas fa-circle status-#{project_item.status.dasherize}")
+    end
+  end
 end

--- a/app/javascript/stylesheets/_status.scss
+++ b/app/javascript/stylesheets/_status.scss
@@ -1,0 +1,19 @@
+.status-created {
+  color: #0000ff;
+}
+
+.status-registered {
+  color: #0000ff;
+}
+
+.status-waiting-for-response {
+  color: #ffff00;
+}
+
+.status-ready {
+  color: #008000;
+}
+
+.status-rejected {
+  color: #ff0000;
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -11,6 +11,7 @@
 @import 'flash';
 @import 'header';
 @import 'order';
+@import 'status';
 @import 'admin/jobs';
 @import 'bootstrap-customizations';
 @import 'policy-cookiebar-customizations';

--- a/app/views/project_items/_project_item.html.haml
+++ b/app/views/project_items/_project_item.html.haml
@@ -1,20 +1,7 @@
 %li.list-group-item
-  .row
-    .col-md.font-weight-bold
-      = link_to project_item.service.title, project_item
-    .col-md-2
-      %span.text-uppercase
-        = project_item.status
-    .col-md-4
-
-      - if project_item.status == ProjectItem.statuses[:ready]
-        %span
-          = link_to "Access the service", project_item.service.webpage_url,
-            class: "btn btn-primary btn-sm"
-    .col-md.text-md-right
-      %span
-        last change: #{time_ago_in_words(project_item.updated_at)} ago
-%li.list-group-item.mt-2
-  .row.d-flex.justify-content-center
-    = link_to "Add another service", services_url
-
+  = link_to project_item.service.title, project_item
+  .float-right
+    - if project_item.open_access?
+      = link_to "Visit website", project_item.service.webpage_url
+    - else
+      = project_item_status(project_item)

--- a/app/views/projects/_empty_project.html.haml
+++ b/app/views/projects/_empty_project.html.haml
@@ -1,10 +1,12 @@
-.border.text-center
-  %p
-    You have no services in this project yet.
-    %br
-    = link_to "Use our catalogue to add one.", services_url
-  %p
-    If you need help with these don't hesitate and
-    %br
-    = link_to "contact with our support!", project_chat_path(project)
+.row.mr-4
+  .col
+    You have no services in this project yet. Use our catalogue to add one.
+  .col
+    = link_to "Add service to this project", services_url, class: "btn btn-primary btn-sm btn-block"
+.row.mt-4.mr-4
+  .col
+    If you need help with these don't hesitate and contact with our support.
+  .col
+    = link_to "Contact with support", project_chat_path(project), class: "btn btn-primary btn-sm btn-block"
 
+%hr.mr-4

--- a/app/views/projects/_project.html.haml
+++ b/app/views/projects/_project.html.haml
@@ -1,13 +1,34 @@
-.row.list-group-item
-  %a{ "href": "#collapse_#{project.id}", "aria-controls": "collapse_#{project.id}",
-      "data-toggle": "collapse", "role": "tab", "aria-expanded": "false" }
-    .collapse-icon.d-inline
-      %i.fas.fa-chevron-down
-      %i.fas.fa-chevron-up
-    %h2.d-inline.ml-3.font-weight-normal= project.name
-    - if policy(project).show?
-      = link_to "Manage and get support", project_url(project),
-        class: "float-right btn-sm btn btn-secondary d-inline"
+.card.mb-2.rounded
+  .card-header{ id: "project_header_#{project.id}" }
+    %h2.mb-0
+      %button.btn.btn-link{ type: "button",
+        data: { toggle: "collapse", target: "#project#{project.id}" },
+        aria: { controls: "project#{project.id}", expanded: "true" } }
+        .collapse-icon.d-inline
+          %i.fas.fa-chevron-down
+          %i.fas.fa-chevron-up
+        = project.name
 
-.row.align-items-center.border.panel-collapse.collapse.show.p-3{ "id": "collapse_#{project.id}" }
-  = render "projects/details_box", project: project
+  .collapse.show{ id: "project#{project.id}", "aria-labelledby": "projectHeader#{project.id}" }
+    .container.m-3
+      .row
+        .col
+          %dl
+            %dt Customer typology
+            %dd= t "projeproject.customer_typology.#{project.customer_typology}"
+            %dt Reason to request access to the EOSC services
+            %dd= project.reason_for_access
+        .col.mr-4
+          %h3.text-uppercase
+            %i.fas.fa-box-open
+            Project services
+          - if project.project_items.size.positive?
+            %ul.list-group-flush
+              = render(project.project_items)
+            .row
+              .col.d-flex.justify-content-end
+                = link_to "Add service to this project", services_url,
+                  class: "btn btn-primary btn-sm"
+          - else
+            = render("projects/empty_project", project: project)
+

--- a/spec/features/my_services_spec.rb
+++ b/spec/features/my_services_spec.rb
@@ -152,15 +152,6 @@ RSpec.feature "My Services" do
 
       expect(page).to have_text("Question cannot be blank")
     end
-
-    scenario "I see webservice link if service is ready" do
-      project = create(:project, user: user)
-      project_item = create(:project_item, project: project, offer: offer, status: :ready)
-
-      visit projects_path
-
-      expect(page).to have_link("Access the service", href: project_item.service.webpage_url)
-    end
   end
 
   context "as anonymous user" do


### PR DESCRIPTION
The name of the branch is misleading. Fix for #929 was done as a result of implementing the new @abacz idea for projects list look and feel. This is not finished yet. Some CSS alignments are still needed (especially `card` component and HTML elements in this component is too specific for offer presentation and need to be refactored).

TODOs:
  * [x] @mkasztelnik initial redesign

This is how it looks like right now:
![new-projects-list](https://user-images.githubusercontent.com/1265430/60421790-d766c580-9bea-11e9-9d2c-d92a3865d19e.png)
