### PR TITLE
Jira client. Return nil if service doesn't have category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - `dev:prime` task migrations update (@goreck888)
+- Return nil to jira if service doesn't have category (@martaswiatkowska)
 
 ## [2.3.0] 2019-11-25
 

--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -204,7 +204,7 @@ private
 
   def encode_order_properties(project_item)
     {
-      "category" => project_item.service.categories.first.name,
+      "category" => project_item.service.categories.first&.name,
       "service" => project_item.service.title,
       "offer" => project_item.offer&.name,
       "attributes" => encode_properties(project_item.properties)


### PR DESCRIPTION
If the service does not have a category, job registration in jira fails. Its connected with fact that Category is not required. 

In this PR if If the service does not have a category, null is send to jira.