### PR TITLE
Disable order button in service preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Active Order button in service preview (@goreck888)
 
 ### Security
 

--- a/app/javascript/stylesheets/_preview.scss
+++ b/app/javascript/stylesheets/_preview.scss
@@ -1,5 +1,5 @@
 .preview {
-  a {
+  .btn.btn-primary {
     pointer-events: none;
   }
 }

--- a/app/views/backoffice/services/preview.html.haml
+++ b/app/views/backoffice/services/preview.html.haml
@@ -16,7 +16,7 @@
           = link_to "Confirm changes", backoffice_services_path,
             class: "btn btn-success", method: :post
 
-.container
+.container.preview
   .pt-4.pl-3.pr-3.shadow-sm.rounded.service-box.service-detail
     = render "services/header", service: @service, preview: true
     = render "services/tabs", service: @service, preview: true


### PR DESCRIPTION
Add css class "preview" to the preview disabling order buttons
Fixes #1182