### PR TITLE
Design system static pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- Add static pages for design system and UI documentation (@mkasztelnik)
 
 ### Changed
 

--- a/app/controllers/designsystem_controller.rb
+++ b/app/controllers/designsystem_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class DesignsystemController < ApplicationController
+  layout "designsystem"
+
+  def index
+  end
+
+  def show
+    render params.require(:file)
+  end
+end

--- a/app/views/designsystem/demo.html.haml
+++ b/app/views/designsystem/demo.html.haml
@@ -1,0 +1,1 @@
+%h1 Design system demo

--- a/app/views/designsystem/index.html.haml
+++ b/app/views/designsystem/index.html.haml
@@ -1,0 +1,1 @@
+%h1 Desgin system

--- a/app/views/layouts/designsystem.html.haml
+++ b/app/views/layouts/designsystem.html.haml
@@ -1,0 +1,7 @@
+!!!
+%html{ lang: "en" }
+  = render "layouts/head"
+  %body
+    = yield
+
+

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "MassAssignment",
       "message": "Parameters should be whitelisted for mass assignment",
       "file": "app/controllers/concerns/sentryable.rb",
-      "line": 18,
+      "line": 17,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
       "render_path": null,
@@ -18,6 +18,26 @@
       },
       "user_input": null,
       "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "611ab052f0559e5d4ff26fa4e4168a783af9cf290779b63eddddd8b63aea84bf",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/designsystem_controller.rb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => params.require(:file), {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "DesignsystemController",
+        "method": "show"
+      },
+      "user_input": "params.require(:file)",
+      "confidence": "High",
       "note": ""
     },
     {
@@ -35,7 +55,7 @@
           "type": "controller",
           "class": "ServicesController",
           "method": "index",
-          "line": 17,
+          "line": 16,
           "file": "app/controllers/services_controller.rb",
           "rendered": {
             "name": "services/index",
@@ -76,7 +96,7 @@
           "type": "controller",
           "class": "ServicesController",
           "method": "index",
-          "line": 17,
+          "line": 16,
           "file": "app/controllers/services_controller.rb",
           "rendered": {
             "name": "services/index",
@@ -137,7 +157,7 @@
           "type": "controller",
           "class": "ServicesController",
           "method": "index",
-          "line": 17,
+          "line": 16,
           "file": "app/controllers/services_controller.rb",
           "rendered": {
             "name": "services/index",
@@ -164,6 +184,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-11-29 09:21:33 +0100",
+  "updated": "2020-01-10 11:20:01 +0100",
   "brakeman_version": "4.7.2"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,5 +103,11 @@ Rails.application.routes.draw do
     match "/500", to: "errors#internal_server_error", via: :all
   end
 
+  if Rails.env.development?
+    get "designsystem" => "designsystem#index"
+    get "designsystem/:file" => "designsystem#show",
+      constraints: { file: %r{[^/\.]+} }
+  end
+
   root "home#index"
 end


### PR DESCRIPTION
This introduces way to create static pages available only in development
mode where UI team can work on components which will be used in
marketplace.

To enter this section visit: `http://localhost:5000/designsystem`. If
you want to create new static page in this scope just create file in
`app/views/designsystem` directory (take a loot at
`app/views/designsystem/demo.html.haml` which is accessable using
`http://localhost:5000/designsystem/demo`).