### PR TITLE
Category and ResearchArea name is parent scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 
 ### Changed
+- Category and Research Area name uniqueness is parent scoped (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,7 +15,7 @@ class Category < ApplicationRecord
   has_many :categorizations, autosave: true, dependent: :destroy
   has_many :services, through: :categorizations
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { scope: :ancestry }
 
   after_destroy :update_main_categories!
 

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -8,7 +8,7 @@ class ResearchArea < ApplicationRecord
   has_many :project_research_areas, autosave: true, dependent: :destroy
   has_many :projects, through: :project_research_areas
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { scope: :ancestry }
 
   def self.names
     all.map(&:name)

--- a/db/migrate/20190919085356_change_category_name_uniq_scope.rb
+++ b/db/migrate/20190919085356_change_category_name_uniq_scope.rb
@@ -1,0 +1,6 @@
+class ChangeCategoryNameUniqScope < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :categories, :name
+    add_index :categories, [:name, :ancestry], unique: true
+  end
+end

--- a/db/migrate/20190919090322_change_research_area_name_uniqueness_scope.rb
+++ b/db/migrate/20190919090322_change_research_area_name_uniqueness_scope.rb
@@ -1,0 +1,6 @@
+class ChangeResearchAreaNameUniquenessScope < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :research_areas, :name
+    add_index :research_areas, [:name, :ancestry], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_02_135120) do
+ActiveRecord::Schema.define(version: 2019_09_19_090322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2019_09_02_135120) do
     t.integer "ancestry_depth", default: 0
     t.index ["ancestry"], name: "index_categories_on_ancestry"
     t.index ["description"], name: "index_categories_on_description"
-    t.index ["name"], name: "index_categories_on_name", unique: true
+    t.index ["name", "ancestry"], name: "index_categories_on_name_and_ancestry", unique: true
   end
 
   create_table "categorizations", force: :cascade do |t|
@@ -166,8 +166,8 @@ ActiveRecord::Schema.define(version: 2019_09_02_135120) do
     t.string "department"
     t.string "webpage"
     t.string "status"
-    t.datetime "created_at", default: "2019-09-02 14:47:09", null: false
-    t.datetime "updated_at", default: "2019-09-02 14:47:09", null: false
+    t.datetime "created_at", default: "2019-09-19 09:11:52", null: false
+    t.datetime "updated_at", default: "2019-09-19 09:11:52", null: false
     t.index ["name", "user_id"], name: "index_projects_on_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 2019_09_02_135120) do
     t.text "name", null: false
     t.string "ancestry"
     t.integer "ancestry_depth", default: 0
-    t.index ["name"], name: "index_research_areas_on_name", unique: true
+    t.index ["name", "ancestry"], name: "index_research_areas_on_name_and_ancestry", unique: true
   end
 
   create_table "service_opinions", force: :cascade do |t|

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Category do
     it { should validate_presence_of(:name) }
 
     subject { create(:category) }
-    it { should validate_uniqueness_of(:name) }
+    it { should validate_uniqueness_of(:name).scoped_to(:ancestry) }
   end
 
   it "is hierarchical" do

--- a/spec/models/research_area_spec.rb
+++ b/spec/models/research_area_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ResearchArea, type: :model do
     it { should validate_presence_of(:name) }
 
     subject { create(:research_area) }
-    it { should validate_uniqueness_of(:name) }
+    it { should validate_uniqueness_of(:name).scoped_to(:ancestry) }
   end
 
   describe "#potential_parents" do


### PR DESCRIPTION
Starting from now we will be able to create following structure:

```
- foo
  - foo
  - bar
- bar
```

but still it will be forbidden to create:

```
- foo
- foo
```

Fixes #1115