### PR TITLE
Category and research area logos in active storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add static pages for design system and UI documentation (@mkasztelnik)
 
 ### Changed
+- Move categories logos to active storage (@mkasztelnik)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add static pages for design system and UI documentation (@mkasztelnik)
 
 ### Changed
-- Move categories logos to active storage (@mkasztelnik)
+- Move research area and category logos to active storage (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   include Pundit
   include Devise::StoreLocation
 
-  before_action :load_main_research_areas!, :load_root_categories!, :report
+  before_action :load_root_categories!, :report
 
   protect_from_forgery
 
@@ -24,10 +24,6 @@ class ApplicationController < ActionController::Base
 
     def load_root_categories!
       @root_categories = Category.roots.order(:name)
-    end
-
-    def load_main_research_areas!
-      @main_research_areas = ResearchArea.roots[0...8].push(ResearchArea.find_by(name: "Other"))
     end
 
     def not_authorized_message(exception)

--- a/app/controllers/backoffice/categories_controller.rb
+++ b/app/controllers/backoffice/categories_controller.rb
@@ -5,7 +5,7 @@ class Backoffice::CategoriesController < Backoffice::ApplicationController
 
   def index
     authorize(Category)
-    @categories = policy_scope(Category)
+    @categories = policy_scope(Category).with_attached_logo
   end
 
   def show
@@ -48,7 +48,7 @@ class Backoffice::CategoriesController < Backoffice::ApplicationController
 
   private
     def find_and_authorize
-      @category = Category.friendly.find(params[:id])
+      @category = Category.with_attached_logo.friendly.find(params[:id])
       authorize(@category)
     end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,10 @@ class HomeController < ApplicationController
 
   def index
     @root_categories = @root_categories.with_attached_logo
+    @main_research_areas =
+      ResearchArea.with_attached_logo.roots[0...8]
+      .push(ResearchArea.with_attached_logo.find_by(name: "Other"))
+      .reject(&:nil?)
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,7 @@ class HomeController < ApplicationController
   before_action :load_services, :load_platforms, :load_providers, :load_target_groups, :load_opinion
 
   def index
+    @root_categories = @root_categories.with_attached_logo
   end
 
   private

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,6 +12,8 @@ class Category < ApplicationRecord
   # services.
   before_destroy :store_affected_services
 
+  has_one_attached :logo
+
   has_many :categorizations, autosave: true, dependent: :destroy
   has_many :services, through: :categorizations
 

--- a/app/models/research_area.rb
+++ b/app/models/research_area.rb
@@ -3,6 +3,8 @@
 class ResearchArea < ApplicationRecord
   include Parentable
 
+  has_one_attached :logo
+
   has_many :service_research_areas, autosave: true, dependent: :destroy
   has_many :services, through: :service_research_areas
   has_many :project_research_areas, autosave: true, dependent: :destroy

--- a/app/policies/backoffice/category_policy.rb
+++ b/app/policies/backoffice/category_policy.rb
@@ -33,7 +33,7 @@ class Backoffice::CategoryPolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :name, :parent_id
+      :name, :parent_id, :logo
     ]
   end
 

--- a/app/policies/backoffice/research_area_policy.rb
+++ b/app/policies/backoffice/research_area_policy.rb
@@ -33,7 +33,7 @@ class Backoffice::ResearchAreaPolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :name, :parent_id
+      :name, :parent_id, :logo
     ]
   end
 

--- a/app/views/backoffice/categories/_form.html.haml
+++ b/app/views/backoffice/categories/_form.html.haml
@@ -1,4 +1,5 @@
 = simple_form_for [:backoffice, category] do |f|
+  = f.input :logo
   = f.input :name
   = f.input :parent_id,
     collection: ancestry_id_tree(category.potential_parents),

--- a/app/views/backoffice/categories/index.html.haml
+++ b/app/views/backoffice/categories/index.html.haml
@@ -10,16 +10,20 @@
       .clearfix
   %ul.list-group.backoffice-list.mt-5.mb-
     - ancestry_tree(@categories).each do |record|
+      - category = record[1]
       %li.list-group-item
-        = link_to record.first, backoffice_category_path(record.last)
-        - if policy([:backoffice, record[1]]).destroy?
-          = link_to backoffice_category_path(record[1]),
+        = link_to backoffice_category_path(record.last) do
+          - if category.logo.attached?
+            = image_tag category.logo.variant(resize: "32x32")
+          = record.first
+        - if policy([:backoffice, category]).destroy?
+          = link_to backoffice_category_path(category),
               method: :delete,
               data: { confirm: "Are you sure you want to remove this category" },
               class: "delete-icon float-right" do
             %i.far.fa-trash-alt
-        - if policy([:backoffice, record[1]]).edit?
+        - if policy([:backoffice, category]).edit?
           = link_to "Edit",
-              edit_backoffice_category_path(record[1]),
+              edit_backoffice_category_path(category),
               class: "btn-sm btn-warning float-right mr-4"
 

--- a/app/views/backoffice/categories/show.html.haml
+++ b/app/views/backoffice/categories/show.html.haml
@@ -2,7 +2,10 @@
 
 %h1= @category.name
 %h2= @category.parent ? "Parent: #{@category.parent.name}" : "Root element"
+- if @category.logo.attached?
+  = image_tag @category.logo
 
+%hr
 .btn-group
   - if policy([:backoffice, @category]).edit?
     = link_to "Edit",

--- a/app/views/backoffice/research_areas/_form.html.haml
+++ b/app/views/backoffice/research_areas/_form.html.haml
@@ -1,4 +1,5 @@
 = simple_form_for [:backoffice, research_area] do |f|
+  = f.input :logo
   = f.input :name
   = f.input :parent_id,
     collection: ancestry_id_tree(research_area.potential_parents),

--- a/app/views/backoffice/research_areas/index.html.haml
+++ b/app/views/backoffice/research_areas/index.html.haml
@@ -10,13 +10,17 @@
       .clearfix
   %ul.list-group.backoffice-list.mt-5.mb-3
     - ancestry_tree(@research_areas).each do |record|
+      - ra = record[1]
       %li.list-group-item
-        = link_to record.first, backoffice_research_area_path(record.last)
-        - if policy([:backoffice, record[1]]).destroy?
-          = link_to backoffice_research_area_path(record[1]),
+        = link_to backoffice_research_area_path(record.last) do
+          - if ra.logo.attached?
+            = image_tag ra.logo.variant(resize: "32x32")
+          = record.first
+        - if policy([:backoffice, ra]).destroy?
+          = link_to backoffice_research_area_path(ra),
                 method: :delete,
                 data: { confirm: "Are you sure you want to remove this research area?" },
                 class: "delete-icon float-right" do
             %i.far.fa-trash-alt
-        - if policy([:backoffice, record[1]]).edit?
-          = link_to "Edit", edit_backoffice_research_area_path(record[1]), class: "btn-sm btn-warning float-right mr-4"
+        - if policy([:backoffice, ra]).edit?
+          = link_to "Edit", edit_backoffice_research_area_path(ra), class: "btn-sm btn-warning float-right mr-4"

--- a/app/views/backoffice/research_areas/show.html.haml
+++ b/app/views/backoffice/research_areas/show.html.haml
@@ -2,7 +2,10 @@
 
 %h1= @research_area.name
 %h2= @research_area.parent ? "Parent: #{@research_area.parent.name}" : "Root element"
+- if @research_area.logo.attached?
+  = image_tag @research_area.logo
 
+%hr
 .btn-group
   - if policy([:backoffice, @research_area]).edit?
     = link_to "Edit",

--- a/app/views/home/_products.html.haml
+++ b/app/views/home/_products.html.haml
@@ -46,12 +46,12 @@
             .branch-box
               = link_to services_path(research_areas: ra.to_param) do
                 .branch-icon
-                  - if File.exist?("app/assets/images/ico_#{ra&.name&.split&.first}.png".underscore)
-                    = image_tag("ico_#{ra&.name.split.first}.png".underscore, alt: "#{ra&.name}")
+                  - if ra.logo.attached?
+                    = image_tag ra.logo, alt: ra.name
                   - else
-                    = image_tag("ico_ra_default.png", alt: "#{ra&.name}")
+                    = image_tag("ico_ra_default.png", alt: "#{ra.name}")
                 .branch-name
-                  = ra&.name
+                  = ra.name
       .row.d-flex.justify-content-center.mt-4
         = link_to "Browse all services", services_path, class: "btn btn-primary font-weight-bold mt-3 services-link"
 

--- a/app/views/home/_products.html.haml
+++ b/app/views/home/_products.html.haml
@@ -63,8 +63,8 @@
             .branch-box
               = link_to root_category do
                 .branch-icon
-                  - if File.exist?("app/assets/images/ico_#{root_category.name.split.first}.png".underscore)
-                    = image_tag("ico_#{root_category.name.split.first}.png".underscore, alt: "#{root_category.name}")
+                  - if root_category.logo.attached?
+                    = image_tag root_category.logo, alt: root_category.name
                   - else
                     = image_tag("ico_default.png", alt: "#{root_category.name}")
                 .branch-name

--- a/lib/tasks/whitelabel.rake
+++ b/lib/tasks/whitelabel.rake
@@ -2,18 +2,26 @@
 
 namespace :whitelabel do
   task migrate_category_logos: :environment do
-    Category.all.each do |category|
-      if has_logo?(category)
-        category.logo.attach(io: File.open(logo_path(category)), filename: "logo.png")
+    attach_logos(Category.all)
+  end
+
+  task migrate_research_area_logos: :environment do
+    attach_logos(ResearchArea.all)
+  end
+
+  def attach_logos(collection)
+    collection.each do |record|
+      if has_logo?(record)
+        record.logo.attach(io: File.open(logo_path(record)), filename: "logo.png")
       end
     end
   end
 
-  def logo_path(category)
-    "app/assets/images/ico_#{category.name.split.first}.png".underscore
+  def logo_path(record)
+    "app/assets/images/ico_#{record.name.split.first}.png".underscore
   end
 
-  def has_logo?(category)
-    File.exist?(logo_path(category))
+  def has_logo?(record)
+    File.exist?(logo_path(record))
   end
 end

--- a/lib/tasks/whitelabel.rake
+++ b/lib/tasks/whitelabel.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :whitelabel do
+  task migrate_category_logos: :environment do
+    Category.all.each do |category|
+      if has_logo?(category)
+        category.logo.attach(io: File.open(logo_path(category)), filename: "logo.png")
+      end
+    end
+  end
+
+  def logo_path(category)
+    "app/assets/images/ico_#{category.name.split.first}.png".underscore
+  end
+
+  def has_logo?(category)
+    File.exist?(logo_path(category))
+  end
+end


### PR DESCRIPTION
First feature connected with Whitelabel: category and research area logos were moved to active storage. A logo is not mandatory, if not present than default one is used. 

As a part of this PR I'm delivring 2 rake tasks: 
  * `rails whitelabel:migrate_category_logos`
  * `rails whitelabel:migrate_research_area_logos`
these tasks need to be invoked on production to attach existing logos to record. 

I will create also follow up PR (something like `whitelabel-cleanup`) where logos and outdated tasks will be removed from the repository. This PR will be merged into the `master` branch after the release. 