### PR TITLE
Service owner can edit service draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- Service owner can edit service draft (@mkasztelnik)
 
 ### Changed
 
@@ -28,7 +29,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Redirection to a service upon choice made by autocomplete in search bar (@bwilk)
-- Reimplemented filters and categories after creating indexes in Elasticsearch (@bwilk) 
+- Reimplemented filters and categories after creating indexes in Elasticsearch (@bwilk)
 
 ### Fixed
 - Blocked access to the draft service via direct link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
-- Service owner can edit service draft (@mkasztelnik)
+- Service owner can edit service draft and service offer drafts (@mkasztelnik)
 
 ### Changed
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -18,6 +18,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
   end
 
   def show
+    @offer = Offer.new(service: @service, status: :draft)
   end
 
   def new

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -138,6 +138,10 @@ class Service < ApplicationRecord
     platforms.pluck(:name).include?("EGI Applications on Demand")
   end
 
+  def owned_by?(user)
+    service_user_relationships.where(user: user).count.positive?
+  end
+
   private
     def logo_variable
       if logo.present? && !logo.variable?

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -15,24 +15,23 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def new?
-    service_portfolio_manager?
+    service_portfolio_manager? || record.service.owned_by?(user)
   end
 
   def create?
-    service_portfolio_manager?
+    managed?
   end
 
   def edit?
-    service_portfolio_manager?
+    managed?
   end
 
   def update?
-    service_portfolio_manager?
+    managed?
   end
 
   def destroy?
-    service_portfolio_manager? &&
-      project_items.count.zero?
+    managed? && project_items.count.zero?
   end
 
   def publish?
@@ -50,6 +49,11 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   private
+
+    def managed?
+      service_portfolio_manager? ||
+        (record.service.owned_by?(user) && record.draft?)
+    end
 
     def service_portfolio_manager?
       user&.service_portfolio_manager?

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -31,17 +31,15 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def destroy?
-    managed? && project_items.count.zero?
+    managed? && orderless?
   end
 
   def publish?
-    service_portfolio_manager? &&
-      record.draft?
+    service_portfolio_manager? && record.draft?
   end
 
   def draft?
-    service_portfolio_manager? &&
-      record.published?
+    service_portfolio_manager? && record.published?
   end
 
   def permitted_attributes
@@ -59,7 +57,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
       user&.service_portfolio_manager?
     end
 
-    def project_items
-      ProjectItem.joins(:offer).where(offers: { service_id: record.service })
+    def orderless?
+      record.project_items.count.zero?
     end
 end

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -31,7 +31,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   def update?
-    service_portfolio_manager?
+    service_portfolio_manager? || (record.draft? && owned_service?)
   end
 
   def publish?

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -77,9 +77,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
     end
 
     def owned_service?
-      ServiceUserRelationship.
-        where(service: record, user: user).
-        count.positive?
+      record.owned_by?(user)
     end
 
     def project_items

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -12,7 +12,7 @@
                   backoffice_service_path(@service),
                   method: :delete, data: { confirm: "Are you sure?" },
                   class: "btn btn-danger float-right"
-      - if policy([:backoffice, @service]).new?
+      - if policy([:backoffice, @offer]).new?
         = link_to "Add new offer", new_backoffice_service_offer_path(@service),
             class: "btn btn-primary float-right ml-3 mb-3"
       - if policy([:backoffice, @service]).edit?
@@ -46,7 +46,7 @@
         .col-6
           %h3.m-0.mt-2 Offers
         .col-6
-          - if policy([:backoffice, @service]).new?
+          - if policy([:backoffice, @offer]).new?
             = link_to "Add new offer", new_backoffice_service_offer_path(@service),
               class: "btn btn-primary btn-sm float-right"
       = render "backoffice/services/offers/offers", service: @service

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -319,4 +319,21 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_content(external_source.to_s, count: 2)
     end
   end
+
+  context "as a service owner" do
+    let(:user) { create(:user) }
+
+    before { checkin_sign_in_as(user) }
+
+    scenario "I can edit service draft" do
+      service = create(:service, owners: [user], status: :draft)
+
+      visit backoffice_service_path(service)
+      click_on "Edit"
+
+      fill_in "Title", with: "Owner can edit service draft"
+      click_on "Update Service"
+      expect(page).to have_content("Owner can edit service draft")
+    end
+  end
 end

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -335,5 +335,19 @@ RSpec.feature "Services in backoffice" do
       click_on "Update Service"
       expect(page).to have_content("Owner can edit service draft")
     end
+
+    scenario "I can create new offer" do
+      service = create(:service, owners: [user])
+
+      visit backoffice_service_path(service)
+      click_on "Add new offer", match: :first
+
+      fill_in "Name", with: "New offer"
+      fill_in "Description", with: "New fancy offer"
+      click_on "Create Offer"
+
+      expect(page).to have_content("New offer")
+      expect(page).to have_content("New fancy offer")
+    end
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -128,4 +128,20 @@ RSpec.describe Service do
     service.order_target = ""
     expect(service.valid?).to be_truthy
   end
+
+  context "#owned_by?" do
+    it "is true when user is in the owners list" do
+      owner = create(:user)
+      service = create(:service, owners: [owner])
+
+      expect(service.owned_by?(owner)).to be_truthy
+    end
+
+    it "is false when user is not in the owers list" do
+      stranger = create(:user)
+      service = create(:service)
+
+      expect(service.owned_by?(stranger)).to be_falsy
+    end
+  end
 end

--- a/spec/policies/backoffice/offer_policy_spec.rb
+++ b/spec/policies/backoffice/offer_policy_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Backoffice::OfferPolicy do
     end
   end
 
+  permissions :destroy? do
+    let(:offer) { create(:offer, service: service) }
+
+    before { create(:project_item, offer: offer) }
+
+    it "denies for all when service is ordered using this offer" do
+      expect(subject).to_not permit(service_portfolio_manager, offer)
+      expect(subject).to_not permit(owner, offer)
+      expect(subject).to_not permit(stranger, offer)
+    end
+  end
+
   context "when offer is published" do
     let(:offer) { build(:offer, service: service, status: :published) }
 

--- a/spec/policies/backoffice/offer_policy_spec.rb
+++ b/spec/policies/backoffice/offer_policy_spec.rb
@@ -5,82 +5,58 @@ require "rails_helper"
 RSpec.describe Backoffice::OfferPolicy do
   let(:service_portfolio_manager) { create(:user, roles: [:service_portfolio_manager]) }
   let(:owner) { create(:user) }
+  let(:stranger) { create(:user) }
+  let(:service) { create(:service, owners: [owner]) }
 
   subject { described_class }
 
-  context "when service is a draft" do
-    let(:service_draft) { create(:service, status: :draft, owners: [owner]) }
+  permissions :new? do
+    let(:offer) { build(:offer, service: service) }
 
-    context "and offer is published" do
-      permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grants access to service portfolio manager" do
-          expect(subject)
-            .to permit(service_portfolio_manager,
-                       build(:offer, service: build(:service, status: :draft)))
-        end
-      end
-
-      permissions :destroy?, :update?, :edit?, :create? do
-        it "denies access to service owner" do
-          expect(subject).
-            to_not permit(owner, build(:offer, service: service_draft))
-        end
-      end
+    it "grants access to service portfolio manager" do
+      expect(subject).to permit(service_portfolio_manager, offer)
     end
 
-    context "and offer is a draft" do
-      permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grants access to service portfolio manager" do
-          expect(subject)
-            .to permit(service_portfolio_manager,
-                       build(:offer, status: :draft,
-                             service: build(:service, status: :draft)))
-        end
+    it "grants access to service owner" do
+      expect(subject).to permit(owner, offer)
+    end
+
+    it "denies access to other users" do
+      expect(subject).to_not permit(stranger, offer)
+    end
+  end
+
+  context "when offer is published" do
+    let(:offer) { build(:offer, service: service, status: :published) }
+
+    permissions :create?, :edit?, :update?, :destroy? do
+      it "grants access to service portfolio manager" do
+        expect(subject).to permit(service_portfolio_manager, offer)
       end
 
-      permissions :destroy?, :new?, :update?, :edit?, :create? do
-        it "grant access to service owner" do
-          expect(subject)
-            .to permit(owner, build(:offer, status: :draft, service: service_draft))
-        end
+      it "denies access to service owner" do
+        expect(subject).to_not permit(owner, offer)
+      end
+
+      it "denies access to other users" do
+        expect(subject).to_not permit(stranger, offer)
       end
     end
   end
 
-  context "when service is published" do
-    let(:service_published) { create(:service, status: :published, owners: [owner]) }
+  context "when offer is a draft" do
+    let(:offer) { build(:offer, service: service, status: :draft) }
 
-    context "and offer is published" do
-      permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grants access to service portfolio manager" do
-          expect(subject)
-            .to permit(service_portfolio_manager,
-                       build(:offer, service: build(:service)))
-        end
+    permissions :create?, :edit?, :update?, :destroy? do
+      it "grants access to service portfolio manager" do
+        expect(subject).to permit(service_portfolio_manager, offer)
       end
 
-      permissions :create?, :edit?, :update?, :destroy? do
-        it "danies access to service owner" do
-          expect(subject)
-            .to_not permit(owner, build(:offer, service: service_published))
-        end
+      it "grant access to service owner" do
+        expect(subject).to permit(owner, offer)
       end
-    end
-
-    context "and offer is a draft" do
-      permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grants access to service portfolio manager" do
-          expect(subject)
-            .to permit(service_portfolio_manager,
-                       build(:offer, status: :draft, service: build(:service)))
-        end
-      end
-
-      permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grant access to service owner" do
-          expect(subject)
-            .to permit(owner, build(:offer, status: :draft, service: service_published))
-        end
+      it "denies access to other users" do
+        expect(subject).to_not permit(stranger, offer)
       end
     end
   end

--- a/spec/policies/backoffice/offer_policy_spec.rb
+++ b/spec/policies/backoffice/offer_policy_spec.rb
@@ -4,72 +4,84 @@ require "rails_helper"
 
 RSpec.describe Backoffice::OfferPolicy do
   let(:service_portfolio_manager) { create(:user, roles: [:service_portfolio_manager]) }
-  let(:service_owner) do
-    create(:user).tap do |user|
-      service_draft = create(:service, status: :draft)
-      service_published = create(:service, status: :published)
-      ServiceUserRelationship.create!(user: user, service: service_draft)
-      ServiceUserRelationship.create!(user: user, service: service_published)
-    end
-  end
+  let(:owner) { create(:user) }
 
   subject { described_class }
 
-  context "offer published" do
-    context "Service draft" do
+  context "when service is a draft" do
+    let(:service_draft) { create(:service, status: :draft, owners: [owner]) }
+
+    context "and offer is published" do
       permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grants access service portfolio manager" do
-          expect(subject).to permit(service_portfolio_manager, build(:offer, service: build(:service, status: :draft)))
+        it "grants access to service portfolio manager" do
+          expect(subject)
+            .to permit(service_portfolio_manager,
+                       build(:offer, service: build(:service, status: :draft)))
         end
       end
 
       permissions :destroy?, :new?, :update?, :edit?, :create? do
-        it "denied access  service owner" do
-          expect(subject).to_not permit(service_owner, build(:offer, service: service_owner.owned_services.draft.first))
+        it "denied access to service owner" do
+          expect(subject)
+            .to_not permit(owner, build(:offer, service: service_draft))
         end
       end
     end
 
-    context "service published" do
+    context "and offer is a draft" do
       permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grants access service portfolio manager" do
-          expect(subject).to permit(service_portfolio_manager, build(:offer, service: build(:service)))
+        it "grants access to service portfolio manager" do
+          expect(subject)
+            .to permit(service_portfolio_manager,
+                       build(:offer, status: :draft,
+                             service: build(:service, status: :draft)))
         end
       end
 
-      permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "danies access service owner" do
-          expect(subject).to_not permit(service_owner, build(:offer, service: service_owner.owned_services.published.first))
+      permissions :destroy?, :new?, :update?, :edit?, :create? do
+        it "denied access to service owner" do
+          expect(subject)
+            .to_not permit(owner,
+                           build(:offer, status: :draft, service: service_draft))
         end
       end
     end
   end
 
-  context "offer draft" do
-    context "Service draft" do
+  context "when service is published" do
+    let(:service_published) { create(:service, status: :published, owners: [owner]) }
+
+    context "and offer is published" do
       permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grants access service portfolio manager" do
-          expect(subject).to permit(service_portfolio_manager, build(:offer, status: :draft, service: build(:service, status: :draft)))
+        it "grants access to service portfolio manager" do
+          expect(subject)
+            .to permit(service_portfolio_manager,
+                       build(:offer, service: build(:service)))
         end
       end
 
-      permissions :destroy?, :new?, :update?, :edit?, :create? do
-        it "denied access  service owner" do
-          expect(subject).to_not permit(service_owner, build(:offer, status: :draft, service: service_owner.owned_services.draft.first))
+      permissions :new?, :create?, :edit?, :update?, :destroy? do
+        it "danies access to service owner" do
+          expect(subject)
+            .to_not permit(owner, build(:offer, service: service_published))
         end
       end
     end
 
-    context "service published" do
+    context "and offer is a draft" do
       permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "grants access service portfolio manager" do
-          expect(subject).to permit(service_portfolio_manager, build(:offer, status: :draft, service: build(:service)))
+        it "grants access to service portfolio manager" do
+          expect(subject)
+            .to permit(service_portfolio_manager,
+                       build(:offer, status: :draft, service: build(:service)))
         end
       end
 
       permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "danies access service owner" do
-          expect(subject).to_not permit(service_owner, build(:offer, status: :draft, service: service_owner.owned_services.published.first))
+        it "danies access to service owner" do
+          expect(subject)
+            .to_not permit(owner,
+                           build(:offer, status: :draft, service: service_published))
         end
       end
     end

--- a/spec/policies/backoffice/offer_policy_spec.rb
+++ b/spec/policies/backoffice/offer_policy_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe Backoffice::OfferPolicy do
         end
       end
 
-      permissions :destroy?, :new?, :update?, :edit?, :create? do
-        it "denied access to service owner" do
-          expect(subject)
-            .to_not permit(owner, build(:offer, service: service_draft))
+      permissions :destroy?, :update?, :edit?, :create? do
+        it "denies access to service owner" do
+          expect(subject).
+            to_not permit(owner, build(:offer, service: service_draft))
         end
       end
     end
@@ -39,10 +39,9 @@ RSpec.describe Backoffice::OfferPolicy do
       end
 
       permissions :destroy?, :new?, :update?, :edit?, :create? do
-        it "denied access to service owner" do
+        it "grant access to service owner" do
           expect(subject)
-            .to_not permit(owner,
-                           build(:offer, status: :draft, service: service_draft))
+            .to permit(owner, build(:offer, status: :draft, service: service_draft))
         end
       end
     end
@@ -60,7 +59,7 @@ RSpec.describe Backoffice::OfferPolicy do
         end
       end
 
-      permissions :new?, :create?, :edit?, :update?, :destroy? do
+      permissions :create?, :edit?, :update?, :destroy? do
         it "danies access to service owner" do
           expect(subject)
             .to_not permit(owner, build(:offer, service: service_published))
@@ -78,10 +77,9 @@ RSpec.describe Backoffice::OfferPolicy do
       end
 
       permissions :new?, :create?, :edit?, :update?, :destroy? do
-        it "danies access to service owner" do
+        it "grant access to service owner" do
           expect(subject)
-            .to_not permit(owner,
-                           build(:offer, status: :draft, service: service_published))
+            .to permit(owner, build(:offer, status: :draft, service: service_published))
         end
       end
     end

--- a/spec/policies/backoffice/service_policy_spec.rb
+++ b/spec/policies/backoffice/service_policy_spec.rb
@@ -53,6 +53,22 @@ RSpec.describe Backoffice::ServicePolicy do
       end
     end
 
+    permissions :update? do
+      let(:owner) { create(:user) }
+
+      it "grants access for service owner when service is a draft" do
+        service = create(:service, owners: [owner], status: :draft)
+
+        expect(subject).to permit(owner, service)
+      end
+
+      it "denies access for service owner when service is published" do
+        service = create(:service, owners: [owner], status: :published)
+
+        expect(subject).to_not permit(owner, service)
+      end
+    end
+
     permissions :destroy? do
       it "grants access for service portfolio manager" do
         expect(subject).to permit(service_portfolio_manager, build(:service, status: :draft))


### PR DESCRIPTION
Service draft can be now edited by the owner. I'm waiting for decision if the owner should be able to edit service draft offers as well.

Fixes #983