### PR TITLE
Disable parsing during data validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Fix attribute input validation (@martaswiatkowska)
 
 ### Security
 

--- a/app/models/attribute.rb
+++ b/app/models/attribute.rb
@@ -31,7 +31,7 @@ class Attribute
   end
 
   def value_valid?
-    JSON::Validator.validate(value_schema, value)
+    JSON::Validator.validate(value_schema, value, parse_data: false)
   end
 
   def validate_config!


### PR DESCRIPTION
If user pass url in to attribute input JSON::Schema::JsonParseError was returned([bug](https://sentry.dev.cyfronet.pl/fid/marketplaceproduction/issues/8643/)). It happened because during validation url was changed to html from this page. For now all strings was parsed to URI during data initialization([code](https://github.com/ruby-json-schema/json-schema/blob/ab1253a874f05a811fdb3280ca1f77ebc9af2902/lib/json-schema/validator.rb#L569)) 
This could be the cause of future attacks.
