### PR TITLE
Fix field naming problem

### DIFF
--- a/app/views/projects/_details.html.haml
+++ b/app/views/projects/_details.html.haml
@@ -61,7 +61,7 @@
 
       - unless project.single_user?
         %dt Collaboration countries
-        %dd= country_name(project.country_of_collaboration).join(", ")
+        %dd= project.countries_of_partnership.join(", ")
 
     %h3 Usage
     %dl


### PR DESCRIPTION
Old field name was used instead of new one