### PR TITLE
Reuse `Project::Authorize` concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Move project create logic from controller to service (@mkasztelnik)
+- Reuse `Project::Authorize`concern in project related controllers (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/controllers/concerns/project/authorize.rb
+++ b/app/controllers/concerns/project/authorize.rb
@@ -4,6 +4,7 @@ module Project::Authorize
   extend ActiveSupport::Concern
 
   included do
+    before_action :authenticate_user!
     before_action :load_and_authorize_project!
   end
 

--- a/app/controllers/projects/adds_controller.rb
+++ b/app/controllers/projects/adds_controller.rb
@@ -1,19 +1,11 @@
 # frozen_string_literal: true
 
 class Projects::AddsController < ApplicationController
-  before_action :authenticate_user!
-  before_action :load_and_authorize_project!
+  include Project::Authorize
 
   def create
     session[:selected_project] = @project.id
 
     redirect_to services_path
   end
-
-  private
-
-    def load_and_authorize_project!
-      @project = Project.find(params[:project_id])
-      authorize(@project, :show?)
-    end
 end

--- a/app/controllers/projects/archives_controller.rb
+++ b/app/controllers/projects/archives_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class Projects::ArchivesController < ApplicationController
-  before_action :load_and_authorize_project!
+  include Project::Authorize
 
   def create
+    authorize(@project, :archive?)
     if Project::Archive.new(@project).call
       redirect_to projects_path,
                   notice: "Project archived"
@@ -12,11 +13,4 @@ class Projects::ArchivesController < ApplicationController
       redirect_to project_path(@project)
     end
   end
-
-  private
-
-    def load_and_authorize_project!
-      @project = Project.find(params[:project_id])
-      authorize(@project, :archive?)
-    end
 end

--- a/app/controllers/projects/conversations_controller.rb
+++ b/app/controllers/projects/conversations_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class Projects::ConversationsController < ApplicationController
-  before_action :authenticate_user!
-  before_action :load_and_authorize_project!
+  include Project::Authorize
 
   def show
     @projects = policy_scope(Project).order(:name)
@@ -24,11 +23,4 @@ class Projects::ConversationsController < ApplicationController
       render :show, status: :bad_request
     end
   end
-
-  private
-
-    def load_and_authorize_project!
-      @project = Project.find(params[:project_id])
-      authorize(@project, :show?)
-    end
 end

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Projects::ServicesController < ApplicationController
-  before_action :authenticate_user!
-
   include Project::Authorize
 
   before_action :load_projects


### PR DESCRIPTION
Fetching project and checking if the project can be displayed by the user logic was duplicated in many controllers. By reusing `Project::Authorize` concern we can avoid duplication.