### PR TITLE
Disable parsing during data validation

### DIFF
--- a/app/models/attribute/input.rb
+++ b/app/models/attribute/input.rb
@@ -3,6 +3,10 @@
 require "json-schema"
 
 class Attribute::Input < Attribute
+  def value_valid?
+    JSON::Validator.validate(value_schema, value, parse_data: false)
+  end
+
   protected
 
     TYPE = "input"


### PR DESCRIPTION
If user pass url in to attribute input JSON::Schema::JsonParseError was returned([bug](https://sentry.dev.cyfronet.pl/fid/marketplaceproduction/issues/8643/)). It happened because
during validation url was changed to html from this page. For now all strings was parsed to URI during data initialization([code](https://github.com/ruby-json-schema/json-schema/blob/ab1253a874f05a811fdb3280ca1f77ebc9af2902/lib/json-schema/validator.rb#L569)) 
This could be the cause of future attacks.

