### PR TITLE
Hide service order configuration step when no data to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Service ordering summary step unification (@goreck888)
 - Anonymous user can enter information step (@martaswiatkowska)
 - Project selection was moved to last service order step (@mkasztelnik)
+- Order configuration step is shown when offer is voucherable or has properties (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/controllers/services/application_controller.rb
+++ b/app/controllers/services/application_controller.rb
@@ -7,7 +7,7 @@ class Services::ApplicationController < ApplicationController
   layout "order"
 
   attr_reader :wizard
-  helper_method :step
+  helper_method :step_for
   helper_method :step_key
   helper_method :next_step_key
   helper_method :prev_step_key
@@ -40,6 +40,10 @@ class Services::ApplicationController < ApplicationController
     end
 
     def step(attrs = saved_state)
+      wizard.step(step_key, attrs)
+    end
+
+    def step_for(step_key, attrs = saved_state)
       wizard.step(step_key, attrs)
     end
 

--- a/app/controllers/services/application_controller.rb
+++ b/app/controllers/services/application_controller.rb
@@ -7,6 +7,7 @@ class Services::ApplicationController < ApplicationController
   layout "order"
 
   attr_reader :wizard
+  helper_method :saved_state
 
   private
 
@@ -15,7 +16,7 @@ class Services::ApplicationController < ApplicationController
     end
 
     def ensure_in_session!
-      unless session[session_key]
+      unless saved_state
         redirect_to service_offers_path(@service),
                     alert: "Service request template not found"
       end
@@ -29,5 +30,9 @@ class Services::ApplicationController < ApplicationController
 
     def save_in_session(step)
       session[session_key] = step.project_item.attributes
+    end
+
+    def saved_state
+      session[session_key]
     end
 end

--- a/app/controllers/services/application_controller.rb
+++ b/app/controllers/services/application_controller.rb
@@ -7,7 +7,10 @@ class Services::ApplicationController < ApplicationController
   layout "order"
 
   attr_reader :wizard
-  helper_method :saved_state
+  helper_method :step
+  helper_method :step_key
+  helper_method :next_step_key
+  helper_method :prev_step_key
 
   private
 
@@ -34,5 +37,25 @@ class Services::ApplicationController < ApplicationController
 
     def saved_state
       session[session_key]
+    end
+
+    def step(attrs = saved_state)
+      wizard.step(step_key, attrs)
+    end
+
+    def next_step_key
+      wizard.next_step_key(step_key)
+    end
+
+    def prev_step_key
+      wizard.prev_step_key(step_key)
+    end
+
+    def prev_step
+      wizard.step(wizard.prev_step_key(step_key), saved_state)
+    end
+
+    def step_key
+      raise "Should be implemented in descendent class"
     end
 end

--- a/app/controllers/services/application_controller.rb
+++ b/app/controllers/services/application_controller.rb
@@ -6,6 +6,8 @@ class Services::ApplicationController < ApplicationController
 
   layout "order"
 
+  attr_reader :wizard
+
   private
 
     def session_key
@@ -22,6 +24,7 @@ class Services::ApplicationController < ApplicationController
     def load_and_authenticate_service!
       @service = Service.friendly.find(params[:service_id])
       authorize(@service, :order?)
+      @wizard = ProjectItem::Wizard.new(@service)
     end
 
     def save_in_session(step)

--- a/app/controllers/services/configurations_controller.rb
+++ b/app/controllers/services/configurations_controller.rb
@@ -4,8 +4,8 @@ class Services::ConfigurationsController < Services::ApplicationController
   before_action :ensure_in_session!
 
   def show
-    if ProjectItem::Wizard::OfferSelectionStep.new(session[session_key]).valid?
-      @step = step_class.new(session[session_key])
+    if wizard.step(:information, session[session_key]).valid?
+      @step = step(session[session_key])
     else
       redirect_to service_offers_path(@service),
                   alert: "Please select one of the service offer"
@@ -13,7 +13,7 @@ class Services::ConfigurationsController < Services::ApplicationController
   end
 
   def update
-    @step = step_class.new(configuration_params)
+    @step = step(configuration_params)
 
     if @step.request_voucher
       @step.voucher_id = ""
@@ -36,7 +36,7 @@ class Services::ConfigurationsController < Services::ApplicationController
           merge(status: :created)
     end
 
-    def step_class
-      ProjectItem::Wizard::ConfigurationStep
+    def step(attrs)
+      wizard.step(:configuration, attrs)
     end
 end

--- a/app/controllers/services/configurations_controller.rb
+++ b/app/controllers/services/configurations_controller.rb
@@ -8,10 +8,10 @@ class Services::ConfigurationsController < Services::ApplicationController
       @step = step(saved_state)
 
       unless @step.visible?
-        redirect_to service_summary_path(@service)
+        redirect_to url_for([@service, next_step_key])
       end
     else
-      redirect_to service_offers_path(@service), alert: prev_step.error
+      redirect_to url_for([@service, pref_step_key]), alert: prev_step.error
     end
   end
 
@@ -24,7 +24,7 @@ class Services::ConfigurationsController < Services::ApplicationController
 
     if @step.valid?
       save_in_session(@step)
-      redirect_to service_summary_path(@service)
+      redirect_to url_for([@service, next_step_key])
     else
       flash.now[:alert] = @step.error
       render :show
@@ -39,11 +39,7 @@ class Services::ConfigurationsController < Services::ApplicationController
         .merge(status: :created)
     end
 
-    def step(attrs)
-      wizard.step(:configuration, attrs)
-    end
-
-    def prev_step
-      @prev_step ||= wizard.step(:information, saved_state)
+    def step_key
+      :configuration
     end
 end

--- a/app/controllers/services/information_controller.rb
+++ b/app/controllers/services/information_controller.rb
@@ -5,6 +5,30 @@ class Services::InformationController < Services::ApplicationController
   before_action :ensure_in_session!
 
   def show
-    @offer = Offer.find(session[session_key]["offer_id"])
+    if prev_step.valid?
+      @step = step(saved_state)
+      @offer = @step.offer
+
+      unless @step.visible?
+        redirect_to url_for([@service, next_step_key])
+      end
+    else
+      redirect_to url_for([@service, pref_step_key]), alert: prev_step.error
+    end
   end
+
+  def update
+    if step.valid?
+      redirect_to url_for([@service, next_step_key])
+    else
+      flash.now[:alert] = @step.error
+      render :show
+    end
+  end
+
+  private
+
+    def step_key
+      :information
+    end
 end

--- a/app/controllers/services/offers_controller.rb
+++ b/app/controllers/services/offers_controller.rb
@@ -17,7 +17,7 @@ class Services::OffersController < Services::ApplicationController
 
     if @step.valid?
       save_in_session(@step)
-      redirect_to service_information_path(@service)
+      redirect_to [@service, next_step_key]
     else
       init_step_data
       flash.now[:alert] = @step.error
@@ -27,8 +27,8 @@ class Services::OffersController < Services::ApplicationController
 
   private
 
-    def step(attrs = nil)
-      wizard.step(:offers, attrs)
+    def step_key
+      :offers
     end
 
     def step_params

--- a/app/controllers/services/offers_controller.rb
+++ b/app/controllers/services/offers_controller.rb
@@ -3,17 +3,17 @@
 class Services::OffersController < Services::ApplicationController
   skip_before_action :authenticate_user!
 
-  def index
+  def show
     init_step_data
 
-    if @service.offers_count == 1
+    unless step.visible?
       params[:project_item] = { offer_id: @offers.first.iid }
       update
     end
   end
 
   def update
-    @step = step_class.new(step_params)
+    @step = step(step_params)
 
     if @step.valid?
       save_in_session(@step)
@@ -27,8 +27,8 @@ class Services::OffersController < Services::ApplicationController
 
   private
 
-    def step_class
-      ProjectItem::Wizard::OfferSelectionStep
+    def step(attrs = nil)
+      wizard.step(:offers, attrs)
     end
 
     def step_params
@@ -44,6 +44,6 @@ class Services::OffersController < Services::ApplicationController
 
     def init_step_data
       @offers = @service.offers.reject { |o| o.draft? }
-      @step = step_class.new(session[session_key])
+      @step = step(session[session_key])
     end
 end

--- a/app/controllers/services/offers_controller.rb
+++ b/app/controllers/services/offers_controller.rb
@@ -21,7 +21,7 @@ class Services::OffersController < Services::ApplicationController
     else
       init_step_data
       flash.now[:alert] = @step.error
-      render :index
+      render :show
     end
   end
 

--- a/app/controllers/services/summaries_controller.rb
+++ b/app/controllers/services/summaries_controller.rb
@@ -4,8 +4,8 @@ class Services::SummariesController < Services::ApplicationController
   before_action :ensure_in_session!
 
   def show
-    if ProjectItem::Wizard::ConfigurationStep.new(session[session_key]).valid?
-      @step = step_class.new(session[session_key])
+    if wizard.step(:configuration, session[session_key]).valid?
+      @step = step(session[session_key])
       setup_show_variables!
     else
       redirect_to service_configuration_path(@service),
@@ -14,7 +14,7 @@ class Services::SummariesController < Services::ApplicationController
   end
 
   def create
-    @step = step_class.new(summary_params)
+    @step = step(summary_params)
 
     if @step.valid?
       do_create(@step.project_item)
@@ -42,8 +42,8 @@ class Services::SummariesController < Services::ApplicationController
       end
     end
 
-    def step_class
-      ProjectItem::Wizard::SummaryStep
+    def step(attrs)
+      wizard.step(:summary, attrs)
     end
 
     def summary_params

--- a/app/helpers/order_nav_helper.rb
+++ b/app/helpers/order_nav_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module OrderNavHelper
-  def order_nav_link(title, path, step, current_step)
+  def order_nav_link(title, path, state)
     content_tag(:li, class: "nav-item") do
-      link_to_if(step <= current_step, title, path,
-                 class: "nav-link #{"active" if step == current_step}") do
-        if step == current_step + 1
+      link_to_if(state != :disabled, title, path,
+                 class: "nav-link #{"active" if state == :active}") do
+        if state == :active
           content_tag(:a, title, class: "nav-link", href: "#",
                       onclick: "document.getElementById('order-form').submit();")
         else

--- a/app/models/project_item/wizard.rb
+++ b/app/models/project_item/wizard.rb
@@ -54,6 +54,9 @@ class ProjectItem::Wizard
     end
 
     class InformationStep < OffersStep
+      def visible?
+        true
+      end
     end
 
     class ConfigurationStep < OffersStep
@@ -63,7 +66,7 @@ class ProjectItem::Wizard
       delegate :created?, to: :project_item
 
       def visible?
-        true
+        offer.nil? || project_item.property_values.count.positive? || voucherable?
       end
 
       def error

--- a/app/models/project_item/wizard.rb
+++ b/app/models/project_item/wizard.rb
@@ -1,45 +1,82 @@
 # frozen_string_literal: true
 
-module ProjectItem::Wizard
-  class Base
-    include ActiveModel::Model
-    attr_accessor :project_item
+class ProjectItem::Wizard
+  STEPS = %w(offers information configuration summary)
 
-    delegate(*::ProjectItem.attribute_names.map { |a| [a, "#{a}="] }.flatten,
-             to: :project_item)
-
-    delegate :service, :offer, :project, to: :project_item
-
-    def initialize(project_item_attributes)
-      @project_item = ::ProjectItem.new(project_item_attributes)
-    end
-
-    def model_name
-      project_item.model_name
-    end
+  def initialize(service)
+    @service = service
   end
 
-  class OfferSelectionStep < Base
-    validates :offer, presence: true
+  def step(step, attrs = {})
+    raise InvalidStep unless step.to_s.in?(ProjectItem::Wizard::STEPS)
 
-    def error
-      "Please select one of the offer"
+    "ProjectItem::Wizard::#{step.to_s.camelize}Step"
+      .constantize.new(@service, attrs)
+  end
+
+  def step_names
+    STEPS
+  end
+
+  class InvalidStep < StandardError; end
+
+  private
+
+    class Base
+      include ActiveModel::Model
+      attr_accessor :project_item, :service
+
+      delegate(*::ProjectItem.attribute_names.map { |a| [a, "#{a}="] }.flatten,
+              to: :project_item)
+
+      delegate :offer, :project, to: :project_item
+
+      def initialize(service, project_item_attributes)
+        @service = service
+        @project_item = ::ProjectItem.new(project_item_attributes)
+      end
+
+      def model_name
+        project_item.model_name
+      end
     end
-  end
 
-  class ConfigurationStep < OfferSelectionStep
-    include ProjectItem::Customization
-    include ProjectItem::VoucherValidation
+    class OffersStep < Base
+      validates :offer, presence: true
 
-    delegate :created?, to: :project_item
+      def visible?
+        service.offers_count > 1
+      end
 
-    def error
-      "Please correct errors presented below"
+      def error
+        "Please select one of the offer"
+      end
     end
-  end
 
-  class SummaryStep < ConfigurationStep
-    include ProjectItem::ProjectValidation
-    delegate :properties?, to: :project_item
-  end
+    class InformationStep < OffersStep
+    end
+
+    class ConfigurationStep < OffersStep
+      include ProjectItem::Customization
+      include ProjectItem::VoucherValidation
+
+      delegate :created?, to: :project_item
+
+      def visible?
+        true
+      end
+
+      def error
+        "Please correct errors presented below"
+      end
+    end
+
+    class SummaryStep < ConfigurationStep
+      include ProjectItem::ProjectValidation
+      delegate :properties?, to: :project_item
+
+      def visible?
+        true
+      end
+    end
 end

--- a/app/models/project_item/wizard.rb
+++ b/app/models/project_item/wizard.rb
@@ -8,10 +8,18 @@ class ProjectItem::Wizard
   end
 
   def step(step, attrs = {})
-    raise InvalidStep unless step.to_s.in?(ProjectItem::Wizard::STEPS)
+    raise InvalidStep unless step.to_s.in?(step_names)
 
     "ProjectItem::Wizard::#{step.to_s.camelize}Step"
       .constantize.new(@service, attrs)
+  end
+
+  def next_step_key(step)
+    step_names[step_names.index(step.to_s) + 1]
+  end
+
+  def prev_step_key(step)
+    step_names[step_names.index(step.to_s) - 1]
   end
 
   def step_names
@@ -77,6 +85,10 @@ class ProjectItem::Wizard
     class SummaryStep < ConfigurationStep
       include ProjectItem::ProjectValidation
       delegate :properties?, to: :project_item
+
+      def error
+        "Please select the project where service will be added"
+      end
 
       def visible?
         true

--- a/app/views/layouts/order/_nav.html.haml
+++ b/app/views/layouts/order/_nav.html.haml
@@ -1,8 +1,6 @@
 %ul.nav.nav-fill.order-nav
-  - if policy(service).offers_show?
-    = order_nav_link("Offer selection", service_offers_path(service), 1, step)
-  = order_nav_link(t("service.information.title"),
-                   service_information_path(service), 2, step)
-  = order_nav_link(t("service.#{service.service_type}.order.configuration.title"),
-                   service_configuration_path(service), 3, step)
-  = order_nav_link("Summary", service_summary_path(service), 4, step)
+  - wizard.step_names.each_with_index do |name, i|
+    - if wizard.step(name).visible?
+      = order_nav_link(t("service.#{service.service_type}.order.#{name}.title",
+        default: "service.#{name}.title".to_sym),
+        url_for([service, name]), i + 1, step)

--- a/app/views/layouts/order/_nav.html.haml
+++ b/app/views/layouts/order/_nav.html.haml
@@ -1,11 +1,11 @@
 %ul.nav.nav-fill.order-nav
   - state = :back
-  - wizard.step_names.each_with_index do |step_name, i|
-    - if wizard.step(step_name, saved_state).visible?
+  - wizard.step_names.each do |step_name|
+    - if step.visible?
       :ruby
         state = :disabled if state == :next
         state = :next if state == :active
-        state = :active if step == i + 1
+        state = :active if step_name == step_key.to_s
 
       = order_nav_link(t("service.#{service.service_type}.order.#{step_name}.title",
         default: "service.#{step_name}.title".to_sym), url_for([service, step_name]), state)

--- a/app/views/layouts/order/_nav.html.haml
+++ b/app/views/layouts/order/_nav.html.haml
@@ -1,7 +1,7 @@
 %ul.nav.nav-fill.order-nav
   - state = :back
   - wizard.step_names.each do |step_name|
-    - if step.visible?
+    - if step_for(step_name).visible?
       :ruby
         state = :disabled if state == :next
         state = :next if state == :active

--- a/app/views/layouts/order/_nav.html.haml
+++ b/app/views/layouts/order/_nav.html.haml
@@ -1,6 +1,11 @@
 %ul.nav.nav-fill.order-nav
-  - wizard.step_names.each_with_index do |name, i|
-    - if wizard.step(name).visible?
-      = order_nav_link(t("service.#{service.service_type}.order.#{name}.title",
-        default: "service.#{name}.title".to_sym),
-        url_for([service, name]), i + 1, step)
+  - state = :back
+  - wizard.step_names.each_with_index do |step_name, i|
+    - if wizard.step(step_name, saved_state).visible?
+      :ruby
+        state = :disabled if state == :next
+        state = :next if state == :active
+        state = :active if step == i + 1
+
+      = order_nav_link(t("service.#{service.service_type}.order.#{step_name}.title",
+        default: "service.#{step_name}.title".to_sym), url_for([service, step_name]), state)

--- a/app/views/services/configurations/show.html.haml
+++ b/app/views/services/configurations/show.html.haml
@@ -1,4 +1,4 @@
-= render "layouts/order/nav", service: @service, step: 3
+= render "layouts/order/nav", service: @service, wizard: @wizard, step: 3
 
 %h2.mb-4.font-weight-normal= t "service.#{@service.service_type}.order.configuration.title"
 %p.mb-4= t "service.#{@service.service_type}.order.configuration.description"

--- a/app/views/services/configurations/show.html.haml
+++ b/app/views/services/configurations/show.html.haml
@@ -1,4 +1,4 @@
-= render "layouts/order/nav", service: @service, wizard: @wizard, step: 3
+= render "layouts/order/nav", service: @service, wizard: @wizard
 
 %h2.mb-4.font-weight-normal= t "service.#{@service.service_type}.order.configuration.title"
 %p.mb-4= t "service.#{@service.service_type}.order.configuration.description"
@@ -19,5 +19,4 @@
 
 = content_for :back_link do
   = link_to "Back to previous step - service information",
-            service_information_path(@service),
-            class: "text-uppercase"
+    url_for([@service, prev_step_key]), class: "text-uppercase"

--- a/app/views/services/information/show.html.haml
+++ b/app/views/services/information/show.html.haml
@@ -1,4 +1,4 @@
-= render "layouts/order/nav", service: @service, wizard: @wizard, step: 2
+= render "layouts/order/nav", service: @service, wizard: @wizard
 
 .col-8
   %h2.mb-4.font-weight-normal= t ("service.type.#{@offer.offer_type}")
@@ -10,12 +10,9 @@
         class: "btn btn-primary mb-2", target: "_blank"
 
 = content_for :next_button do
-  = link_to t("service.next"),
-            service_configuration_path(@service),
-            class: "btn btn-primary"
+  = link_to t("service.next"), url_for, method: :put, class: "btn btn-primary"
 
 - if policy(@service).offers_show?
   = content_for :back_link do
     = link_to "Back to previous step - Offers",
-              service_offers_path(@service),
-              class: "text-uppercase"
+      url_for([@service, prev_step_key]), class: "text-uppercase"

--- a/app/views/services/information/show.html.haml
+++ b/app/views/services/information/show.html.haml
@@ -1,4 +1,4 @@
-= render "layouts/order/nav", service: @service, step: 2
+= render "layouts/order/nav", service: @service, wizard: @wizard, step: 2
 
 .col-8
   %h2.mb-4.font-weight-normal= t ("service.type.#{@offer.offer_type}")

--- a/app/views/services/offers/show.html.haml
+++ b/app/views/services/offers/show.html.haml
@@ -1,4 +1,4 @@
-= render "layouts/order/nav", service: @service, step: 1
+= render "layouts/order/nav", service: @service, wizard: @wizard, step: 1
 
 %h2.mb-4.font-weight-normal Offer selection
 %p.mb-4

--- a/app/views/services/offers/show.html.haml
+++ b/app/views/services/offers/show.html.haml
@@ -1,4 +1,4 @@
-= render "layouts/order/nav", service: @service, wizard: @wizard, step: 1
+= render "layouts/order/nav", service: @service, wizard: @wizard
 
 %h2.mb-4.font-weight-normal Offer selection
 %p.mb-4

--- a/app/views/services/summaries/show.html.haml
+++ b/app/views/services/summaries/show.html.haml
@@ -1,4 +1,4 @@
-= render "layouts/order/nav", service: @service, step: 4
+= render "layouts/order/nav", service: @service, wizard: @wizard, step: 4
 
 %h2.mb-4.font-weight-normal Summary
 %p.mb-4

--- a/app/views/services/summaries/show.html.haml
+++ b/app/views/services/summaries/show.html.haml
@@ -1,4 +1,4 @@
-= render "layouts/order/nav", service: @service, wizard: @wizard, step: 4
+= render "layouts/order/nav", service: @service, wizard: @wizard
 
 %h2.mb-4.font-weight-normal Summary
 %p.mb-4

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,8 +39,12 @@ en:
     order:
       title: Access the service
     next: Next
+    offers:
+      title: Offer selection
     information:
       title: Information
+    summary:
+      title: Summary
     type:
       open_access:
         Open Access type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     scope module: :services do
       resource :offers, only: [:show, :update]
       resource :configuration, only: [:show, :update]
-      resource :information, only: :show
+      resource :information, only: [:show, :update]
       resource :summary, only: [:show, :create]
       resource :cancel, only: :destroy
       resource :questions, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,7 @@ Rails.application.routes.draw do
 
   resources :services, only: [:index, :show] do
     scope module: :services do
-      resources :offers, only: :index
-      resource :offers, only: :update
+      resource :offers, only: [:show, :update]
       resource :configuration, only: [:show, :update]
       resource :information, only: :show
       resource :summary, only: [:show, :create]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_24_122430) do
+ActiveRecord::Schema.define(version: 2019_10_29_141900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/add_item_to_project_spec.rb
+++ b/spec/features/add_item_to_project_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature "Add project item to project" do
 
     visit service_information_path(service)
     click_on "Next", match: :first
-    click_on "Next", match: :first
 
     expect(page).to have_select("project_item_project_id",
                                 selected: "my fancy project")

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -54,13 +54,6 @@ RSpec.feature "Service ordering" do
 
       click_on "Next", match: :first
 
-      # Step 3
-      expect(page).to have_current_path(service_configuration_path(service))
-      expect(page).to have_selector(:link_or_button,
-                                    "Next", exact: true)
-
-      click_on "Next", match: :first
-
       # Step 4
       expect(page).to have_current_path(service_summary_path(service))
       expect(page).to have_selector(:link_or_button,
@@ -141,8 +134,6 @@ RSpec.feature "Service ordering" do
 
         # Information step
         click_on "Next", match: :first
-        # Configuration step
-        click_on "Next", match: :first
 
         # Project selection
         select "Services", from: "project_item_project_id"
@@ -156,8 +147,6 @@ RSpec.feature "Service ordering" do
         click_on "Access the service"
 
         # Information step
-        click_on "Next", match: :first
-        # Configuration step
         click_on "Next", match: :first
 
         # Project selection
@@ -256,12 +245,8 @@ RSpec.feature "Service ordering" do
 
       click_on "Access the service"
 
+      # Information page
       click_on "Next", match: :first
-
-      # Project selection
-      expect(page).to have_current_path(service_configuration_path(open_access_service))
-      click_on "Next", match: :first
-
 
       # Summary page
       expect(page).to have_current_path(service_summary_path(open_access_service))
@@ -287,11 +272,6 @@ RSpec.feature "Service ordering" do
 
       click_on "Access the service"
       click_on "Next", match: :first
-
-      # Project selection
-      expect(page).to have_current_path(service_configuration_path(external_service))
-      click_on "Next", match: :first
-
 
       # Summary page
       expect(page).to have_current_path(service_summary_path(external_service))
@@ -324,7 +304,6 @@ RSpec.feature "Service ordering" do
 
       click_on "Access the service"
       click_on "Next", match: :first
-      click_on "Next", match: :first
 
       click_on "Add new project"
       within("#ajax-modal") do
@@ -353,7 +332,6 @@ RSpec.feature "Service ordering" do
 
       click_on "Access the service"
       click_on "Next", match: :first
-      click_on "Next", match: :first
       click_on "Add new project"
 
       click_on "Create new project"
@@ -375,7 +353,6 @@ RSpec.feature "Service ordering" do
       visit service_path(service)
 
       click_on "Access the service"
-      click_on "Next", match: :first
       click_on "Next", match: :first
       click_on "Add new project"
       within("#ajax-modal") do
@@ -417,14 +394,12 @@ RSpec.feature "Service ordering" do
       visit service_path(service)
 
       click_on "Access the service"
-      click_on "Next", match: :first
 
-      # Step 2
-      expect(page).to_not have_text("Voucher")
-
+      # Information step
       click_on "Next", match: :first
 
       # Step 3
+      expect(page).to have_current_path(service_summary_path(service))
       expect(page).to_not have_text("Voucher")
     end
 
@@ -531,7 +506,7 @@ RSpec.feature "Service ordering" do
         click_on "Next", match: :first
       end.to change { User.count }.by(1)
 
-      expect(page).to have_current_path(service_configuration_path(service))
+      expect(page).to have_current_path(service_summary_path(service))
       expect(User.last.full_name).to eq(user.full_name)
     end
 


### PR DESCRIPTION
The code responsible for deciding if a step should be visible was moved to the wizard step class. This leads to wizard, controllers, and views refactoring. As a conclusion now we can easily add new steps to the wizard, add visibility logic, etc.

This PR should be merged after #1226 is merged.