### PR TITLE
Showing only published services at the homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Showing only published services at the homepage
+
 
 ### Security
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,6 +12,6 @@ class HomeController < ApplicationController
       @providers_number = Provider.count
       @services_number = Service.count
       @countries_number = 32
-      @services = Service.includes(:providers).order(rating: :asc, title: :desc).limit(8)
+      @services = Service.published.includes(:providers).order(rating: :asc, title: :desc).limit(8)
     end
 end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -14,4 +14,14 @@ RSpec.feature "Home" do
     expect(page).to have_current_path(services_path, ignore_query: true)
     expect(page).to have_selector("#q[value='Something']")
   end
+
+  context "services carousel" do
+    let!(:service1) { create(:service, title: "published-service-123", status: :published) }
+    let!(:service2) { create(:service, title: "draft-service-123", status: :draft) }
+    it "should not show not published service at carousel" do
+      visit "/"
+      expect(page).to have_selector("div.card-title", text: "published-service-123")
+      expect(page).not_to have_selector("div.card-title", text: "draft-service-123")
+    end
+  end
 end


### PR DESCRIPTION
Quick fix for not public services that are currently shown (eIC services are not visible in catalogue but homepage shows them even though they are Drafts)

<img width="612" alt="Zrzut ekranu 2019-08-12 o 18 34 55" src="https://user-images.githubusercontent.com/2674939/62881415-0d41b280-bd30-11e9-844d-3f05593be3aa.png">


