### PR TITLE
Use service type as order type while seeding data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Catalog can be added to project (@martaswiatkowska)
 - Project_new_message mails content (@martaswiatkowska)
 - Information step to ordering path (@martaswiatkowska)
+- Use service type as default order type while seeding db (@mkasztelnik)
 
 ### Changed
 - Internal server error message (@goreck888)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -96,6 +96,7 @@ yaml_hash["services"].each do |_, hash|
       service.offers.create!(name: h["name"],
                              description: h["description"],
                              parameters: h["parameters"] || [],
+                             offer_type: service_type,
                              status: :published)
     end
   end


### PR DESCRIPTION
Before there was `nil` as a result all order views have corrupted translations.