### PR TITLE
Reject projects without country in usage statistic

### DIFF
--- a/app/models/usage_report.rb
+++ b/app/models/usage_report.rb
@@ -24,7 +24,10 @@ class UsageReport
   end
 
   def countries
-    used_projects.map { |p| p.country_of_origin.name }.uniq
+    used_projects
+      .reject { |p| p.country_of_origin.nil? }
+      .map { |p| p.country_of_origin.name }
+      .uniq
   end
 
   private


### PR DESCRIPTION
After testing statistics on production data I discovered that some of
the projects do not have a country of origin filled in. To solve this
issue additional reject filter was added.

No changelog entry because this is a fix to feature not yet released which has dedicated changelog entry.