### PR TITLE
Turn off model validation on project migration tasks

### DIFF
--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -203,7 +203,7 @@ private
         nil
       end
     when "CP-CustomerCountry"
-      project.country_of_origin.name || "N/A"
+      project.country_of_origin&.name || "N/A"
     when "CP-CollaborationCountry"
       if project.countries_of_partnership.present?
         project.countries_of_partnership.map(&:name).join(", ")

--- a/lib/jira/project_migrator.rb
+++ b/lib/jira/project_migrator.rb
@@ -11,7 +11,8 @@ module Jira
     def call
       Project.where(issue_status: :jira_require_migration).each do |project|
         issue = @client.create_project_issue project
-        project.update_attributes(issue_id: issue.id, issue_key: issue.key, issue_status: :jira_active)
+        project.update_columns(issue_id: issue.id, issue_key: issue.key,
+                               issue_status: :jira_active)
 
         puts "Created issue for Project with ID '#{project.id}' - JIRA issue: #{issue.key}"
 

--- a/lib/tasks/projects_migrate_from_affiliation.rake
+++ b/lib/tasks/projects_migrate_from_affiliation.rake
@@ -4,7 +4,6 @@ require "securerandom"
 
 namespace :projects do
   desc "Remove default projects without services attached"
-
   task migrate_from_affiliation: :environment do
     Project.transaction do
       Project.includes(:project_items, user: :affiliations)
@@ -45,11 +44,7 @@ namespace :projects do
       project.reason_for_access = "Not specified" if project.reason_for_access.blank?
       project.user_group_name = "Not speficied" if project.user_group_name.blank?
 
-      unless project.valid?
-        puts "ERROR!!!!!!!!! #{project.errors.inspect}"
-      end
-
-      project.save!
+      project.save!(validate: false)
     end
   end
 end


### PR DESCRIPTION
This is needed since we did it wrong and after the release, we will have nil values in the place where such values should not occur. This missing information should be filled in by the project owner, but until this happened we need to perform a set of migrations (migrated data from affiliation to project, register project in Jira). To make it happened we need to update not valid (yet) project. This is the reason why
validation is turned on on these migration tasks.