### PR TITLE
Downgrade rack to 2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Security
 
+## [2.5.1] Unreleased
+
+### Fixed
+- Rollback to `rack` 2.0.7. New version is not compatible yet with `redis-rack` (@mkasztelnik)
+
 ## [2.5.0] 2020-01-13
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.8)
+    rack (2.0.7)
     rack-oauth2 (1.10.1)
       activesupport
       attr_required


### PR DESCRIPTION
New version is not compatible with `redis-rack` yet.