### PR TITLE
Offer selection available for anonymous user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Internal server error message (@goreck888)
+- Anonymous user can enter service offer selection section (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   include Turbolinks::Redirection
   include Sentryable
   include Pundit
+  include Devise::StoreLocation
 
   before_action :load_main_research_areas!, :load_root_categories!
 

--- a/app/controllers/concerns/devise/store_location.rb
+++ b/app/controllers/concerns/devise/store_location.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Devise::StoreLocation
+  extend ActiveSupport::Concern
+
+  included do
+    prepend_before_action :store_user_location!, if: :storable_location?
+  end
+
+  private
+
+    def storable_location?
+      request.get? && is_navigational_format? &&
+        !devise_controller? && !request.xhr?
+    end
+
+    def store_user_location!
+      store_location_for(:user, request.fullpath)
+    end
+end

--- a/app/controllers/services/offers_controller.rb
+++ b/app/controllers/services/offers_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Services::OffersController < Services::ApplicationController
+  skip_before_action :authenticate_user!
+
   def index
     init_offer_selection!
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -24,8 +24,4 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def after_omniauth_failure_path_for(scope)
     root_path
   end
-
-  def after_sign_in_path_for(scope)
-    request.env["omniauth.origin"] || super(scope)
-  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   else
     config.action_controller.perform_caching = false
 
-    config.cache_store = :null_store
+    config.cache_store = :memory_store
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -447,11 +447,9 @@ RSpec.feature "Service ordering" do
   end
 
   context "as anonymous user" do
-    scenario "I nead to login to order service" do
+    scenario "I can see service offers" do
       service = create(:service)
-      create_list(:offer, 2, service: service)
-      user = create(:user)
-      stub_checkin(user)
+      o1, o2 = create_list(:offer, 2, service: service)
 
       visit service_path(service)
 
@@ -459,8 +457,24 @@ RSpec.feature "Service ordering" do
 
       click_on "Order", match: :first
 
-      expect(page).to have_current_path(service_offers_path(service))
       expect(page).to have_text(service.title)
+      expect(page).to have_text(o1.name)
+      expect(page).to have_text(o2.name)
+    end
+
+    scenario "I need to log in to configure my order" do
+      service = create(:service)
+      create(:offer, service: service)
+      user = build(:user)
+      stub_checkin(user)
+
+      expect do
+        visit service_offers_path(service)
+        # If new user is logged in using checkin new user record is created
+      end.to change { User.count }.by(1)
+
+      expect(page).to have_current_path(service_configuration_path(service))
+      expect(User.last.full_name).to eq(user.full_name)
     end
 
     scenario "I can see order button" do

--- a/spec/support/helpers/omniauth_helper.rb
+++ b/spec/support/helpers/omniauth_helper.rb
@@ -2,11 +2,10 @@
 
 module OmniauthHelper
   def stub_omniauth(provider, options = {})
-    first_name = options.fetch(:first_name, "John"),
-    last_name = options.fetch(:last_name, "Doe"),
+    first_name = options.fetch(:first_name, "John")
+    last_name = options.fetch(:last_name, "Doe")
     email = options.fetch(:email, "#{first_name}.#{last_name}@email.pl")
     uid = options.fetch(:uid, 123)
-    origin = options.fetch(:origin, current_path)
 
     OmniAuth.config.add_mock(
       provider,
@@ -18,9 +17,6 @@ module OmniauthHelper
       provider: provider,
       uid: uid
     )
-    OmniAuth.config.before_callback_phase do |env|
-      env["omniauth.origin"] = origin
-    end
   end
 
   def stub_checkin(user)


### PR DESCRIPTION
Offers selection is made available for anonymous users. There is one problem: while the user is clicking on a specific offer then after checkin login session is cleared and the selected offer is not available. This only happened in the development environment. The solution to this issue was to change the development `cache_store` to `memory_store`. 

There is another change connected with redirecting user after a successful login. Before ` request.env["omniauth.origin"]` was used and it was done in the PR #941 as a solution for #798. After going back to the default implementation (method `after_sign_in_path_for` was removed from `app/controllers/users/omniauth_callbacks_controller.rb`) I was not able to reproduce the issue described in #798 but is require to double-check (@bwilk can you do that?). 