### PR TITLE
Publish service as unverified service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- Service unverified but published state (@mkasztelnik)
 
 ### Changed
 

--- a/app/controllers/backoffice/services/publishes_controller.rb
+++ b/app/controllers/backoffice/services/publishes_controller.rb
@@ -4,7 +4,7 @@ class Backoffice::Services::PublishesController < Backoffice::ApplicationControl
   before_action :find_and_authorize
 
   def create
-    Service::Publish.new(@service).call
+    Service::Publish.new(@service, verified: verified?).call
     redirect_to [:backoffice, @service]
   end
 
@@ -13,6 +13,10 @@ class Backoffice::Services::PublishesController < Backoffice::ApplicationControl
     def find_and_authorize
       @service = Service.friendly.find(params[:service_id])
 
-      authorize(@service, :publish?)
+      authorize(@service, verified? ? :publish? : :publish_unverified?)
+    end
+
+    def verified?
+      params[:unverified] != "true"
     end
 end

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -73,7 +73,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
     end
 
     def filter_classes
-      super << Filter::UpstreamSource
+      super + [Filter::UpstreamSource, Filter::Status]
     end
 
     def sort_options

--- a/app/helpers/backoffice/services_helper.rb
+++ b/app/helpers/backoffice/services_helper.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 module Backoffice::ServicesHelper
+  BADGES = {
+    "published" => "badge-success",
+    "unverified" => "badge-warning",
+    "draft" => "badge-error"
+  }
+
   def service_status(service)
-    status_badge_class = service.published? ? "badge-success" : "badge-warning"
-    content_tag(:span, service.status, class: "badge #{status_badge_class}")
+    content_tag(:span, service.status, class: "badge #{BADGES[service.status]}")
   end
 
   def offer_status(offer)
-    status_badge_class = offer.published? ? "badge-success" : "badge-warning"
-    content_tag(:span, offer.status, class: "badge #{status_badge_class}")
+    content_tag(:span, offer.status, class: "badge #{BADGES[offer.status]}")
   end
 end

--- a/app/models/filter/status.rb
+++ b/app/models/filter/status.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Filter::Status < Filter
+  def initialize(params = {})
+    super(params: params.fetch(:params, {}),
+          field_name: "state", type: :select,
+          title: "Service status", index: "status")
+  end
+
+  private
+
+    def fetch_options
+      [ { name: "Any", id: nil } ] +
+      Service.statuses.map do |key, value|
+        {
+          name: I18n.t("simple_form.options.service.status.#{key}"),
+          id: value
+        }
+      end
+    end
+
+    def where_constraint
+      { @index.to_sym => value  }
+    end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -50,6 +50,7 @@ class Service < ApplicationRecord
 
   STATUSES = {
     published: "published",
+    unverified: "unverified",
     draft: "draft"
   }
 

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -35,11 +35,15 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   def publish?
-    service_portfolio_manager? && record.draft?
+    service_portfolio_manager? && (record.draft? || record.unverified?)
+  end
+
+  def publish_unverified?
+    service_portfolio_manager? && (record.draft? || record.published?)
   end
 
   def draft?
-    service_portfolio_manager? && record.published?
+    service_portfolio_manager? && (record.published? || record.unverified?)
   end
 
   def destroy?

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -3,12 +3,12 @@
 class ServicePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.where(status: :published)
+      scope.where(status: [:published, :unverified])
     end
   end
 
   def show?
-    record.published?
+    record.published? || record.unverified?
   end
 
   def order?

--- a/app/services/service/publish.rb
+++ b/app/services/service/publish.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Service::Publish
-  def initialize(service)
+  def initialize(service, verified: true)
     @service = service
+    @status = verified ? :published : :unverified
   end
 
   def call
-    @service.update(status: :published)
+    @service.update(status: @status)
   end
 end

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -25,18 +25,25 @@
         %span Status:
         %span.font-weight-bold= @service.status
       .col-12.col-sm-6
-        - if policy([:backoffice, @service]).publish?
-          = link_to "Publish",
-                  backoffice_service_publish_path(@service),
-                  method: :post,
-                  data: { confirm: "Are you sure you want to publish this service?" },
-                  class: "btn btn-warning float-right btn-sm"
-        - if policy([:backoffice, @service]).draft?
-          = link_to "Stop showing in the MP",
-                  backoffice_service_draft_path(@service),
-                  method: :post,
-                  data: { confirm: "Are you sure you want to stop showing this service?" },
-                  class: "btn btn-warning float-right btn-sm"
+        .btn-group.float-right
+          - if policy([:backoffice, @service]).publish?
+            = link_to "Publish",
+                    backoffice_service_publish_path(@service),
+                    method: :post,
+                    data: { confirm: "Are you sure you want to publish this service?" },
+                    class: "btn btn-success btn-sm"
+          - if policy([:backoffice, @service]).publish_unverified?
+            = link_to "Publish as unverified service",
+                    backoffice_service_publish_path(@service, unverified: true),
+                    method: :post,
+                    data: { confirm: "Are you sure you want to publish this service as unvefiried service?" },
+                    class: "btn btn-warning btn-sm"
+          - if policy([:backoffice, @service]).draft?
+            = link_to "Stop showing in the MP",
+                    backoffice_service_draft_path(@service),
+                    method: :post,
+                    data: { confirm: "Are you sure you want to stop showing this service?" },
+                    class: "btn btn-error btn-sm"
   .row.mt-4
     .col-12.col-sm-8
       %p

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -90,6 +90,10 @@ en:
           beta: "Beta (min. TRL 7)"
           production: "Production (min. TRL 8)"
           retired: "Retired (n/a)"
+        status:
+          draft: "Draft"
+          published: "Published"
+          unverified: "Published as unverified"
     project_item:
         status:
           created: Created

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -111,6 +111,33 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_content("Sorry, but the logo format you were trying to attach is not supported in the Marketplace.")
     end
 
+    scenario "I can publish service" do
+      service = create(:service, status: :draft)
+
+      visit backoffice_service_path(service)
+      click_on "Publish"
+
+      expect(page).to have_content("Status: published")
+    end
+
+    scenario "I can publish as unverified service" do
+      service = create(:service, status: :draft)
+
+      visit backoffice_service_path(service)
+      click_on "Publish as unverified service"
+
+      expect(page).to have_content("Status: unverified")
+    end
+
+    scenario "I can unpublish service" do
+      service = create(:service, status: :published)
+
+      visit backoffice_service_path(service)
+      click_on "Stop showing in the MP"
+
+      expect(page).to have_content("Status: draft")
+    end
+
     scenario "I can edit any service" do
       service = create(:service, title: "my service")
 

--- a/spec/models/filter/status_spec.rb
+++ b/spec/models/filter/status_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Filter::Status do
+end

--- a/spec/policies/backoffice/service_policy_spec.rb
+++ b/spec/policies/backoffice/service_policy_spec.rb
@@ -168,9 +168,9 @@ RSpec.describe Backoffice::ServicePolicy do
   end
 
   permissions :publish? do
-    it "grants access for owned not published service" do
-      expect(subject).
-        to permit(service_portfolio_manager, build(:service, owners: [service_portfolio_manager], status: :draft))
+    it "grants access for service portfolio manager and not published services" do
+      expect(subject).to permit(service_portfolio_manager, build(:service, status: :draft))
+      expect(subject).to permit(service_portfolio_manager, build(:service, status: :unverified))
     end
 
     it "denies access for other users" do
@@ -178,8 +178,37 @@ RSpec.describe Backoffice::ServicePolicy do
     end
 
     it "denies access for already published service" do
-      expect(subject).
-        to_not permit(service_portfolio_manager, build(:service, owners: [service_portfolio_manager], status: :published))
+      expect(subject).to_not permit(service_portfolio_manager, build(:service, status: :published))
+    end
+  end
+
+  permissions :publish_unverified? do
+    it "grants access for service portfolio manager and not published unverified services" do
+      expect(subject).to permit(service_portfolio_manager, build(:service, status: :draft))
+      expect(subject).to permit(service_portfolio_manager, build(:service, status: :published))
+    end
+
+    it "denies access for other users" do
+      expect(subject).to_not permit(service_owner, build(:service, status: :draft))
+    end
+
+    it "denies access for already published unverified service" do
+      expect(subject).to_not permit(service_portfolio_manager, build(:service, status: :unverified))
+    end
+  end
+
+  permissions :draft? do
+    it "grants access for service portfolio manager and not draft services" do
+      expect(subject).to permit(service_portfolio_manager, build(:service, status: :published))
+      expect(subject).to permit(service_portfolio_manager, build(:service, status: :unverified))
+    end
+
+    it "denies access for other users" do
+      expect(subject).to_not permit(service_owner, build(:service, status: :published))
+    end
+
+    it "denies access fo service in draft state" do
+      expect(subject).to_not permit(service_portfolio_manager, build(:service, status: :draft))
     end
   end
 end

--- a/spec/policies/service_policy_spec.rb
+++ b/spec/policies/service_policy_spec.rb
@@ -4,12 +4,11 @@ require "rails_helper"
 
 RSpec.describe ServicePolicy do
   let(:user) { create(:user) }
-  let(:scope) { Service.where(status: :published) }
 
   subject { described_class }
 
   def resolve
-    subject::Scope.new(user, scope).resolve
+    subject::Scope.new(user, Service).resolve
   end
 
   permissions ".scope" do
@@ -23,6 +22,26 @@ RSpec.describe ServicePolicy do
       create(:service, status: :published)
 
       expect(resolve.count).to eq(1)
+    end
+
+    it "allows unverified services" do
+      create(:service, status: :unverified)
+
+      expect(resolve.count).to eq(1)
+    end
+  end
+
+  permissions :show? do
+    it "is granted for published service" do
+      expect(subject).to permit(user, build(:service, status: :published))
+    end
+
+    it "is granted for unvefiried service" do
+      expect(subject).to permit(user, build(:service, status: :unverified))
+    end
+
+    it "denies for draft service" do
+      expect(subject).to_not permit(user, build(:service, status: :draft))
     end
   end
 

--- a/spec/services/service/publish_spec.rb
+++ b/spec/services/service/publish_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe Service::Publish do
 
     expect(service.reload).to be_published
   end
+
+  it "publish unverified service" do
+    service = create(:service)
+
+    described_class.new(service, verified: false).call
+
+    expect(service.reload).to be_unverified
+  end
 end


### PR DESCRIPTION
The new state was added to service: `unverified`. It means that service is published (it is visible to end-user) but is not confirmed by onboarding team.

Fixes #1103