### PR TITLE
Fix cancel order redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Active Order button in service preview (@goreck888)
+- Cancel order link redirect for non logged-in user (goreck888)
 
 ### Security
 

--- a/app/controllers/services/cancels_controller.rb
+++ b/app/controllers/services/cancels_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Services::CancelsController < Services::ApplicationController
+  skip_before_action :authenticate_user!
+
   def destroy
     session.delete(session_key)
     session.delete(:selected_project)


### PR DESCRIPTION
For non logged-in user order cancel link was redirecting
to the login page. This commit fixes it.