### PR TITLE
1284 unify offer view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Move test services generation from `db:seed` to `dev:prime` (@mkasztelnik)
 - Merge Filterable and Searchable into one module Searchable (@goreck888)
 - ProjectItem rating questions customization by offer type (@goreck888)
+- Offer view unification (@jarekzet)
 
 ### Deprecated
 

--- a/app/javascript/controllers/paragraph_controller.js
+++ b/app/javascript/controllers/paragraph_controller.js
@@ -3,11 +3,6 @@ import {Controller} from 'stimulus'
 export default class extends Controller {
   static targets = ["showMore"];
 
-  connect() {
-  }
-
-  initialize(){}
-
   showMore(event){
     const element = event.target
     event.preventDefault()

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -1,24 +1,7 @@
 .col-md-6.d-flex.align-items-stretch.mb-5{ "data-controller" => "service-offer" }
   .card.offers
-    .card-body.pt-4.collapse-group
-      - if offer.voucherable
-        .card-label
-          %i.fas.fa-ticket-alt
-          %span Voucher
-      %span.text-sm-right.fa-pull-right.badge= t("service.type.#{offer.offer_type}")
-      %h4.card-title= offer.name
-      %p
-        .card-text.mb-2
-          - if offer.description.size > 200
-            = markdown(offer.description.truncate(200, separator: " "))
-            = link_to "Show more", "#", class: "show-more-#{offer.id}",
-                                  data: { "target" => "service-offer.showMore",
-                                          "action" => "click->service-offer#showMore",
-                                          "text": markdown(offer.description) }
-          - else
-            = markdown(offer.description)
-
-      = render "services/offers/parameters", parameters: offer.attributes
+    = render "services/offers/description", offer: offer
+    = render "services/offers/parameters", parameters: offer.attributes
     .card-button.text-center
       %label
         = link_to service_offers_path(offer.service, project_item: { offer_id: offer.iid }), method: :put do

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -1,7 +1,8 @@
-.col-md-6.d-flex.align-items-stretch.mb-5{ "data-controller" => "service-offer" }
-  .card.offers
+.col-md-6
+  .card.m-0.mb-5
     = render "services/offers/description", offer: offer
     = render "services/offers/parameters", parameters: offer.attributes
+
     .card-button.text-center
       %label
         = link_to service_offers_path(offer.service, project_item: { offer_id: offer.iid }), method: :put do

--- a/app/views/services/offers/_description.html.haml
+++ b/app/views/services/offers/_description.html.haml
@@ -6,12 +6,12 @@
   %span.text-sm-right.fa-pull-right.badge= t("service.type.#{offer.offer_type}")
   %h4.card-title= offer.name
   %p
-    .card-text.mb-2
+    .card-text.mb-2{ "data-controller" => "paragraph" }
       - if offer.description.size > 200
         = markdown(offer.description.truncate(200, separator: " "))
         = link_to "Show more", "#", class: "show-more-#{offer.id}",
-                                  data: { "target" => "service-offer.showMore",
-                                          "action" => "click->service-offer#showMore",
+                                  data: { "target" => "paragraph.showMore",
+                                          "action" => "click->paragraph#showMore",
                                           "text": markdown(offer.description) }
       - else
         = markdown(offer.description)

--- a/app/views/services/offers/_description.html.haml
+++ b/app/views/services/offers/_description.html.haml
@@ -1,0 +1,17 @@
+.card-body.pt-4.pb-0.collapse-group
+  - if offer.voucherable
+    .card-label
+      %i.fas.fa-ticket-alt
+      %span Voucher
+  %span.text-sm-right.fa-pull-right.badge= t("service.type.#{offer.offer_type}")
+  %h4.card-title= offer.name
+  %p
+    .card-text.mb-2
+      - if offer.description.size > 200
+        = markdown(offer.description.truncate(200, separator: " "))
+        = link_to "Show more", "#", class: "show-more-#{offer.id}",
+                                  data: { "target" => "service-offer.showMore",
+                                          "action" => "click->service-offer#showMore",
+                                          "text": markdown(offer.description) }
+      - else
+        = markdown(offer.description)

--- a/app/views/services/offers/_offer.html.haml
+++ b/app/views/services/offers/_offer.html.haml
@@ -1,4 +1,4 @@
-.col-lg-4.d-flex.align-items-stretch{ "data-controller" => "service-offer" }
+.col-lg-4
   .card.m-0.mb-5
     = render "services/offers/description", offer: offer
     = render "services/offers/parameters", parameters: offer.attributes

--- a/app/views/services/offers/_offer.html.haml
+++ b/app/views/services/offers/_offer.html.haml
@@ -1,4 +1,4 @@
-.col-lg-4.d-flex.align-items-stretch
+.col-lg-4.d-flex.align-items-stretch{ "data-controller" => "service-offer" }
   .card.m-0.mb-5
     = render "services/offers/description", offer: offer
     = render "services/offers/parameters", parameters: offer.attributes

--- a/app/views/services/offers/_offer.html.haml
+++ b/app/views/services/offers/_offer.html.haml
@@ -1,14 +1,7 @@
 .col-lg-4.d-flex.align-items-stretch
   .card.m-0.mb-5
-    .card-body.pt-4
-      - if offer.voucherable
-        .card-label
-          %i.fas.fa-ticket-alt
-          %span Voucher
-      %span.text-sm-right.fa-pull-right.badge= t("service.type.#{offer.offer_type}")
-      %h4.card-title= offer.name
-      %p.card-text.mb-4= markdown(offer.description)
-      = render "services/offers/parameters", parameters: offer.attributes
+    = render "services/offers/description", offer: offer
+    = render "services/offers/parameters", parameters: offer.attributes
 
     .card-button.text-center
       %label

--- a/app/views/services/offers/_parameters.html.haml
+++ b/app/views/services/offers/_parameters.html.haml
@@ -1,10 +1,11 @@
 - technical_parameters = filter_technical_parameters(parameters.map(&:to_json))
 
 - if technical_parameters.present?
-  %h5.text-uppercase.parameters-title.mb-0= "Technical parameters"
-  %table.offer-params.table.table-hover
-    %tbody
-      - technical_parameters.each do |parameter|
-        %tr
-          %td= parameter["label"]
-          %td.text-right.text-nowrap.font-weight-bold= parse_offer_parameter_value(parameter)
+  .card-body.pt-0.collapse-group
+    %h5.text-uppercase.parameters-title.mb-0= "Technical parameters"
+    %table.offer-params.table.table-hover
+      %tbody
+        - technical_parameters.each do |parameter|
+          %tr
+            %td= parameter["label"]
+            %td.text-right.text-nowrap.font-weight-bold= parse_offer_parameter_value(parameter)


### PR DESCRIPTION
Added _description template (/app/views/services/offers/_description.html.haml) with one unified service description.

Fix for #1284 