### PR TITLE
Fix displaying link to external services

### DIFF
--- a/app/views/services/information/show.html.haml
+++ b/app/views/services/information/show.html.haml
@@ -3,7 +3,7 @@
     service_title: wizard_title, faq_url: page_path("help"))
 
 .text-center
-  - unless @offer.orderable? && !@offer.webpage.blank?
+  - unless @offer.orderable? || @offer.webpage.blank?
     = link_to t("service.#{@offer.offer_type}.link"),  @offer.webpage,
       class: "btn btn-primary mb-2", target: "_blank", title: "External link"
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,22 +1,23 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "0aab5394581d33c77243c3186cdc35e902aef31f5e13cc4a78c39a83e6ac896c",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/projects/index.html.haml",
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "2fbbd766459c796fa13ed38170547a2689999b1648f61869c8d90112ea51af73",
+      "check_name": "MassAssignment",
+      "message": "Parameters should be whitelisted for mass assignment",
+      "file": "app/controllers/concerns/sentryable.rb",
       "line": 18,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => policy_scope(Project).order(:name).eager_load(:project_items).where(\"project_items.status = ?\", params[:status]), {})",
-      "render_path": [{"type":"controller","class":"ProjectsController","method":"index","line":10,"file":"app/controllers/projects_controller.rb","rendered":{"name":"projects/index","file":"/home/marek/git/mp/app/views/projects/index.html.haml"}}],
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
       "location": {
-        "type": "template",
-        "template": "projects/index"
+        "type": "method",
+        "class": "Sentryable",
+        "method": "set_raven_context"
       },
-      "user_input": "params[:status]",
-      "confidence": "Weak",
+      "user_input": null,
+      "confidence": "Medium",
       "note": ""
     },
     {
@@ -49,7 +50,29 @@
       "line": 8,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
-      "render_path": [{"type":"controller","class":"ServicesController","method":"index","line":15,"file":"app/controllers/services_controller.rb","rendered":{"name":"services/index","file":"/home/marek/git/mp/app/views/services/index.html.haml"}},{"type":"template","name":"services/index","line":52,"file":"app/views/services/index.html.haml","rendered":{"name":"services/_paginate_simple","file":"/home/marek/git/mp/app/views/services/_paginate_simple.haml"}}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "ServicesController",
+          "method": "index",
+          "line": 17,
+          "file": "app/controllers/services_controller.rb",
+          "rendered": {
+            "name": "services/index",
+            "file": "app/views/services/index.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "services/index",
+          "line": 55,
+          "file": "app/views/services/index.html.haml",
+          "rendered": {
+            "name": "services/_paginate_simple",
+            "file": "app/views/services/_paginate_simple.haml"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "services/_paginate_simple"
@@ -68,10 +91,52 @@
       "line": 11,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
-      "render_path": [{"type":"controller","class":"ServicesController","method":"index","line":15,"file":"app/controllers/services_controller.rb","rendered":{"name":"services/index","file":"/home/marek/git/mp/app/views/services/index.html.haml"}},{"type":"template","name":"services/index","line":52,"file":"app/views/services/index.html.haml","rendered":{"name":"services/_paginate_simple","file":"/home/marek/git/mp/app/views/services/_paginate_simple.haml"}}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "ServicesController",
+          "method": "index",
+          "line": 17,
+          "file": "app/controllers/services_controller.rb",
+          "rendered": {
+            "name": "services/index",
+            "file": "app/views/services/index.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "services/index",
+          "line": 55,
+          "file": "app/views/services/index.html.haml",
+          "rendered": {
+            "name": "services/_paginate_simple",
+            "file": "app/views/services/_paginate_simple.haml"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "services/_paginate_simple"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "d06e1c85551aa02f3f8da3a7d5c309ed69783a1fa39928ea676b0bf9646f3d0c",
+      "check_name": "MassAssignment",
+      "message": "Parameters should be whitelisted for mass assignment",
+      "file": "app/helpers/categories_helper.rb",
+      "line": 5,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CategoriesHelper",
+        "method": "category_query_params"
       },
       "user_input": null,
       "confidence": "Medium",
@@ -87,7 +152,29 @@
       "line": 6,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
-      "render_path": [{"type":"controller","class":"ServicesController","method":"index","line":15,"file":"app/controllers/services_controller.rb","rendered":{"name":"services/index","file":"/home/marek/git/mp/app/views/services/index.html.haml"}},{"type":"template","name":"services/index","line":52,"file":"app/views/services/index.html.haml","rendered":{"name":"services/_paginate_simple","file":"/home/marek/git/mp/app/views/services/_paginate_simple.haml"}}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "ServicesController",
+          "method": "index",
+          "line": 17,
+          "file": "app/controllers/services_controller.rb",
+          "rendered": {
+            "name": "services/index",
+            "file": "app/views/services/index.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "services/index",
+          "line": 55,
+          "file": "app/views/services/index.html.haml",
+          "rendered": {
+            "name": "services/_paginate_simple",
+            "file": "app/views/services/_paginate_simple.haml"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "services/_paginate_simple"
@@ -97,6 +184,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-06-27 20:59:46 +0200",
-  "brakeman_version": "4.4.0"
+  "updated": "2019-11-26 13:39:04 +0100",
+  "brakeman_version": "4.7.2"
 }

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -464,15 +464,41 @@ RSpec.feature "Service ordering" do
       expect(page).to_not have_text("11111-22222-33333-44444")
     end
 
-    scenario "I see offer type on information step" do
-      service = create(:service)
-      create(:open_access_offer, service: service)
+    context "On information step" do
+      scenario "I can see link to external service webpage when offert is open_access" do
+        service = create(:service)
+        create(:open_access_offer, service: service)
 
-      visit service_path(service)
+        visit service_path(service)
 
-      click_on "Access the service"
+        click_on "Access the service"
 
-      expect(page).to have_link("Go to the service")
+        expect(page).to have_link("Go to the service")
+      end
+
+      scenario "I cannot see link to external service webpage when offert is orderable" do
+        service = create(:service)
+        create(:offer, service: service)
+
+        visit service_path(service)
+
+        click_on "Access the service"
+
+        expect(page).to_not have_link("Go to the service")
+        expect(page).to_not have_link("Order externally")
+        expect(page).to_not have_link("Link")
+      end
+
+      scenario "I can see link to external service webpage when offert is external" do
+        service = create(:service)
+        create(:external_offer, service: service)
+
+        visit service_path(service)
+
+        click_on "Access the service"
+
+        expect(page).to have_link("Order externally")
+      end
     end
   end
 


### PR DESCRIPTION
If the service was ordered and the website was not blank, "Link" was displayed
Now link to external service is displayed only when offer is not orderable and offer.website is not blank. 