### PR TITLE
Don't register internal messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Hide parameters section when there is not parameters (@martaswiatkowska, @mkasztelnik)
+- Don't register internal messages (@mkasztelnik, @martaswiatkowska)
 
 ### Deprecated
 

--- a/app/services/jira/comment_created.rb
+++ b/app/services/jira/comment_created.rb
@@ -30,7 +30,15 @@ class Jira::CommentCreated
     end
 
     def reject?
-      @comment["author"]["name"] == jira_username
+      owned? || !visible?
+    end
+
+    def owned?
+      @comment.dig("author", "name") == jira_username
+    end
+
+    def visible?
+      (@comment.dig("visibility", "value") || "User") == "User"
     end
 
     def jira_username

--- a/spec/services/jira/comment_created_spec.rb
+++ b/spec/services/jira/comment_created_spec.rb
@@ -41,6 +41,25 @@ RSpec.describe Jira::CommentCreated do
       expect(email.body.encoded).to match(/A new message was added to your service request/)
       expect(email.subject).to eq("Question about your service access request in EOSC Portal Marketplace")
     end
+
+    it "register messages for all and for User" do
+      expect do
+        described_class.new(project_item,
+                            comment(message: "question",
+                                    id: "321", visibility: "User")).call
+        described_class.new(project_item,
+                            comment(message: "question",
+                                    id: "321", visibility: nil)).call
+      end.to change { project_item.messages.count }.by(2)
+    end
+
+    it "does not register internal messages" do
+      expect do
+        described_class.new(project_item,
+                            comment(message: "question",
+                                    id: "321", visibility: "Admin")).call
+      end.to_not change { project_item.messages.count }
+    end
   end
 
   context "for project" do
@@ -78,12 +97,32 @@ RSpec.describe Jira::CommentCreated do
       expect(email.body.encoded).to match(/You have received a message related to your Project/)
       expect(email.subject).to eq("Question about your Project Project in EOSC Portal Marketplace")
     end
+
+    it "register messages for all and for User" do
+      expect do
+        described_class.new(project,
+                            comment(message: "question",
+                                    id: "321", visibility: "User")).call
+        described_class.new(project,
+                            comment(message: "question",
+                                    id: "321", visibility: nil)).call
+      end.to change { project.messages.count }.by(2)
+    end
+
+    it "does not register internal messages" do
+      expect do
+        described_class.new(project,
+                            comment(message: "question",
+                                    id: "321", visibility: "Admin")).call
+      end.to_not change { project.messages.count }
+    end
   end
 
-  def comment(message:, id:, email: "non@existing.pl", name: "nonexisting")
+  def comment(message:, id:, email: "non@existing.pl", name: "nonexisting", visibility: "User")
     {
       "body" => message, "id" => id, "emailAddress" => email,
-      "author" => { "name" => name }
+      "author" => { "name" => name },
+      "visibility" => { "value" => visibility }
     }
   end
 


### PR DESCRIPTION
This is an extraction (and small improvements) of  "don't register internal messages" feature from #1276. Basically it skips internal messages reported by Jira.