### PR TITLE
Exact match in filter search

### DIFF
--- a/app/javascript/controllers/multicheckbox_controller.js
+++ b/app/javascript/controllers/multicheckbox_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
       return { 'item': item, 'title': item.getElementsByTagName("span")[0].textContent }
     });
 
-    this.fuse = new Fuse(candidates, { keys: ['title'] });
+    this.fuse = new Fuse(candidates, { keys: ['title'], distance: 1 });
   }
 
   search() {


### PR DESCRIPTION
Fuzzy search distance is set to 1. This allows us to have an exact match for providers.

No changelog entry, because it is a modification of the feature already mentioned in this sprint changelog.