### PR TITLE
Fix validation url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Url validation (@martaswiatkowska)
 
 ### Security
 

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "counter_culture", "~> 2.0"
 # validation
 gem "valid_email2"
 gem "json-schema"
-gem "validate_url", github: "perfectline/validates_url"
+gem "public_suffix"
 
 gem "searchkick"
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/perfectline/validates_url.git
-  revision: 81f520f076f19c69ed4b6856677b527beec6c662
-  specs:
-    validate_url (1.0.7)
-      activemodel (>= 3.0.0)
-      public_suffix
-
-GIT
   remote: https://github.com/thethanghn/custom-err-msg.git
   revision: b913309360995472507ea444c6f1a80315b99d28
   specs:
@@ -450,6 +442,9 @@ GEM
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
+    validate_url (1.0.8)
+      activemodel (>= 3.0.0)
+      public_suffix
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -517,6 +512,7 @@ DEPENDENCIES
   pry-doc
   pry-nav
   pry-rails
+  public_suffix
   puma (~> 3.11)
   pundit (~> 2.0)
   rack_session_access
@@ -543,7 +539,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unirest
   valid_email2
-  validate_url!
   web-console (>= 3.3.0)
   webdrivers (~> 3.0)
   webpacker (~> 4.x)

--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -226,7 +226,7 @@ private
     when "CI-Department"
       project.single_user_or_community? ? project.department : nil
     when "CI-DepartmentalWebPage"
-      project.single_user_or_community? ? project.webpage : nil
+      project.single_user_or_community? ? URI.parse(project.webpage).to_s : nil
     when "CI-DisplayName"
       "#{project.user.first_name} #{project.user.last_name}"
     when "CP-ScientificDiscipline"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -44,17 +44,17 @@ class Project < ApplicationRecord
   validates :customer_typology, presence: true
 
   validates :organization, presence: true, if: :single_user_or_community?
-  validates :webpage, presence: true, url: true, if: :single_user_or_community?
+  validates :webpage, presence: true, mp_url: true, if: :single_user_or_community?
 
   validates :user_group_name, presence: true, if: :research?
 
   validates :project_name, presence: true, if: :project?
-  validates :project_website_url, url: true, presence: true, if: :project?
+  validates :project_website_url, mp_url: true, presence: true, if: :project?
 
   validates :company_name, presence: true, if: :private_company?
   validates :countries_of_partnership, presence: true, if: :research_or_project?,
             multiselect_choices: { collection: Country.all }
-  validates :company_website_url,  url: true, presence: true, if: :private_company?
+  validates :company_website_url, mp_url: true, presence: true, if: :private_company?
 
   validates :issue_id, presence: true, if: :require_jira_issue?
   validates :issue_key, presence: true, if: :require_jira_issue?
@@ -81,7 +81,6 @@ class Project < ApplicationRecord
   end
 
   private
-
     def require_jira_issue?
       jira_active? || jira_deleted?
     end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -99,17 +99,17 @@ class Service < ApplicationRecord
   validates :title, presence: true
   validates :description, presence: true
   validates :tagline, presence: true
-  validates :connected_url, presence: true, url: true, if: :open_access?
+  validates :connected_url, presence: true, mp_url: true, if: :open_access?
   validates :rating, presence: true
-  validates :terms_of_use_url, url: true, if: :terms_of_use_url?
-  validates :access_policies_url, url: true, if: :access_policies_url?
-  validates :sla_url, url: true, if: :sla_url?
-  validates :webpage_url, url: true, if: :webpage_url?
-  validates :manual_url, url: true, if: :manual_url?
-  validates :helpdesk_url, url: true, if: :helpdesk_url?
+  validates :terms_of_use_url, mp_url: true, if: :terms_of_use_url?
+  validates :access_policies_url, mp_url: true, if: :access_policies_url?
+  validates :sla_url, mp_url: true, if: :sla_url?
+  validates :webpage_url, mp_url: true, if: :webpage_url?
+  validates :manual_url, mp_url: true, if: :manual_url?
+  validates :helpdesk_url, mp_url: true, if: :helpdesk_url?
   validates :helpdesk_email, allow_blank: true, email: true
   validates :contact_emails, array: { email: true }
-  validates :tutorial_url, url: true, if: :tutorial_url?
+  validates :tutorial_url, mp_url: true, if: :tutorial_url?
   validates :logo, blob: { content_type: :image }
   validate :logo_variable, on: [:create, :update]
   validates :research_areas, presence: true
@@ -118,7 +118,6 @@ class Service < ApplicationRecord
   validates :order_target, allow_blank: true, email: true
 
   after_save :set_first_category_as_main!, if: :main_category_missing?
-  before_validation :strip_whitespace
 
   def main_category
     @main_category ||= categories.joins(:categorizations).
@@ -152,16 +151,5 @@ class Service < ApplicationRecord
 
     def main_category_missing?
       categorizations.where(main: true).count.zero?
-    end
-
-    def strip_whitespace
-      self.terms_of_use_url&.strip!
-      self.access_policies_url&.strip!
-      self.sla_url&.strip!
-      self.webpage_url&.strip!
-      self.manual_url&.strip!
-      self.helpdesk_url&.strip!
-      self.tutorial_url&.strip!
-      self.connected_url&.strip!
     end
 end

--- a/app/validators/mp_url_validator.rb
+++ b/app/validators/mp_url_validator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "public_suffix"
+
+class MpUrlValidator < ActiveModel::EachValidator
+  def initialize(options)
+    options.reverse_merge!(schemes: %w(http https))
+    options.reverse_merge!(message: :url)
+
+    super(options)
+  end
+
+  def validate_each(record, attribute, value)
+    schemes = [*options.fetch(:schemes)].map(&:to_s)
+    begin
+      uri = URI.parse(value)
+      host = uri&.host
+      scheme = uri&.scheme
+
+      valid_suffix = host && PublicSuffix.valid?(host)
+      valid_no_local = host&.include?(".")
+      valid_scheme = host && scheme && schemes.include?(scheme)
+
+      unless valid_scheme && valid_no_local && valid_suffix
+        record.errors.add(attribute, options.fetch(:message), value: value)
+      end
+
+    rescue URI::InvalidURIError
+      record.errors.add(attribute, options.fetch(:message), value: value)
+    end
+  end
+end

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -159,18 +159,12 @@ RSpec.feature "Service browsing" do
     expect(page.body.index("Service b")).to be < page.body.index("Service c")
   end
 
-  scenario "selecting sorting will set query param and preserve existing ones", js: true do
+  scenario "sorting will set query param and preserve existing ones", js: true do
     create(:service, title: "DDDD Something 1", rating: 4.1)
     create(:service, title: "DDDD Something 2", rating: 4.0)
     create(:service, title: "DDDD Something 3", rating: 3.9)
 
-    visit services_path(q: "DDDD Something")
-
-    select "rate 1-5", from: "sort"
-
-    # This is a little trick to wait for turbolinks.
-    # See https://stackoverflow.com/questions/41854537/capybara-poltergeist-wait-for-javascript-completions
-    expect(page).to have_text("DDDD Something 1")
+    visit services_path(q: "DDDD Something", sort: "rating")
 
     expect(page.text.index("DDDD Something 3")).to be < page.text.index("DDDD Something 2")
     expect(page.text.index("DDDD Something 2")).to be < page.text.index("DDDD Something 1")

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -67,16 +67,6 @@ RSpec.describe Service do
     expect(s1.related_services).to contain_exactly(s2, s3)
   end
 
-  it "it removes leading and trailing spaces from urls before validation" do
-    service = create(:service)
-    service.terms_of_use_url = "https://sample.url "
-    service.access_policies_url = " https://sample.url"
-
-    expect(service.valid?).to be_truthy
-    expect(service.terms_of_use_url).to eq("https://sample.url")
-    expect(service.access_policies_url).to eq("https://sample.url")
-  end
-
   it "requires service_order_target to be an email" do
     service = create(:service)
     service.order_target = "not-valid-email"

--- a/spec/validators/mp_url_validator_spec.rb
+++ b/spec/validators/mp_url_validator_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Test
+  MpUrlValidatable = Struct.new(:webpage) do
+    include ActiveModel::Validations
+
+    validates :webpage, mp_url: true
+  end
+end
+
+# Validator tests with the test object
+describe MpUrlValidator, type: :model do
+  subject { Test::MpUrlValidatable.new("http://testvalid.com") }
+
+  it { is_expected.to be_valid(:webpage) }
+
+  it "require webpage to be valid mp_url" do
+    subject.webpage = "http://www.abc def.com"
+    expect(subject.valid?).to be_falsey
+    subject.webpage = "https://www.aaaaa.com/search?arg=\"Ala ma kota\""
+    expect(subject.valid?).to be_truthy
+    subject.webpage = "https://www.google.com/a/b/ala ma/search"
+    expect(subject.valid?).to be_falsey
+  end
+
+  it "require http/https" do
+    subject.webpage = "www.abcdef.com"
+    expect(subject.valid?).to be_falsey
+    subject.webpage = "http://www.abcdef.com"
+    expect(subject.valid?).to be_truthy
+    subject.webpage = "http://www.abcdef.com"
+    expect(subject.valid?).to be_truthy
+  end
+
+  it "required suffix" do
+    subject.webpage = "http://bcdef"
+    expect(subject.valid?).to be_falsey
+  end
+
+  it "forbidden local" do
+    subject.webpage = "http://localhost:5000/projects/1"
+    expect(subject.valid?).to be_falsey
+  end
+end


### PR DESCRIPTION
Fixed url validation occured https://sentry.dev.cyfronet.pl/fid/marketplaceproduction/issues/8645/
Checking if spaces are in the url except in parameters.


Feel free to propose other names for MpUrlValidator
Its solution before merge this pr https://github.com/perfectline/validates_url/pull/85 after that MpUrlValidator can be replaced to validates_url 