### PR TITLE
[#1095] Change highlights in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Project selection was moved to last service order step (@mkasztelnik)
 - Order configuration step is shown when offer is voucherable or has properties (@mkasztelnik)
 - Improve order wizard naming (@mkasztelnik)
+- Highlights in search from bold to mark (@goreck888)
 
 ### Deprecated
 

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -15,7 +15,7 @@ module Service::Searchable
              page: params[:page],
              per_page: per_page,
              order: ordering,
-             highlight: { fields: [:title], tag: "<b>" },
+             highlight: { fields: [:title, :tagline], tag: "<mark>" },
              scope_results: ->(r) { r.includes(:research_areas, :providers, :target_groups).with_attached_logo }))
   end
 


### PR DESCRIPTION
Change highlights from bold to mark
Add showing highlights to the tagline

Fixes #1095