### PR TITLE
Remove categories counter cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Deprecated
 
 ### Removed
+- Remove category `services_count` (@mkasztelnik)
 
 ### Fixed
 - Hide scrollArrow on scroll event (@goreck888)

--- a/app/models/categorization.rb
+++ b/app/models/categorization.rb
@@ -3,36 +3,11 @@
 class Categorization < ApplicationRecord
   belongs_to :service
   belongs_to :category
-  counter_culture :category,
-    foreign_key_values: proc { |category_id| [category_id, *Category.find(category_id).ancestor_ids] },
-    column_name: proc { |model| model.published? ? "services_count" : nil }
 
   validates :service, presence: true
   validates :category, presence: true
 
   after_save :guarantee_only_one_main, if: :main?
-  after_touch :_update_counts_after_update
-
-  attribute :status
-
-  def published?
-    status == Service.statuses[:published]
-  end
-
-  def category_id_before_last_save
-    super || category_id
-  end
-
-  def saved_changes
-    super.tap do |saved_changes|
-      status_change = service.saved_change_to_status
-      saved_changes["status"] = status_change if status_change
-    end
-  end
-
-  def status
-    super || (service && service.status)
-  end
 
   private
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -132,11 +132,6 @@ class Service < ApplicationRecord
     offers_count.positive?
   end
 
-  after_commit on: [:update] do
-    # Update categories counters
-    categorizations.each(&:touch) if saved_change_to_status
-  end
-
   def aod?
     platforms.pluck(:name).include?("EGI Applications on Demand")
   end

--- a/db/migrate/20190919073353_remove_services_count_from_category.rb
+++ b/db/migrate/20190919073353_remove_services_count_from_category.rb
@@ -1,0 +1,5 @@
+class RemoveServicesCountFromCategory < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :categories, :services_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_02_135120) do
+ActiveRecord::Schema.define(version: 2019_09_19_073353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,6 @@ ActiveRecord::Schema.define(version: 2019_09_02_135120) do
     t.string "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "services_count", default: 0
     t.string "slug"
     t.integer "ancestry_depth", default: 0
     t.index ["ancestry"], name: "index_categories_on_ancestry"
@@ -166,8 +165,8 @@ ActiveRecord::Schema.define(version: 2019_09_02_135120) do
     t.string "department"
     t.string "webpage"
     t.string "status"
-    t.datetime "created_at", default: "2019-09-02 14:47:09", null: false
-    t.datetime "updated_at", default: "2019-09-02 14:47:09", null: false
+    t.datetime "created_at", default: "2019-09-19 07:34:55", null: false
+    t.datetime "updated_at", default: "2019-09-19 07:34:55", null: false
     t.index ["name", "user_id"], name: "index_projects_on_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_projects_on_user_id"
   end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -26,14 +26,4 @@ RSpec.describe Category do
 
     expect(service.main_category).to eq(other)
   end
-
-  it "has services counter" do
-    category = create(:category, services: create_list(:service, 1))
-    subcategory = create(:category, parent: category, services: create_list(:service, 1))
-    subsubcategory = create(:category, parent: subcategory, services: create_list(:service, 1))
-
-    expect(subsubcategory.reload.services_count).to eq(1)
-    expect(subcategory.reload.services_count).to eq(2)
-    expect(category.reload.services_count).to eq(3)
-  end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -67,44 +67,6 @@ RSpec.describe Service do
     expect(s1.related_services).to contain_exactly(s2, s3)
   end
 
-  context "category services counter cache" do
-    let(:category) { create(:category) }
-
-    it "is inceased when creating already published service" do
-      create(:service, status: :published, categories: [category])
-
-      category.reload
-
-      expect(category.services_count).to eq(1)
-    end
-
-    it "is not modified when creating draft service" do
-      create(:service, status: "draft", categories: [category])
-
-      category.reload
-
-      expect(category.services_count).to eq(0)
-    end
-
-    it "is increased when publishing" do
-      service = create(:service, status: "draft", categories: [category])
-
-      service.published!
-      category.reload
-
-      expect(category.services_count).to eq(1)
-    end
-
-    it "is decreased when unpublishing" do
-      service = create(:service, status: :published, categories: [category])
-
-      service.draft!
-      category.reload
-
-      expect(category.services_count).to eq(0)
-    end
-  end
-
   it "it removes leading and trailing spaces from urls before validation" do
     service = create(:service)
     service.terms_of_use_url = "https://sample.url "


### PR DESCRIPTION
Category `counter_cache` is not used anymore. Instead, counters are calculated using elasticsearch. This was the reason for deleting this field and all the code connected with calculating counters for
categories.