### PR TITLE
Allow only child research areas in service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Cleanup and refactoring for service browsing specs (@mkasztelnik)
 - UI Fixes and upgrades (@jarekzet)
 - Show first project services when after entering "My projects" section (@mkasztelnik)
+- Allow only child research areas in services (@goreck888)
 
 ### Removed
 - Remove category `services_count` (@mkasztelnik)

--- a/app/controllers/backoffice/research_areas_controller.rb
+++ b/app/controllers/backoffice/research_areas_controller.rb
@@ -2,6 +2,7 @@
 
 class Backoffice::ResearchAreasController < Backoffice::ApplicationController
   before_action :find_and_authorize, only: [:show, :edit, :update, :destroy]
+  before_action :parent_services, only: [:create, :update]
 
   def index
     authorize(ResearchArea)
@@ -20,9 +21,17 @@ class Backoffice::ResearchAreasController < Backoffice::ApplicationController
     @research_area = ResearchArea.new(permitted_attributes(ResearchArea))
     authorize(@research_area)
 
+    if params[:commit] == "other_for_parent"
+      move_services(@research_area.parent, other_for(@research_area.parent))
+    elsif params[:commit] == "other"
+      move_services(@research_area.parent, other)
+    elsif params[:commit] == "current"
+      move_services(@research_area.parent, @research_area)
+    end
+
     if @research_area.save
       redirect_to backoffice_research_area_path(@research_area),
-                  notice: "New research_area created sucessfully"
+                  notice: "New research area created sucessfully"
     else
       render :new, status: :bad_request
     end
@@ -50,5 +59,26 @@ class Backoffice::ResearchAreasController < Backoffice::ApplicationController
     def find_and_authorize
       @research_area = ResearchArea.find(params[:id])
       authorize(@research_area)
+    end
+
+    def parent_services
+      @parent_services = ResearchArea.find_by(id: params[:research_area][:parent_id])&.services
+    end
+
+    def other_for(research_area)
+      ResearchArea.find_by(name: "Other for #{research_area.name.downcase}") ||
+          ResearchArea.create(name: "Other for #{research_area.name.downcase}", parent: research_area)
+    end
+
+    def other
+      ResearchArea.find_by(name: "Other") || ResearchArea.create(name: "Other")
+    end
+
+    def move_services(from, to)
+      from.services.each do |service|
+        service.research_areas.delete(from)
+        service.research_areas << to
+        service.save!
+      end
     end
 end

--- a/app/javascript/controllers/research_area_controller.js
+++ b/app/javascript/controllers/research_area_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+    static targets = ["parent"];
+
+    hidePrompt(event) {
+        event.preventDefault();
+        const buttons = document.getElementsByClassName("moveButton")
+        Array.prototype.forEach.call(buttons, function (btn) {
+            btn.setAttribute("disabled", true);
+        });
+        document.getElementById("action-frame").innerHTML = "";
+    }
+}

--- a/app/javascript/controllers/research_area_controller.js
+++ b/app/javascript/controllers/research_area_controller.js
@@ -5,10 +5,12 @@ export default class extends Controller {
 
     hidePrompt(event) {
         event.preventDefault();
-        const buttons = document.getElementsByClassName("moveButton")
-        Array.prototype.forEach.call(buttons, function (btn) {
-            btn.setAttribute("disabled", true);
-        });
-        document.getElementById("action-frame").innerHTML = "";
+        const button = document.getElementById("submit");
+        const label = button.getAttribute("label");
+        button.setAttribute("value", label);
+        const frame = document.getElementById("action-frame");
+        if(frame) {
+            frame.remove();
+        }
     }
 }

--- a/app/models/filter/ancestry_multiselect.rb
+++ b/app/models/filter/ancestry_multiselect.rb
@@ -35,7 +35,7 @@ class Filter::AncestryMultiselect < Filter
         {
             name: record.name,
             id: record.id,
-            count: @counters[record.id].to_i,
+            count: @ancestry_counters[record.id].to_i,
             children: create_ancestry_tree(children)
         }
       end.sort_by! { |e| [-e[:count], e[:name] ] }

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -2,6 +2,7 @@
 
 class ResearchArea < ApplicationRecord
   include Parentable
+  attr_accessor :move_ra_id
 
   has_many :service_research_areas, autosave: true, dependent: :destroy
   has_many :services, through: :service_research_areas
@@ -41,7 +42,7 @@ class ResearchArea < ApplicationRecord
       result
     end
 
-    def self.name_with_path(parent, child, separator = " / ")
+    def self.name_with_path(parent, child, separator = " ⇒ ")
       parent.blank? ? child : parent + separator + child
     end
 

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -10,7 +10,7 @@ class ResearchArea < ApplicationRecord
   has_many :projects, through: :project_research_areas
 
   validates :name, presence: true, uniqueness: { scope: :ancestry }
-  validate :parent_has_services, if: :parent
+  validate :parent_has_services, if: :parent_id
 
   def self.names
     all.map(&:name)
@@ -47,6 +47,10 @@ class ResearchArea < ApplicationRecord
     end
 
     def parent_has_services
-      errors.add(:parent_id, "has services") unless parent.services.blank?
+      errors.add(:parent_id, "has services") if parent_has_services?
+    end
+
+    def parent_has_services?
+      ServiceResearchArea.where(research_area_id: parent_id).count.positive?
     end
 end

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -9,8 +9,43 @@ class ResearchArea < ApplicationRecord
   has_many :projects, through: :project_research_areas
 
   validates :name, presence: true, uniqueness: { scope: :ancestry }
+  validate :parent_has_services, if: :parent
 
   def self.names
     all.map(&:name)
   end
+
+  def self.leafs
+    all_childless
+  end
+
+  def self.leafs_with_nested_names
+    all_childless(true)
+  end
+
+  def self.other
+    ResearchArea.find_by(name: "Other")
+  end
+
+
+  private
+
+    def self.all_childless(with_names = false, records = ResearchArea.arrange, parent_name = "", result = [])
+      records.each do |r, sub_r|
+        if sub_r.blank?
+          result << (with_names ? [name_with_path(parent_name, r.name), r] : r)
+        else
+          all_childless(with_names, sub_r, name_with_path(parent_name, r.name), result)
+        end
+      end
+      result
+    end
+
+    def self.name_with_path(parent, child, separator = " / ")
+      parent.blank? ? child : parent + separator + child
+    end
+
+    def parent_has_services
+      errors.add(:parent_id, "has services") unless parent.services.blank?
+    end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -113,6 +113,7 @@ class Service < ApplicationRecord
   validates :logo, blob: { content_type: :image }
   validate :logo_variable, on: [:create, :update]
   validates :research_areas, presence: true
+  validate :children_research_areas
   validates :providers, presence: true
   validates :status, presence: true
   validates :order_target, allow_blank: true, email: true
@@ -155,5 +156,10 @@ class Service < ApplicationRecord
 
     def main_category_missing?
       categorizations.where(main: true).count.zero?
+    end
+
+    def children_research_areas
+      excluded = research_areas.select { |ra| ResearchArea.leafs.exclude?(ra) }
+      errors.add(:research_areas, "cannot contains parents: #{excluded&.map(&:name).join(", ")}") unless excluded.blank?
     end
 end

--- a/app/policies/backoffice/research_area_policy.rb
+++ b/app/policies/backoffice/research_area_policy.rb
@@ -33,7 +33,7 @@ class Backoffice::ResearchAreaPolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :name, :parent_id
+      :name, :parent_id, :move_ra_id
     ]
   end
 

--- a/app/views/backoffice/research_areas/_form.html.haml
+++ b/app/views/backoffice/research_areas/_form.html.haml
@@ -1,10 +1,13 @@
-= simple_form_for [:backoffice, research_area] do |f|
+= simple_form_for [:backoffice, research_area], html: { data: { controller: "research-area" } } do |f|
   = f.input :name
   = f.input :parent_id,
     collection: ancestry_id_tree(research_area.potential_parents),
-    label_method: :first, value_method: :last, as: :select, include_blank: true
+    label_method: :first, value_method: :last, as: :select, include_blank: true,
+    input_html: { data: { target: "research-area.parent", action: "change->research-area#hidePrompt" } }
 
 
   .btn-group
     = f.button :submit, class: "btn btn-success"
     = back_link_to "Cancel", research_area, prefix: :backoffice, class: "btn btn-secondary"
+  - unless research_area.errors[:parent_id].empty?
+    = render "move_services", research_area: research_area, parent_services: parent_services, f: f

--- a/app/views/backoffice/research_areas/_form.html.haml
+++ b/app/views/backoffice/research_areas/_form.html.haml
@@ -4,10 +4,10 @@
     collection: ancestry_id_tree(research_area.potential_parents),
     label_method: :first, value_method: :last, as: :select, include_blank: true,
     input_html: { data: { target: "research-area.parent", action: "change->research-area#hidePrompt" } }
-
-
-  .btn-group
-    = f.button :submit, class: "btn btn-success"
-    = back_link_to "Cancel", research_area, prefix: :backoffice, class: "btn btn-secondary"
   - unless research_area.errors[:parent_id].empty?
-    = render "move_services", research_area: research_area, parent_services: parent_services, f: f
+    = render "move_services", research_area: research_area, parent_services: parent_services, f: f, leafs: leafs
+  .btn-group
+    = f.button :submit, class: "btn btn-success",
+    value: (research_area.errors[:parent_id].empty? ? label : t("backoffice.research_area.move", label: label)),
+    id: "submit", label: label
+    = back_link_to "Cancel", research_area, prefix: :backoffice, class: "btn btn-secondary"

--- a/app/views/backoffice/research_areas/_move_services.html.haml
+++ b/app/views/backoffice/research_areas/_move_services.html.haml
@@ -1,0 +1,33 @@
+#action-frame.container
+  %hr
+  .mb-4
+    %p
+      You are trying to add parent which contains following services:
+      %ul.simple-list
+        - parent_services&.each do |service|
+          %li= service.title
+    %p
+      You can move services listed above to the:
+      %ul.simple-list
+        %li "Other for #{research_area&.parent&.name}" (will be automatically created)
+        %li "Other" Research area (if not exist it will be created, unavailable if "Other" has children)
+        %li Research area you want to create
+    %p
+      Choose an option below or choose another parent and click create:
+  .btn-group-toggle
+    = f.button :button, "Create other for #{research_area&.parent&.name}",
+      name: "commit",
+      value: "other_for_parent",
+      class: "btn btn-primary pl-5 pr-5 mr-5 moveButton",
+      data: { controller: "research-area", target: "research-area.move" }
+    - unless ResearchArea.other&.has_children?
+      = f.button :button, "Move to Other",
+        name: "commit",
+        value: "other",
+        class: "btn btn-primary pl-5 pr-5 mr-5 moveButton",
+        data: { controller: "research-area", target: "research-area.move" }
+    = f.button :button, "Move to actually created",
+      name: "commit",
+      value: "current",
+      class: "btn btn-primary pl-5 pr-5 mr-5 moveButton",
+      data: { controller: "research-area", target: "research-area.move" }

--- a/app/views/backoffice/research_areas/_move_services.html.haml
+++ b/app/views/backoffice/research_areas/_move_services.html.haml
@@ -7,27 +7,6 @@
         - parent_services&.each do |service|
           %li= service.title
     %p
-      You can move services listed above to the:
-      %ul.simple-list
-        %li "Other for #{research_area&.parent&.name}" (will be automatically created)
-        %li "Other" Research area (if not exist it will be created, unavailable if "Other" has children)
-        %li Research area you want to create
-    %p
-      Choose an option below or choose another parent and click create:
-  .btn-group-toggle
-    = f.button :button, "Create other for #{research_area&.parent&.name}",
-      name: "commit",
-      value: "other_for_parent",
-      class: "btn btn-primary pl-5 pr-5 mr-5 moveButton",
-      data: { controller: "research-area", target: "research-area.move" }
-    - unless ResearchArea.other&.has_children?
-      = f.button :button, "Move to Other",
-        name: "commit",
-        value: "other",
-        class: "btn btn-primary pl-5 pr-5 mr-5 moveButton",
-        data: { controller: "research-area", target: "research-area.move" }
-    = f.button :button, "Move to actually created",
-      name: "commit",
-      value: "current",
-      class: "btn btn-primary pl-5 pr-5 mr-5 moveButton",
-      data: { controller: "research-area", target: "research-area.move" }
+      Please choose research area, where the selected services will be moved:
+      = f.input :move_ra_id, label: "Possible choices", collection: leafs.map { |ra| [ra.name, ra.id] },
+      include_blank: false, label_method: :first, value_method: :last

--- a/app/views/backoffice/research_areas/_tree.html.haml
+++ b/app/views/backoffice/research_areas/_tree.html.haml
@@ -1,0 +1,10 @@
+%ul.list-group.simple-list.backoffice-list
+  - research_areas.each do |ra, sub_ra|
+    %li.list-group-item.list-group-item-primary= link_to ra.name, backoffice_research_area_path(ra)
+    - unless ra&.services.blank?
+      %ul.list-group.simple-list
+        - ra&.services.each do |service|
+          %li.list-group-item.list-group-item-secondary
+            = link_to service.title, backoffice_service_path(service)
+    - unless sub_ra.blank?
+      = render "tree", research_areas: sub_ra

--- a/app/views/backoffice/research_areas/edit.html.haml
+++ b/app/views/backoffice/research_areas/edit.html.haml
@@ -1,4 +1,4 @@
 - breadcrumb :backoffice_research_area_edit, @research_area
 
 %h2 Edit Research Area
-= render "form", research_area: @research_area
+= render "form", research_area: @research_area, parent_services: @parent_services, leafs: @leafs, label: @label

--- a/app/views/backoffice/research_areas/index.html.haml
+++ b/app/views/backoffice/research_areas/index.html.haml
@@ -12,6 +12,7 @@
     - ancestry_tree(@research_areas).each do |record|
       %li.list-group-item
         = link_to record.first, backoffice_research_area_path(record.last)
+        services: #{record.last.services.count}
         - if policy([:backoffice, record[1]]).destroy?
           = link_to backoffice_research_area_path(record[1]),
                 method: :delete,

--- a/app/views/backoffice/research_areas/new.html.haml
+++ b/app/views/backoffice/research_areas/new.html.haml
@@ -1,4 +1,4 @@
 - breadcrumb :backoffice_research_area_new, @research_area
 
 %h2 New Research Area
-= render "form", research_area: @research_area, parent_services: @parent_services
+= render "form", research_area: @research_area, parent_services: @parent_services, leafs: @leafs, label: @label

--- a/app/views/backoffice/research_areas/new.html.haml
+++ b/app/views/backoffice/research_areas/new.html.haml
@@ -1,4 +1,4 @@
 - breadcrumb :backoffice_research_area_new, @research_area
 
 %h2 New Research Area
-= render "form", research_area: @research_area
+= render "form", research_area: @research_area, parent_services: @parent_services

--- a/app/views/backoffice/research_areas/show.html.haml
+++ b/app/views/backoffice/research_areas/show.html.haml
@@ -1,7 +1,14 @@
 - breadcrumb :backoffice_research_area, @research_area
-
 %h1= @research_area.name
-%h2= @research_area.parent ? "Parent: #{@research_area.parent.name}" : "Root element"
+%h2
+  - unless @research_area.parent.blank?
+    = link_to "Parent: #{@research_area&.parent&.name}", backoffice_research_area_path(@research_area&.parent)
+  - else
+    Root element
+- unless @research_area.children.blank? && @research_area.services.blank?
+  %h2 Subtree with services:
+  = render "tree", research_areas: @research_area.subtree.arrange
+
 
 .btn-group
   - if policy([:backoffice, @research_area]).edit?

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -24,7 +24,9 @@
   = f.association :platforms, multiple: true, input_html: { data: { choice: true } },
                   disabled: cant_edit([platform_ids: []])
   = f.association :research_areas, input_html: { data: { choice: true } }, include_hidden: false,
-                  disabled: cant_edit([research_area_ids: []])
+                  disabled: cant_edit([research_area_ids: []]),
+                  collection: ResearchArea.leafs_with_nested_names.map { |name, ra| [name, ra.id] },
+                  label_method: :first, value_method: :second
   = f.association :target_groups,
                   label: "Dedicated For",
                   input_html: { data: { choice: true }, class: "target_groups" },

--- a/app/views/backoffice/services/edit.html.haml
+++ b/app/views/backoffice/services/edit.html.haml
@@ -4,4 +4,3 @@
   .edit-service
     = render "form", service: @service
 
-

--- a/app/views/backoffice/services/edit.html.haml
+++ b/app/views/backoffice/services/edit.html.haml
@@ -4,3 +4,4 @@
   .edit-service
     = render "form", service: @service
 
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,9 @@ en:
       new: Add new Provider
     research_area:
       new: Add new Research Area
+      create: Create Research area
+      move: "%{label} and move services to the selected one"
+      update: Update Research area
     service:
       new: Create new Service
       edit: Edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
     get "service_autocomplete", to: "services#autocomplete", as: :service_autocomplete
     get "services/c/:category_id" => "services#index", as: :category_services
     resources :research_areas
+      get "research-areas/popup", to: "research_areas#popup"
     resources :categories
     resources :providers
     resources :platforms

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,6 @@ Rails.application.routes.draw do
     get "service_autocomplete", to: "services#autocomplete", as: :service_autocomplete
     get "services/c/:category_id" => "services#index", as: :category_services
     resources :research_areas
-      get "research-areas/popup", to: "research_areas#popup"
     resources :categories
     resources :providers
     resources :platforms

--- a/db/data.yml
+++ b/db/data.yml
@@ -1909,7 +1909,7 @@ services:
         access_policies_url: https://marketplace.egi.eu/content/7-access-policy
         places: *europe
         languages: *english
-        area: [*socialSciences, *humanities]
+        area: [*political, *philosophy]
         target_groups: [*researchers] #TODO: but not specified
 #        #restrictions: *notSpecified
         phase: production
@@ -1957,7 +1957,7 @@ services:
         access_policies_url: https://marketplace.egi.eu/content/7-access-policy
         places: *europe
         languages: *english
-        area: [*socialSciences, *humanities]
+        area: [*political, *philosophy]
         target_groups: [*researchers] #TODO: but not specified
 #        #restrictions: *notSpecified
         phase: production
@@ -2022,7 +2022,7 @@ services:
         places: *europe
         languages: *english
         target_groups: [*researchers] #TODO: but not specified
-        area: *humanities
+        area: *philosophy
 #        #restrictions: *notSpecified
         phase: production
         tagline: A service that allows researchers to create their own citable digital bookmarks.
@@ -2534,7 +2534,7 @@ services:
 #        places: *europe
 #        target_groups: ["Researchers", "Research organisations"]
 #        languages: *english
-#        area: *humanities
+#        area: *philosophy
 #        #restrictions: *notSpecified
 #        phase: production
 #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
@@ -2810,7 +2810,7 @@ services:
         places: *europe
         target_groups: [*researchers, *research_organisations]
         languages: *english
-        area: *humanities
+        area: *philosophy
         #restrictions: *notSpecified
         phase: production
         tagline: The DARIAH Science Gateway is a platform that provides access to various digital applications and services for the Arts & Humanities researchers
@@ -3591,7 +3591,7 @@ services:
         places: *europe
         target_groups: [*researchers, *research_organisations, *research_groups]
         languages: *english
-        area: [*lifeSciences, *socialSciences, *physicalSciences, *formalSciences, *interdisciplinary]
+        area: [*lifeSciences, *political, *physicalSciences, *formalSciences, *interdisciplinary]
         restrictions: "Research affiliation needed"
         phase: alpha
         tagline: "EODC JupyterHub provides access to the global EODC Copernicus Data Archive."
@@ -3648,7 +3648,7 @@ services:
         places: *europe
         target_groups: [*researchers, *research_organisations, *research_groups, *providers]
         languages: *english
-        area: [*lifeSciences, *socialSciences, *physicalSciences, *formalSciences, *interdisciplinary]
+        area: [*lifeSciences, *political, *physicalSciences, *formalSciences, *interdisciplinary]
         #restrictions: *notSpecified
         phase: production
         tagline: "Catalog Service for the Web (CSW), OGC compliant catalogue service to expose metadata of geospatial records hosted at EODC"
@@ -3792,7 +3792,7 @@ services:
         places: *europe
         target_groups: [*researchers, *research_organisations, *research_groups, *providers, *business]
         languages: *english
-        area: [*lifeSciences, *socialSciences, *physicalSciences, *formalSciences, *appliedScience, *interdisciplinary]
+        area: [*lifeSciences, *political, *physicalSciences, *formalSciences, *appliedScience, *interdisciplinary]
         #restrictions: *notSpecified
         phase: production
         tagline: "Data Collections Catalog is based on two solutions  – CKAN - comprehensive frontend catalogue application for information discovery and EO Browser – specialized catalogue application for robust satellite imagery discovery and quick georeferenced preview"
@@ -3835,7 +3835,7 @@ services:
         places: *europe
         target_groups: [*researchers, *research_organisations, *research_groups, *providers, *business]
         languages: *english
-        area: [*lifeSciences, *socialSciences, *physicalSciences, *formalSciences, *appliedScience, *interdisciplinary]
+        area: [*lifeSciences, *political, *physicalSciences, *formalSciences, *appliedScience, *interdisciplinary]
         #restrictions: *notSpecified
         phase: production
         tagline: "CREODIAS platform is a cloud infrastructure adapted to the processing of big amounts of EO data, including an EO Data storage cluster and a dedicated IaaS cloud infrastructure for the platform’s Users"
@@ -3874,7 +3874,7 @@ services:
         places: *europe
         target_groups: [*researchers, *research_organisations, *research_groups, *providers, *business]
         languages: *english
-        area: [*lifeSciences, *socialSciences, *physicalSciences, *formalSciences, *appliedScience, *interdisciplinary]
+        area: [*lifeSciences, *political, *physicalSciences, *formalSciences, *appliedScience, *interdisciplinary]
         #restrictions: *notSpecified
         phase: production
         tagline: "Manage your data products"
@@ -3905,7 +3905,7 @@ services:
         places: *europe
         target_groups: [*researchers, *research_organisations, *research_groups, *providers, *business]
         languages: *english
-        area: [*lifeSciences, *socialSciences, *physicalSciences, *formalSciences, *appliedScience, *interdisciplinary]
+        area: [*lifeSciences, *political, *physicalSciences, *formalSciences, *appliedScience, *interdisciplinary]
         #restrictions: *notSpecified
         phase: production
         tagline: "The EO Browser allows visualization and basic processing of selected data collections (like Sentinel-1 L1 GRD or Sentinel-2 L1C)"
@@ -4534,7 +4534,7 @@ services:
       places: *europe
       target_groups: [*researchers, *research_organisations, *research_groups, *providers]
       languages: *english
-      area: [*interdisciplinary, *lifeSciences, *socialSciences, *humanities, *appliedScience, *philosophy]
+      area: [*interdisciplinary, *lifeSciences, *political, *appliedScience, *philosophy]
       #restrictions: *notSpecified
       phase: production
       tagline: Secure and cost-effective cloud computing for processing sensitive data

--- a/lib/tasks/move_to_child_research_areas.rake
+++ b/lib/tasks/move_to_child_research_areas.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :research_areas do
+  desc "Move all services with parent research areas to other_for child"
+  task migrate_from_parent_research_areas: :environment do
+    ResearchArea.transaction do
+      parents = ResearchArea.all - ResearchArea.leafs
+      parents.each do |ra|
+        services = ra.services
+        services.each { |service| service.research_areas.delete(ra) }
+        services.each do |service|
+          service.research_areas << other_for(ra)
+          service.save!(validate: false)
+        end
+      end
+    end
+  end
+
+  def other_for(research_area)
+    ResearchArea.find_by(name: "Other for #{research_area.name.downcase}") ||
+        ResearchArea.create(name: "Other for #{research_area.name.downcase}", parent: research_area)
+  end
+end

--- a/spec/controllers/concerns/searchable_spec.rb
+++ b/spec/controllers/concerns/searchable_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     context Filter::ResearchArea do
-      let!(:collection) { create_list(:research_area, 3) }
+      let!(:collection) { create_list(:research_area, 3, parent: create(:research_area)) }
       let!(:field_name) { :research_areas }
       let!(:param_name) { :research_areas }
       let!(:filter_class) { Filter::ResearchArea }

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     sequence(:dedicated_for) { |n| ["service #{n} dedicated for"] }
     sequence(:restrictions) { |n| "service #{n} restrictions" }
     sequence(:phase) { :alpha }
-    sequence(:research_areas) { |n| [create(:research_area)] }
+    sequence(:research_areas) { |n| [create(:research_area, parent: create(:research_area))] }
     sequence(:providers) { |n| [create(:provider)] }
     sequence(:categories) { |n| [create(:category)] }
     sequence(:status) { :published }

--- a/spec/features/backoffice/research_areas_spec.rb
+++ b/spec/features/backoffice/research_areas_spec.rb
@@ -59,5 +59,58 @@ RSpec.feature "Research areas in backoffice" do
       expect(page).to have_content("New name")
       expect(page).to have_content("parent")
     end
+
+    context "with research area as parent containing services" do
+      let!(:parent) { create(:research_area, name: "parent") }
+      let!(:leaf) { create(:research_area, name: "leaf") }
+      let!(:services) { create_list(:service, 3, research_areas: [parent]) }
+
+      before(:each) do
+        visit backoffice_research_areas_path
+        click_on "Add new Research Area"
+
+        fill_in "Name", with: "My new research area"
+        select "parent", from: "Parent"
+
+        click_on "Create Research area"
+      end
+
+      context "I can't create research area with parent contains services" do
+        it "shows error" do
+          expect(page).to have_text("Parent has services")
+          expect(page.status_code).to eq(400)
+        end
+
+        it "shows possible options to move services" do
+          expect(page).to have_text(services.first.title)
+          expect(page).to have_text(services.second.title)
+          expect(page).to have_text(services.third.title)
+
+          expect(page).to have_button("Create Research area and move services to the selected")
+        end
+      end
+      context "move actions" do
+        scenario "I can move services to different research area" do
+          select "leaf", from: "Possible choices"
+          expect { click_on "Create Research area and move services to the selected one" }.
+              to change { ResearchArea.count }.by(1)
+
+          expect([leaf.services]).to contain_exactly(services)
+
+          expect(page).to have_content("My new research area")
+          expect(page).to have_content("parent")
+        end
+
+        scenario "I can move services to current" do
+          select "My new research area", from: "Possible choices"
+          expect { click_on "Create Research area and move services to the selected one" }.
+              to change { ResearchArea.count }.by(1)
+
+          expect(page).to have_text(services.first.title)
+          expect(page).to have_text(services.second.title)
+          expect(page).to have_text(services.third.title)
+        end
+      end
+    end
   end
 end

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Services in backoffice" do
       fill_in "Activate message", with: "Welcome!!!"
       fill_in "Service Order Target", with: "email@domain.com"
       select "Alpha (min. TRL 5)", from: "Phase"
-      select "#{research_area.root.name} / #{research_area.name}", from: "Research areas"
+      select "#{research_area.root.name} ⇒ #{research_area.name}", from: "Research areas"
       select provider.name, from: "Providers"
       select "open_access", from: "Service type"
       select platform.name, from: "Platforms"
@@ -103,7 +103,7 @@ RSpec.feature "Services in backoffice" do
       fill_in "Title", with: "service title"
       fill_in "Tagline", with: "tagline"
       fill_in "Description", with: "description"
-      select "#{research_area.root.name} / #{research_area.name}", from: "Research areas"
+      select "#{research_area.root.name} ⇒ #{research_area.name}", from: "Research areas"
       select provider.name, from: "Providers"
 
       click_on "Preview"
@@ -127,7 +127,7 @@ RSpec.feature "Services in backoffice" do
       fill_in "Title", with: "service title"
       fill_in "Description", with: "service description"
       fill_in "Tagline", with: "service tagline"
-      select "#{research_area.root.name} / #{research_area.name}", from: "Research areas"
+      select "#{research_area.root.name} ⇒ #{research_area.name}", from: "Research areas"
       select provider.name, from: "Providers"
 
       expect { click_on "Create Service" }.

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -31,7 +31,8 @@ RSpec.feature "Services in backoffice" do
     scenario "I can create new service" do
       category = create(:category)
       provider = create(:provider)
-      research_area = create(:research_area)
+      root = create(:research_area)
+      research_area = create(:research_area, parent: root)
       platform = create(:platform)
       target_group = create(:target_group)
 
@@ -57,7 +58,7 @@ RSpec.feature "Services in backoffice" do
       fill_in "Activate message", with: "Welcome!!!"
       fill_in "Service Order Target", with: "email@domain.com"
       select "Alpha (min. TRL 5)", from: "Phase"
-      select research_area.name, from: "Research areas"
+      select "#{research_area.root.name} / #{research_area.name}", from: "Research areas"
       select provider.name, from: "Providers"
       select "open_access", from: "Service type"
       select platform.name, from: "Platforms"
@@ -93,7 +94,8 @@ RSpec.feature "Services in backoffice" do
 
     scenario "I can preview service before create" do
       provider = create(:provider)
-      research_area = create(:research_area)
+      root = create(:research_area)
+      research_area = create(:research_area, parent: root)
 
       visit backoffice_services_path
       click_on "Create new Service"
@@ -101,7 +103,7 @@ RSpec.feature "Services in backoffice" do
       fill_in "Title", with: "service title"
       fill_in "Tagline", with: "tagline"
       fill_in "Description", with: "description"
-      select research_area.name, from: "Research areas"
+      select "#{research_area.root.name} / #{research_area.name}", from: "Research areas"
       select provider.name, from: "Providers"
 
       click_on "Preview"
@@ -115,7 +117,8 @@ RSpec.feature "Services in backoffice" do
 
     scenario "I cannot create service with wrong logo file" do
       provider = create(:provider)
-      research_area = create(:research_area)
+      root = create(:research_area)
+      research_area = create(:research_area, parent: root)
 
       visit backoffice_services_path
       click_on "Create new Service"
@@ -124,7 +127,7 @@ RSpec.feature "Services in backoffice" do
       fill_in "Title", with: "service title"
       fill_in "Description", with: "service description"
       fill_in "Tagline", with: "service tagline"
-      select research_area.name, from: "Research areas"
+      select "#{research_area.root.name} / #{research_area.name}", from: "Research areas"
       select provider.name, from: "Providers"
 
       expect { click_on "Create Service" }.

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -78,30 +78,30 @@ RSpec.feature "Service filter" do
 
     it "show services from root and children when hierarchical" do
       root = create(:research_area)
-      sub = create(:research_area, parent: root)
-      subsub = create(:research_area, parent: sub)
+      sub1 = create(:research_area, parent: root)
+      sub2 = create(:research_area, parent: root)
 
-      create(:service, research_areas: [root], title: "Root service")
-      create(:service, research_areas: [sub], title: "Sub service")
-      create(:service, research_areas: [subsub], title: "Subsub service")
-      create(:service, title: "Other service")
+      create(:service, research_areas: [sub1], title: "Sub1a service")
+      create(:service, research_areas: [sub1], title: "Sub1b service")
+      create(:service, research_areas: [sub2], title: "Sub2 service")
+      create(:service)
 
       visit services_path(research_areas: [root.id])
-      expect(page).to have_text("Root service")
-      expect(page).to have_text("Sub service")
-      expect(page).to have_text("Subsub service")
+      expect(page).to have_text("Sub1a service")
+      expect(page).to have_text("Sub1b service")
+      expect(page).to have_text("Sub2 service")
       expect(page).to_not have_text("Other service")
 
-      visit services_path(research_areas: [sub.id])
-      expect(page).to_not have_text("Root service")
-      expect(page).to have_text("Sub service")
-      expect(page).to have_text("Subsub service")
+      visit services_path(research_areas: [sub1.id])
+      expect(page).to_not have_text("Sub2 service")
+      expect(page).to have_text("Sub1a service")
+      expect(page).to have_text("Sub1b service")
       expect(page).to_not have_text("Other service")
 
-      visit services_path(research_areas: [subsub.id])
-      expect(page).to_not have_text("Root service")
-      expect(page).to_not have_text("Sub service")
-      expect(page).to have_text("Subsub service")
+      visit services_path(research_areas: [sub2.id])
+      expect(page).to_not have_text("Sub1a service")
+      expect(page).to_not have_text("Sub1b service")
+      expect(page).to have_text("Sub2 service")
       expect(page).to_not have_text("Other service")
     end
 

--- a/spec/lib/import/eic_spec.rb
+++ b/spec/lib/import/eic_spec.rb
@@ -172,7 +172,7 @@ describe Import::EIC do
     end
 
     it "should not update research_areas and categories" do
-      research_area_something = create(:research_area, name: "Something")
+      research_area_something = create(:research_area, name: "Something", parent: create(:research_area))
 
       service = create(:service, categories: [Category.find_by(name: "Networking")], research_areas: [research_area_something])
       source = create(:service_source, eid: "phenomenal.phenomenal", service_id: service.id, source_type: "eic")
@@ -261,7 +261,7 @@ describe Import::EIC do
 
     make_and_stub_eic(ids: [], dry_run: false, default_upstream: :eic).call
 
-    research_area = create(:research_area)
+    research_area = create(:research_area, parent: create(:research_area))
     service = Service.first
     service.update!(status: "published", research_areas: [research_area], categories: [])
 

--- a/spec/models/filter/research_area_spec.rb
+++ b/spec/models/filter/research_area_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe Filter::ResearchArea do
       root = create(:research_area)
       child1, child2 = create_list(:research_area, 2, parent: root)
 
-      create(:service, research_areas: [root])
       create(:service, research_areas: [child1, child2])
       create(:service, research_areas: [child2])
 
-      counters = { root.id => 1, child1.id => 1, child2.id => 2 }
+      counters = { root.id => 0, child1.id => 1, child2.id => 2 }
       subject.counters = counters
 
       options = subject.options
@@ -22,7 +21,7 @@ RSpec.describe Filter::ResearchArea do
       first_option = options.first
       expect(first_option[:name]).to eq(root.name)
       expect(first_option[:id]).to eq(root.id)
-      expect(first_option[:count]).to eq(1)
+      expect(first_option[:count]).to eq(3)
 
       expect(first_option[:children]).to contain_exactly(
         { name: child1.name, id: child1.id, count: 1, children: [] },

--- a/spec/models/research_area_spec.rb
+++ b/spec/models/research_area_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe ResearchArea, type: :model do
 
     subject { create(:research_area) }
     it { should validate_uniqueness_of(:name).scoped_to(:ancestry) }
+
+    it "should return validation error if we try to create research area with parent contains services" do
+      parent = create(:research_area)
+      create_list(:service, 3, research_areas: [parent])
+      child = build(:research_area, parent: parent)
+      expect { child.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Parent has services")
+    end
   end
 
   describe "#potential_parents" do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe Service do
     expect(service.main_category).to eq(main)
   end
 
+  it "doesn't allow to select research area with children" do
+    root = create(:research_area)
+    create(:research_area, parent: root)
+
+    service = build(:service, research_areas: [root])
+
+    expect { service.save! }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   context "if open access" do
     before { allow(subject).to receive(:open_access?) { true } }
 


### PR DESCRIPTION
This PR contains a change the way user can choose research area.
Previously there was a possibility to chose from all research areas.
From now we can choose only from the child research areas.

Fixes #1089