### PR TITLE
[#1123] Disable fields in service's edit with eid

### DIFF
--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -9,6 +9,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
   before_action :find_and_authorize, only: [:show, :edit, :update, :destroy]
   before_action :sort_options
   prepend_before_action :index_authorize, only: :index
+  helper_method :cant_edit
 
   def index
     if params["service_id"].present?
@@ -50,6 +51,10 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
     Service::Destroy.new(@service).call
     redirect_to backoffice_services_path,
                 notice: "Service destroyed"
+  end
+
+  def cant_edit(attribute)
+    !policy([:backoffice, @service]).permitted_attributes.include?(attribute)
   end
 
   private

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+
+EIC_SOURCE_FIELDS = [
+  :logo,
+  :title,
+  :description,
+  :tagline,
+  :connected_url,
+  :places,
+  :languages,
+  :dedicated_for,
+  :terms_of_use_url,
+  :access_policies_url,
+  :sla_url,
+  :webpage_url,
+  :manual_url,
+  :helpdesk_url,
+  :tutorial_url,
+  :phase,
+  :service_type,
+  [provider_ids: []],
+]
+
+
 class Backoffice::ServicePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
@@ -13,6 +36,10 @@ class Backoffice::ServicePolicy < ApplicationPolicy
       end
     end
   end
+
+  SOURCES_FIELDS = {
+      "eic" => EIC_SOURCE_FIELDS
+  }
 
   def index?
     service_portfolio_manager? || service_owner?
@@ -57,7 +84,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [
+    attrs = [
       :title, :description,
       :tagline, :connected_url, :service_type,
       [provider_ids: []], :places, :languages,
@@ -72,6 +99,12 @@ class Backoffice::ServicePolicy < ApplicationPolicy
       [owner_ids: []], :status, :upstream_id,
       sources_attributes: [:id, :source_type, :eid, :_destroy]
     ]
+
+    if !@record.is_a?(Service) || @record.upstream.nil?
+      attrs
+    else
+      attrs - SOURCES_FIELDS[@record.upstream.source_type]
+    end
   end
 
   private

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -2,59 +2,68 @@
   = f.error_notification
   .row
     .col-12.col-md-10
-      = f.input :logo
-      = f.input :title
-      = f.input :tagline
-      = f.input :tag_list, input_html: { value: service.tag_list.to_s }
+      = f.input :logo, disabled: cant_edit(:logo)
+      = f.input :title, disabled: cant_edit(:title)
+      = f.input :tagline, disabled: cant_edit(:tagline)
+      = f.input :tag_list, input_html: { value: service.tag_list.to_s }, disabled: cant_edit(:tag_list)
       .service-description
-        = f.input :description
+        = f.input :description, disabled: cant_edit(:description)
   .row.mt-5
     .col-12.col-md-5
       = f.input :service_type, collection: Service.service_types.keys.map(&:to_sym),
-        input_html: { "data-target" => "service.serviceType", "data-action" => "change->service#showConnectedUrl" }
+        input_html: { "data-target" => "service.serviceType", "data-action" => "change->service#showConnectedUrl" },
+        disabled: cant_edit(:service_type)
       = f.input :connected_url, label: "Service website",
-        wrapper_html: { "data-target" => "service.connectedUrl" }
+        wrapper_html: { "data-target" => "service.connectedUrl" },
+        disabled: cant_edit(:connected_url)
 
-  = f.association :categories, multiple: true, input_html: { data: { choice: true } }
-  = f.association :providers, multiple: true, input_html: { data: { choice: true } }
-  = f.association :platforms, multiple: true, input_html: { data: { choice: true } }
-  = f.association :research_areas, input_html: { data: { choice: true } }, include_hidden: false
+  = f.association :categories, multiple: true, input_html: { data: { choice: true } },
+                  disabled: cant_edit([category_ids: []])
+  = f.association :providers, multiple: true, input_html: { data: { choice: true } },
+                  disabled: cant_edit([provider_ids: []])
+  = f.association :platforms, multiple: true, input_html: { data: { choice: true } },
+                  disabled: cant_edit([platform_ids: []])
+  = f.association :research_areas, input_html: { data: { choice: true } }, include_hidden: false,
+                  disabled: cant_edit([research_area_ids: []])
   = f.association :target_groups,
                   label: "Dedicated For",
                   input_html: { data: { choice: true }, class: "target_groups" },
-                  include_hidden: false
+                  include_hidden: false,
+                  disabled: cant_edit([target_group_ids: []])
   .row.mt-5
     .col-12.col-md-5
-      = f.association :owners, multiple: true, input_html: { data: { choice: true } }
+      = f.association :owners, multiple: true, input_html: { data: { choice: true } },
+                      disabled: cant_edit([owner_ids: []])
   .row.service-contact-emails
     .col-12.col-md-6
-      = f.input :contact_emails, multiple: true, as: :array, wrapper_html: { "data-target" => "service.contactEmails" }
+      = f.input :contact_emails, multiple: true, as: :array, wrapper_html: { "data-target" => "service.contactEmails" },
+        disabled: cant_edit([contact_emails: []])
       %a.text-primary{ "data-action" => "click->service#addNewEmailField" } Add additional email
   .row.mt-5
     .col-12.col-md-10
-      = f.input :order_target, label: "Service Order Target"
+      = f.input :order_target, label: "Service Order Target", disabled: cant_edit(:order_target)
 
   .row.mt-5
     .col-12.col-md-5
-      = f.input :places
-      = f.input :languages
+      = f.input :places, disabled: cant_edit(:places)
+      = f.input :languages, disabled: cant_edit(:languages)
   .row
     .col-12.col-md-10
-      = f.input :terms_of_use_url
-      = f.input :access_policies_url
-      = f.input :sla_url
-      = f.input :webpage_url
-      = f.input :manual_url
-      = f.input :helpdesk_url
-      = f.input :helpdesk_email, input_html: { type: "text" }
-      = f.input :tutorial_url
+      = f.input :terms_of_use_url, disabled: cant_edit(:terms_of_use_url)
+      = f.input :access_policies_url, disabled: cant_edit(:access_policies_url)
+      = f.input :sla_url, disabled: cant_edit(:sla_url)
+      = f.input :webpage_url, disabled: cant_edit(:webpage_url)
+      = f.input :manual_url, disabled: cant_edit(:manual_url)
+      = f.input :helpdesk_url, disabled: cant_edit(:helpdesk_url)
+      = f.input :helpdesk_email, input_html: { type: "text" }, disabled: cant_edit(:helpdesk_email)
+      = f.input :tutorial_url, disabled: cant_edit(:tutorial_url)
   .row
     .col-12.col-md-5
-      = f.input :phase, collection: Service.phases.values.map(&:to_sym)
-      = f.input :restrictions
+      = f.input :phase, collection: Service.phases.values.map(&:to_sym), disabled: cant_edit(:phase)
+      = f.input :restrictions, disabled: cant_edit(:restrictions)
   .row.service-activate-message
     .col-12.col-md-10
-      = f.input :activate_message
+      = f.input :activate_message, disabled: cant_edit(:activate_message)
   .row.mt-5
     .col-12.col-md-5
       = f.input :upstream_id, collection: f.object.sources.reject { |source| source.id.nil? },

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -381,6 +381,80 @@ RSpec.feature "Services in backoffice" do
       click_on "Update Service"
       expect(page).to have_content(external_source.to_s, count: 2)
     end
+
+    scenario "if upstream is set to MP (nil) all fields should be enabled" do
+      service = create(:service, title: "my service", upstream: nil)
+      create(:service_source, service: service, source_type: :eic)
+
+      visit backoffice_service_path(service)
+      click_on "Edit"
+
+      expect(page).to have_field "Logo", disabled: false
+      expect(page).to have_field "Title", disabled: false
+      expect(page).to have_field "Tag list", disabled: false
+      expect(page).to have_field "Description", disabled: false
+      expect(page).to have_field "Service type", disabled: false
+      expect(page).to have_field "Service website", disabled: false
+      expect(page).to have_field "Categories", disabled: false
+      expect(page).to have_field "Providers", disabled: false
+      expect(page).to have_field "Platforms", disabled: false
+      expect(page).to have_field "Research areas", disabled: false
+      expect(page).to have_field "Dedicated For", disabled: false
+      expect(page).to have_field "Owners", disabled: false
+      expect(page).to have_field "service_contact_emails_0", disabled: false
+      expect(page).to have_field "Service Order Target", disabled: false
+      expect(page).to have_field "Places", disabled: false
+      expect(page).to have_field "Languages", disabled: false
+      expect(page).to have_field "Terms of use url", disabled: false
+      expect(page).to have_field "Access policies url", disabled: false
+      expect(page).to have_field "Sla url", disabled: false
+      expect(page).to have_field "Webpage url", disabled: false
+      expect(page).to have_field "Manual url", disabled: false
+      expect(page).to have_field "Helpdesk url", disabled: false
+      expect(page).to have_field "Helpdesk email", disabled: false
+      expect(page).to have_field "Tutorial url", disabled: false
+      expect(page).to have_field "Phase", disabled: false
+      expect(page).to have_field "Restrictions", disabled: false
+      expect(page).to have_field "Activate message", disabled: false
+    end
+
+    scenario "If EIC is selected as upstream fields imported from there should be disabled" do
+      service = create(:service, title: "my service")
+      external_source = create(:service_source, service: service, source_type: :eic)
+      service.upstream = external_source
+      service.save!
+
+      visit backoffice_service_path(service)
+      click_on "Edit"
+
+      expect(page).to have_field "Logo", disabled: true
+      expect(page).to have_field "Title", disabled: true
+      expect(page).to have_field "Tag list", disabled: false
+      expect(page).to have_field "Description", disabled: true
+      expect(page).to have_field "Service type", disabled: true
+      expect(page).to have_field "Service website", disabled: true
+      expect(page).to have_field "Categories", disabled: false
+      expect(page).to have_field "Providers", disabled: true
+      expect(page).to have_field "Platforms", disabled: false
+      expect(page).to have_field "Research areas", disabled: false
+      expect(page).to have_field "Dedicated For", disabled: false
+      expect(page).to have_field "Owners", disabled: false
+      expect(page).to have_field "service_contact_emails_0", disabled: false
+      expect(page).to have_field "Service Order Target", disabled: false
+      expect(page).to have_field "Places", disabled: true
+      expect(page).to have_field "Languages", disabled: true
+      expect(page).to have_field "Terms of use url", disabled: true
+      expect(page).to have_field "Access policies url", disabled: true
+      expect(page).to have_field "Sla url", disabled: true
+      expect(page).to have_field "Webpage url", disabled: true
+      expect(page).to have_field "Manual url", disabled: true
+      expect(page).to have_field "Helpdesk url", disabled: true
+      expect(page).to have_field "Helpdesk email", disabled: false
+      expect(page).to have_field "Tutorial url", disabled: true
+      expect(page).to have_field "Phase", disabled: true
+      expect(page).to have_field "Restrictions", disabled: false
+      expect(page).to have_field "Activate message", disabled: false
+    end
   end
 
   context "as a service owner" do

--- a/spec/policies/backoffice/service_policy_spec.rb
+++ b/spec/policies/backoffice/service_policy_spec.rb
@@ -13,6 +13,42 @@ RSpec.describe Backoffice::ServicePolicy do
 
   subject { described_class }
 
+  context "permitted_attributes" do
+    it "should return attrs if service has no upstream or is not persisted" do
+      policy = described_class.new(service_owner, create(:service))
+      expect(policy.permitted_attributes).to eq([
+                                                    :title, :description,
+                                                    :tagline, :connected_url, :service_type,
+                                                    [provider_ids: []], :places, :languages,
+                                                    [target_group_ids: []], :terms_of_use_url,
+                                                    :access_policies_url, :sla_url,
+                                                    :webpage_url, :manual_url, :helpdesk_url,
+                                                    :helpdesk_email, :tutorial_url, :restrictions,
+                                                    :phase, :order_target,
+                                                    :activate_message, :logo,
+                                                    [contact_emails: []], [research_area_ids: []],
+                                                    [platform_ids: []], :tag_list, [category_ids: []],
+                                                    [owner_ids: []], :status, :upstream_id,
+                                                    sources_attributes: [:id, :source_type, :eid, :_destroy]
+                                                ])
+    end
+
+    it "should filter eic managed fields if upstream is set to eic source" do
+      service = create(:service)
+      source = create(:service_source, source_type: :eic, service: service)
+      service.update!(upstream: source)
+      policy = described_class.new(service_owner, service)
+      expect(policy.permitted_attributes).to eq([
+                                                    [target_group_ids: []], :helpdesk_email, :restrictions,
+                                                    :order_target, :activate_message,
+                                                    [contact_emails: []], [research_area_ids: []],
+                                                    [platform_ids: []], :tag_list, [category_ids: []],
+                                                    [owner_ids: []], :status, :upstream_id,
+                                                    sources_attributes: [:id, :source_type, :eid, :_destroy]
+                                                ])
+    end
+  end
+
   context "service draft" do
     permissions :index? do
       it "grants access for service portfolio manager" do


### PR DESCRIPTION
## What is in this PR?

When upstream in service is set to EIC some fields (which are updated from EIC should be disabled)

![image](https://user-images.githubusercontent.com/13235269/66487143-25258080-eaac-11e9-8af7-916a7687eb1a.png)

![image](https://user-images.githubusercontent.com/13235269/66487227-3ec6c800-eaac-11e9-8668-3cb0875f1552.png)

The list of fields which should be disabled:

* `logo`
* `title`
* `description`
* `tagline`
* `connected_url`
* `places`
* `languages`
* `dedicated_for`
* `terms_of_use_url`
* `access_policies_url`
* `sla_url`
* `webpage_url`
* `manual_url`
* `helpdesk_url`
* `tutorial_url`
* `phase`
* `service_type`
* `providers`


Closes: #1123