### PR TITLE
[#1285] Disable visibility of input type attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Statistics for executive user group (@mkasztelnik)
 
 ### Changed
+- Disable visibility of `input` type attribute on the offer view (@goreck888)
 
 ### Deprecated
 

--- a/app/helpers/attributes_helper.rb
+++ b/app/helpers/attributes_helper.rb
@@ -3,7 +3,7 @@
 # Used to convert Postgres JSON to list of elements, which can be rendered
 # in views
 module AttributesHelper
-  EXCLUDED_TYPES = ["date"]
+  EXCLUDED_TYPES = ["date", "input"]
 
   def filter_technical_parameters(parameters)
     parameters.select do |parameter|
@@ -35,7 +35,6 @@ module AttributesHelper
   end
 
   private
-
     def from_to(from, to)
       "#{from || "?"} - #{to || "?"}"
     end


### PR DESCRIPTION
In the offer view disabled all input attributes, because they haven't minimum and maximum values, so they can be treated the same way like string attribute.
Fixes #1285