### PR TITLE
Update rack to 2.0.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,10 @@ gem "high_voltage", "~> 3.1"
 gem "jira-ruby"
 
 gem "redis-rails"
+# Remove after https://github.com/redis-store/redis-rack/pull/50 is merged and
+# released.
+gem "redis-rack", github: "le0pard/redis-rack", ref: "5a297ce"
+
 gem "sidekiq"
 
 gem "custom_error_message", git: "https://github.com/thethanghn/custom-err-msg.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/le0pard/redis-rack.git
+  revision: 5a297ce11904f87172353d221d6b9974fc130fbe
+  ref: 5a297ce
+  specs:
+    redis-rack (2.1.0.pre)
+      rack (>= 2.0.8, < 3)
+      redis-store (>= 1.2, < 2)
+
+GIT
   remote: https://github.com/thethanghn/custom-err-msg.git
   revision: b913309360995472507ea444c6f1a80315b99d28
   specs:
@@ -267,7 +276,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-oauth2 (1.10.1)
       activesupport
       attr_required
@@ -325,9 +334,6 @@ GEM
     redis-activesupport (5.2.0)
       activesupport (>= 3, < 7)
       redis-store (>= 1.3, < 2)
-    redis-rack (2.0.6)
-      rack (>= 1.5, < 3)
-      redis-store (>= 1.2, < 2)
     redis-rails (5.0.2)
       redis-actionpack (>= 5.0, < 6)
       redis-activesupport (>= 5.0, < 6)
@@ -545,6 +551,7 @@ DEPENDENCIES
   rails (~> 6.0.0)
   recaptcha
   redcarpet
+  redis-rack!
   redis-rails
   reverse_markdown
   role_model


### PR DESCRIPTION
Rails version we are currently using requires rack 2.0.8. 

This is very similar to #1338 but also upgrade `redis-rack` to use new rack API (we are using redis to store user session).