### PR TITLE
Clean service browsing specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Changed
 
 - Service's status is preserved when updating services during EIC import (@michal-szostak)
+- Cleanup and refactoring for service browsing specs (@mkasztelnik)
 
 ### Deprecated
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Service searching in top bar", js: true do
 
   before { category = create(:category) }
 
-  scenario "search with 'Allservices' selected should submit to /services" do
+  scenario "search with 'All Services' selected should submit to /services" do
     visit root_path
     select "All services", from: "category-select"
     click_on(id: "query-submit")
@@ -32,5 +32,37 @@ RSpec.feature "Service searching in top bar", js: true do
     expect(url.path).to eq(category_services_path(category_id: category))
 
     expect(page).to have_select("category-select", selected: category.name)
+  end
+
+  scenario "I can clear search conditions" do
+    visit services_path(q: "DDDD Something")
+    expect(page).to have_css(".categories", text: "Looking for: DDDD Something")
+    find(:css, ".search-clear").click
+    expect(page).to_not have_css(".categories", text: "Looking for: DDDD Something")
+  end
+
+  scenario "redirect when selecting service_id by autocomplete controller", js: true, search: true do
+    service = create(:service)
+    fill_in "q", with: service.title
+    find(:css, "li.dropdown-item[id='-option-0']").click
+    expect(current_path).to eq(service_path(service))
+  end
+
+  scenario "redirect when selecting service_id by autocomplete controller", js: true, search: true do
+    service = create(:service)
+    visit services_path(service_id: service.id)
+    expect(current_path).to eq(service_path(service))
+  end
+
+  scenario "After starting searching autocomplete are shown", js: true, search: true do
+    create(:service, title: "DDDD Something 1")
+    create(:service, title: "DDDD Something 2")
+    create(:service, title: "DDDD Something 3")
+
+    visit services_path
+
+    fill_in "q", with: "DDDD Something"
+
+    expect(page).to have_selector("li.dropdown-item[role='option']:not([style*=\"display: none\"]", count: 3)
   end
 end

--- a/spec/features/service_question_spec.rb
+++ b/spec/features/service_question_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Question about service" do
+  include OmniauthHelper
+
+  scenario "cannot be send when contact emails are empty" do
+    service = create(:service)
+
+    visit service_path(service)
+
+    expect(page).to_not have_content "Want to ask a question about this service?"
+  end
+
+  context "as logged in user" do
+    before { checkin_sign_in_as(create(:user)) }
+
+    scenario "I can send qestion to contact emails" do
+      user1, user2 = create_list(:user, 2)
+      service = create(:service, contact_emails: [user1.email, user2.email])
+
+      visit service_path(service)
+
+      find("#modal-show").click
+
+      within("#question-modal") do
+        fill_in("service_question_text", with: "my question")
+      end
+
+      expect do
+        click_on "SEND"
+        expect(page).to have_content("Your message was successfully sent")
+      end.to change { ActionMailer::Base.deliveries.count }.by(2)
+    end
+
+    scenario "I cannot send message about service with empty message", js: true do
+      user1, user2 = create_list(:user, 2)
+      service = create(:service, contact_emails: [user1.email, user2.email])
+
+      visit service_path(service)
+
+      find("#modal-show").click
+
+      click_on "SEND"
+
+      expect(page).to have_content("Text Question cannot be blank")
+    end
+  end
+
+  context "as not logged in user" do
+    scenario "I can send message about service", js: true do
+      user1, user2 = create_list(:user, 2)
+      service = create(:service, contact_emails: [user1.email, user2.email])
+
+      visit service_path(service)
+
+      find("#modal-show").click
+
+      within("#question-modal") do
+        fill_in("service_question_author", with: "John Doe")
+        fill_in("service_question_email", with: "john.doe@company.com")
+        fill_in("service_question_text", with: "text")
+      end
+
+      expect do
+        click_on "SEND"
+        expect(page).to have_content("Your message was successfully sent")
+      end.to change { ActionMailer::Base.deliveries.count }.by(2)
+    end
+
+    scenario "I cannot send message about service with empty fields", js: true do
+      user1, user2 = create_list(:user, 2)
+      service = create(:service, contact_emails: [user1.email, user2.email])
+
+      visit service_path(service)
+
+      find("#modal-show").click
+
+      click_on "SEND"
+
+      expect(page).to have_content("Author can't be blank")
+      expect(page).to have_content("Email can't be blank and Email is not a valid email address")
+      expect(page).to have_content("Text Question cannot be blank")
+    end
+  end
+end


### PR DESCRIPTION
Deep cleanup for all specs related to service browsing. Specs related to concrete features (e.g. search, filter, ask a question) were moved to dedicated files. Some tests which test case was duplicated by other tests were removed. Also, all `sleep` was eliminated from the spec code.  This was possible thanks to this simple trick:

https://stackoverflow.com/questions/41854537/capybara-poltergeist-wait-for-javascript-completions