### PR TITLE
Revert "Bump rack from 2.0.7 to 2.0.8"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     puma (3.12.2)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.8)
+    rack (2.0.7)
     rack-oauth2 (1.10.1)
       activesupport
       attr_required


### PR DESCRIPTION
Reverts cyfronet-fid/marketplace#1329

We need to revert this change since we are facing a problem with sidekiq described here https://github.com/rack/rack/issues/1432. 