### PR TITLE
[#954] Delete "terms of use" from form in backoffice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Removed
 - Affiliation model removed (@mkasztelnik)
+- Remove terms_of_use field from the service model and forms (@goreck888)
 
 ### Fixed
 - Display choices.js in the owners multiselect field in the new service form (@goreck888)

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -50,7 +50,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :title, :description, :terms_of_use,
+      :title, :description,
       :tagline, :connected_url, :service_type,
       [provider_ids: []], :places, :languages,
       [target_group_ids: []], :terms_of_use_url,

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -40,7 +40,6 @@
       = f.input :languages
   .row
     .col-12.col-md-10
-      = f.input :terms_of_use
       = f.input :terms_of_use_url
       = f.input :access_policies_url
       = f.input :corporate_sla_url

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -66,9 +66,6 @@
 
       %hr
 
-      %h5 Terms of use
-      = markdown(@service.terms_of_use)
-
       %h5 Service website
       %p= @service.connected_url
 

--- a/db/migrate/20190816135743_remove_terms_of_use_in_service.rb
+++ b/db/migrate/20190816135743_remove_terms_of_use_in_service.rb
@@ -1,0 +1,5 @@
+class RemoveTermsOfUseInService < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :services, :terms_of_use
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_14_203908) do
+ActiveRecord::Schema.define(version: 2019_08_16_135743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,8 +166,8 @@ ActiveRecord::Schema.define(version: 2019_08_14_203908) do
     t.string "department"
     t.string "webpage"
     t.string "status"
-    t.datetime "created_at", default: "2019-08-20 11:12:44", null: false
-    t.datetime "updated_at", default: "2019-08-20 11:12:44", null: false
+    t.datetime "created_at", default: "2019-08-19 15:42:13", null: false
+    t.datetime "updated_at", default: "2019-08-19 15:42:13", null: false
     t.index ["name", "user_id"], name: "index_projects_on_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
@@ -278,7 +278,6 @@ ActiveRecord::Schema.define(version: 2019_08_14_203908) do
     t.text "description", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "terms_of_use"
     t.text "tagline", null: false
     t.decimal "rating", precision: 2, scale: 1, default: "0.0", null: false
     t.text "connected_url"

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -17,7 +17,6 @@ if Rails.env.development?
         owners = sample_user ? [sample_user] : []
         Service.create(title: Faker::Lorem.sentence,
                        description: Faker::Lorem.paragraph,
-                       terms_of_use: Faker::Lorem.paragraph,
                        tagline: Faker::Lorem.sentence,
                        categories: [Category.all.sample],
                        owners: owners,

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :service do
     sequence(:title) { |n| "service #{n}" }
     sequence(:description) { |n| "service #{n} description" }
-    sequence(:terms_of_use) { |n| "service #{n} terms of use" }
     sequence(:tagline) { |n| "service #{n} tagline" }
     sequence(:service_type) { :normal }
 

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -77,7 +77,6 @@ RSpec.feature "Services in backoffice" do
 
       expect(page).to have_content("service title")
       expect(page).to have_content("service description")
-      expect(page).to have_content("service terms of use")
       expect(page).to have_content("service tagline")
       expect(page).to have_content("https://sample.url")
       expect(page).to have_content("open_access")


### PR DESCRIPTION
Delete terms_of_use field in the service forms, models and views
Fixes #954