### PR TITLE
Help in DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 - Add static pages for design system and UI documentation (@mkasztelnik)
 - Comment changes in jira propagate to mp (@martaswiatkowska)
+- Dynamic help sections visible currently only for admin (@mkasztelnik)
 
 ### Changed
 - Move research area and category logos to active storage (@mkasztelnik)

--- a/app/controllers/admin/help_items_controller.rb
+++ b/app/controllers/admin/help_items_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class Admin::HelpItemsController < Admin::ApplicationController
+  before_action :find_and_authorize, except: [:new, :create]
+
+  def new
+    @help_item = HelpItem.new(help_section: HelpSection.find_by(slug: params["section"]))
+    authorize(@help_item)
+  end
+
+  def create
+    @help_item = HelpItem.new(permitted_attributes(HelpItem))
+    authorize(@help_item)
+
+    if @help_item.save
+      redirect_to admin_help_path(anchor: @help_item.help_section.slug),
+                  notice: "New help item created sucessfully"
+    else
+      render :new, status: :bad_request
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @help_item.update(permitted_attributes(HelpItem))
+      redirect_to admin_help_path(anchor: @help_item.help_section.slug),
+                  notice: "New help item created sucessfully"
+    else
+      render :edit, status: :bad_request
+    end
+  end
+
+  def destroy
+    @help_item.destroy!
+
+    redirect_to admin_help_path(anchor: @help_item.help_section.slug),
+                notice: "Help item destroyed"
+  end
+
+  private
+    def find_and_authorize
+      @help_item = HelpItem.find(params[:id])
+      authorize(@help_item)
+    end
+end

--- a/app/controllers/admin/help_sections_controller.rb
+++ b/app/controllers/admin/help_sections_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Admin::HelpSectionsController < Admin::ApplicationController
+  before_action :find_and_authorize, except: [:new, :create]
+
+  def new
+    @help_section = HelpSection.new
+    authorize(@help_section)
+  end
+
+  def create
+    @help_section = HelpSection.new(permitted_attributes(HelpSection))
+    authorize(@help_section)
+
+    if @help_section.save
+      redirect_to admin_help_path,
+                  notice: "New help category created sucessfully"
+    else
+      render :new, status: :bad_request
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @help_section.update(permitted_attributes(HelpSection))
+      redirect_to admin_help_path,
+                  notice: "Help category updated sucessfully"
+    else
+      render :edit, status: :bad_request
+    end
+  end
+
+  def destroy
+    @help_section.destroy!
+
+    redirect_to admin_help_path, notice: "Help category destroyed"
+  end
+
+  private
+    def find_and_authorize
+      @help_section = HelpSection.friendly.find(params[:id])
+      authorize(@help_section)
+    end
+end

--- a/app/controllers/admin/helps_controller.rb
+++ b/app/controllers/admin/helps_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Admin::HelpsController < Admin::ApplicationController
+  def show
+    @sections = HelpSection.includes(:help_items).all
+  end
+end

--- a/app/controllers/admin/helps_controller.rb
+++ b/app/controllers/admin/helps_controller.rb
@@ -2,6 +2,6 @@
 
 class Admin::HelpsController < Admin::ApplicationController
   def show
-    @sections = HelpSection.includes(:help_items).all
+    @sections = policy_scope(HelpSection).includes(:help_items).order(:position)
   end
 end

--- a/app/controllers/helps_controller.rb
+++ b/app/controllers/helps_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class HelpsController < ApplicationController
+  before_action :ensure_admin
+
+  def show
+    @sections = HelpSection.includes(:help_items)
+  end
+
+  private
+    def ensure_admin
+      redirect_to page_path("help") unless current_user&.admin?
+    end
+end

--- a/app/controllers/helps_controller.rb
+++ b/app/controllers/helps_controller.rb
@@ -4,7 +4,7 @@ class HelpsController < ApplicationController
   before_action :ensure_admin
 
   def show
-    @sections = HelpSection.includes(:help_items)
+    @sections = policy_scope(HelpSection).includes(:help_items).order(:position)
   end
 
   private

--- a/app/javascript/app/index.js
+++ b/app/javascript/app/index.js
@@ -52,3 +52,6 @@ document.addEventListener('DOMContentLoaded', function () {
     initFlash();
     dom.watch();
 });
+
+require("trix")
+require("@rails/actiontext")

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,9 +8,3 @@
 // layout file, like app/views/layouts/application.html.erb
 
 import "app"
-
-
-
-
-
-

--- a/app/javascript/stylesheets/actiontext.scss
+++ b/app/javascript/stylesheets/actiontext.scss
@@ -1,0 +1,31 @@
+@import 'trix/dist/trix.css';
+
+// We need to override trix.css’s image gallery styles to accommodate the
+// <action-text-attachment> element we wrap around attachments. Otherwise,
+// images in galleries will be squished by the max-width: 33%; rule.
+.trix-content {
+  .attachment-gallery {
+    > action-text-attachment,
+    > .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%;
+    }
+
+    &.attachment-gallery--2,
+    &.attachment-gallery--4 {
+      > action-text-attachment,
+      > .attachment {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+    }
+  }
+
+  action-text-attachment {
+    .attachment {
+      padding: 0 !important;
+      max-width: 100% !important;
+    }
+  }
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -17,3 +17,5 @@
 @import 'bootstrap-customizations';
 @import 'policy-cookiebar-customizations';
 @import 'test';
+
+@import 'actiontext';

--- a/app/models/help_item.rb
+++ b/app/models/help_item.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HelpItem < ApplicationRecord
+  has_rich_text :content
+
+  belongs_to :help_section
+
+  validates :title, presence: true
+  validates :content, presence: true
+end

--- a/app/models/help_section.rb
+++ b/app/models/help_section.rb
@@ -4,7 +4,7 @@ class HelpSection < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: :slugged
 
-  has_many :help_items, dependent: :destroy
+  has_many :help_items, -> { order(:position) }, dependent: :destroy
 
   validates :title, presence: true
 end

--- a/app/models/help_section.rb
+++ b/app/models/help_section.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HelpSection < ApplicationRecord
+  extend FriendlyId
+  friendly_id :title, use: :slugged
+
+  has_many :help_items, dependent: :destroy
+
+  validates :title, presence: true
+end

--- a/app/policies/admin/help_item_policy.rb
+++ b/app/policies/admin/help_item_policy.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Admin::HelpItemPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+
+  def new?
+    admin?
+  end
+
+  def create?
+    admin?
+  end
+
+  def update?
+    admin?
+  end
+
+  def destroy?
+    admin?
+  end
+
+  def permitted_attributes
+    [
+      :title, :help_section_id, :content
+    ]
+  end
+
+  private
+    def admin?
+      user&.admin?
+    end
+end

--- a/app/policies/admin/help_item_policy.rb
+++ b/app/policies/admin/help_item_policy.rb
@@ -25,7 +25,7 @@ class Admin::HelpItemPolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :title, :help_section_id, :content
+      :title, :help_section_id, :content, :position
     ]
   end
 

--- a/app/policies/admin/help_section_policy.rb
+++ b/app/policies/admin/help_section_policy.rb
@@ -25,7 +25,7 @@ class Admin::HelpSectionPolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :title
+      :title, :position
     ]
   end
 

--- a/app/policies/admin/help_section_policy.rb
+++ b/app/policies/admin/help_section_policy.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Admin::HelpSectionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+
+  def new?
+    admin?
+  end
+
+  def create?
+    admin?
+  end
+
+  def update?
+    admin?
+  end
+
+  def destroy?
+    admin?
+  end
+
+  def permitted_attributes
+    [
+      :title
+    ]
+  end
+
+  private
+    def admin?
+      user&.admin?
+    end
+end

--- a/app/policies/help_section_policy.rb
+++ b/app/policies/help_section_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class HelpSectionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/admin/help_items/_form.html.haml
+++ b/app/views/admin/help_items/_form.html.haml
@@ -1,0 +1,9 @@
+= simple_form_for [:admin, help_item] do |f|
+  = f.input :title
+  = f.association :help_section
+  = f.input :content do
+    = f.rich_text_area :content
+
+  = f.button :submit, class: "btn btn-primary pl-5 pr-5 mr-5"
+  = link_to "Cancel and back to help preview", admin_help_path,
+    class: "text-left flex-grow-1 text-uppercase"

--- a/app/views/admin/help_items/_form.html.haml
+++ b/app/views/admin/help_items/_form.html.haml
@@ -1,6 +1,7 @@
 = simple_form_for [:admin, help_item] do |f|
   = f.input :title
   = f.association :help_section
+  = f.input :position
   = f.input :content do
     = f.rich_text_area :content
 

--- a/app/views/admin/help_items/edit.html.haml
+++ b/app/views/admin/help_items/edit.html.haml
@@ -1,0 +1,4 @@
+.container
+  %h2 Edit Help Item
+  = render "form", help_item: @help_item
+

--- a/app/views/admin/help_items/new.html.haml
+++ b/app/views/admin/help_items/new.html.haml
@@ -1,0 +1,4 @@
+.container
+  %h2 New Help Item
+  = render "form", help_item: @help_item
+

--- a/app/views/admin/help_sections/_form.html.haml
+++ b/app/views/admin/help_sections/_form.html.haml
@@ -1,5 +1,6 @@
 = simple_form_for [:admin, help_section] do |f|
   = f.input :title
+  = f.input :position
 
   = f.button :submit, class: "btn btn-primary pl-5 pr-5 mr-5"
   = link_to "Cancel and back to help preview", admin_help_path,

--- a/app/views/admin/help_sections/_form.html.haml
+++ b/app/views/admin/help_sections/_form.html.haml
@@ -1,0 +1,6 @@
+= simple_form_for [:admin, help_section] do |f|
+  = f.input :title
+
+  = f.button :submit, class: "btn btn-primary pl-5 pr-5 mr-5"
+  = link_to "Cancel and back to help preview", admin_help_path,
+    class: "text-left flex-grow-1 text-uppercase"

--- a/app/views/admin/help_sections/edit.html.haml
+++ b/app/views/admin/help_sections/edit.html.haml
@@ -1,0 +1,4 @@
+.container
+  %h2 Edit Help Section
+  = render "form", help_section: @help_section
+

--- a/app/views/admin/help_sections/new.html.haml
+++ b/app/views/admin/help_sections/new.html.haml
@@ -1,0 +1,4 @@
+.container
+  %h2 New Help Section
+  = render "form", help_section: @help_section
+

--- a/app/views/admin/helps/_item.html.haml
+++ b/app/views/admin/helps/_item.html.haml
@@ -1,0 +1,18 @@
+- id = "#{parent}-#{item_counter}"
+.card.shadow-sm.rounded
+  .card-header{ id: "#{id}-header" }
+    %button.btn.btn-link{ type: "button",
+        data: { toggle: "collapse", target: "##{id}" },
+        aria: { expanded: true, controls: id } }
+      = item.title
+
+    .float-right
+      = link_to "Edit", edit_admin_help_item_path(item),
+        class: "btn btn-sm btn-warning"
+      = link_to "Remove", admin_help_item_path(item),
+        class: "btn btn-sm btn-danger",
+        method: :delete, data: { confirm: "Are you sure?" }
+
+.collapse{ id: id, "aria-labelledby": "#{id}-header", "data-parent": "##{parent}" }
+  .card-body
+    = item.content

--- a/app/views/admin/helps/_section.html.haml
+++ b/app/views/admin/helps/_section.html.haml
@@ -4,6 +4,6 @@
   = link_to "Add new help item",
             new_admin_help_item_path(section: section.slug),
             class: "btn btn-sm btn-success float-right"
-.accordion.faq-list{ id: section.slug }
+.accordion.faq-list{ id: "s-#{section.slug}" }
   = render partial: "item",
-    collection: section.help_items, locals: { parent: section.slug }
+    collection: section.help_items, locals: { parent: "s-#{section.slug}" }

--- a/app/views/admin/helps/_section.html.haml
+++ b/app/views/admin/helps/_section.html.haml
@@ -1,0 +1,9 @@
+%h3.subsection
+  %a{ id: section.slug }
+  = section.title
+  = link_to "Add new help item",
+            new_admin_help_item_path(section: section.slug),
+            class: "btn btn-sm btn-success float-right"
+.accordion.faq-list{ id: section.slug }
+  = render partial: "item",
+    collection: section.help_items, locals: { parent: section.slug }

--- a/app/views/admin/helps/_toc.html.haml
+++ b/app/views/admin/helps/_toc.html.haml
@@ -1,0 +1,8 @@
+%li.list-group-item
+  = link_to section.title, admin_help_path(anchor: section.slug)
+  .float-right
+    = link_to "Edit", edit_admin_help_section_path(section),
+      class: "btn btn-sm btn-warning"
+    = link_to "Remove", admin_help_section_path(section),
+      class: "btn btn-sm btn-danger",
+      method: :delete, data: { confirm: "Are you sure?" }

--- a/app/views/admin/helps/show.html.haml
+++ b/app/views/admin/helps/show.html.haml
@@ -1,0 +1,11 @@
+.container
+  %h1
+    Frequently Asked Questions Builder
+    = link_to "Add new help section",
+              new_admin_help_section_path,
+              class: "btn btn-sm btn-success float-right"
+
+  %ul.list-group
+    = render partial: "toc", collection: @sections, as: :section
+
+  = render partial: "section", collection: @sections

--- a/app/views/helps/_item.html.haml
+++ b/app/views/helps/_item.html.haml
@@ -1,0 +1,11 @@
+- id = "#{parent}-#{item_counter}"
+.card.shadow-sm.rounded
+  .card-header{ id: "#{id}-header" }
+    %button.btn.btn-link{ type: "button",
+        data: { toggle: "collapse", target: "##{id}" },
+        aria: { expanded: true, controls: id } }
+      = item.title
+
+.collapse{ id: id, "aria-labelledby": "#{id}-header", "data-parent": "##{parent}" }
+  .card-body
+    = item.content

--- a/app/views/helps/_section.html.haml
+++ b/app/views/helps/_section.html.haml
@@ -1,0 +1,6 @@
+%h3.subsection
+  %a{ id: section.slug }
+  = section.title
+.accordion.faq-list{ id: section.slug }
+  = render partial: "item",
+    collection: section.help_items, locals: { parent: section.slug }

--- a/app/views/helps/_section.html.haml
+++ b/app/views/helps/_section.html.haml
@@ -1,6 +1,6 @@
 %h3.subsection
   %a{ id: section.slug }
   = section.title
-.accordion.faq-list{ id: section.slug }
+.accordion.faq-list{ id: "s-#{section.slug}" }
   = render partial: "item",
-    collection: section.help_items, locals: { parent: section.slug }
+    collection: section.help_items, locals: { parent: "s-#{section.slug}" }

--- a/app/views/helps/_toc.html.haml
+++ b/app/views/helps/_toc.html.haml
@@ -1,0 +1,2 @@
+%li.list-group-item
+  = link_to section.title, help_path(anchor: section.slug)

--- a/app/views/helps/show.html.haml
+++ b/app/views/helps/show.html.haml
@@ -1,0 +1,8 @@
+.container
+  %h1
+    Frequently Asked Questions Builder
+
+  %ul.list-group
+    = render partial: "toc", collection: @sections, as: :section
+
+  = render partial: "section", collection: @sections

--- a/app/views/helps/show.html.haml
+++ b/app/views/helps/show.html.haml
@@ -1,6 +1,6 @@
 .container
   %h1
-    Frequently Asked Questions Builder
+    Frequently Asked Questions
 
   %ul.list-group
     = render partial: "toc", collection: @sections, as: :section

--- a/app/views/layouts/admin/_navbar.html.haml
+++ b/app/views/layouts/admin/_navbar.html.haml
@@ -17,6 +17,8 @@
           = link_to "Getting Started", admin_path, class: "nav-link px-2 py-1"
         = nav_link controller: :jobs, html_options: { class: "nav-item" } do
           = link_to "Delayed jobs", admin_jobs_path, class: "nav-link px-2 py-1"
+        = nav_link controller: :jobs, html_options: { class: "nav-item" } do
+          = link_to "Help builder", admin_help_path, class: "nav-link px-2 py-1"
         %li.nav-item
           = link_to "Logout", destroy_user_session_path, method: :delete, class: "nav-link px-2 py-1"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,11 @@ Rails.application.routes.draw do
   resource :admin, only: :show
   namespace :admin do
     resources :jobs, only: :index
+    resource :help, only: :show
+    resources :help_sections, except: [:index, :show]
+    resources :help_items, except: [:index, :show]
   end
+
   # Sidekiq monitoring
   authenticate :user, ->(u) { u.admin? } do
     require "sidekiq/web"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
   end
 
   resource :profile, only: :show
+  resource :help, only: :show
 
   resource :backoffice, only: :show
   namespace :backoffice do

--- a/db/migrate/20200114124437_create_action_text_tables.action_text.rb
+++ b/db/migrate/20200114124437_create_action_text_tables.action_text.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_text_rich_texts do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end

--- a/db/migrate/20200114130609_create_help_sections.rb
+++ b/db/migrate/20200114130609_create_help_sections.rb
@@ -1,9 +1,9 @@
 class CreateHelpSections < ActiveRecord::Migration[6.0]
   def change
     create_table :help_sections do |t|
-      t.string :title, nil: false
+      t.string :title, null: false
       t.string :slug, unique: true
-      t.integer :position, nil: false, default: 0
+      t.integer :position, null: false, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20200114130609_create_help_sections.rb
+++ b/db/migrate/20200114130609_create_help_sections.rb
@@ -1,0 +1,11 @@
+class CreateHelpSections < ActiveRecord::Migration[6.0]
+  def change
+    create_table :help_sections do |t|
+      t.string :title, nil: false
+      t.string :slug, unique: true
+      t.integer :position, nil: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200114134749_create_help_items.rb
+++ b/db/migrate/20200114134749_create_help_items.rb
@@ -1,9 +1,9 @@
 class CreateHelpItems < ActiveRecord::Migration[6.0]
   def change
     create_table :help_items do |t|
-      t.string :title, nil: false
+      t.string :title, null: false
       t.string :slug, unique: true
-      t.integer :position, nil: false, default: 0
+      t.integer :position, null: false, default: 0
 
       t.belongs_to :help_section, null: false
 

--- a/db/migrate/20200114134749_create_help_items.rb
+++ b/db/migrate/20200114134749_create_help_items.rb
@@ -1,0 +1,13 @@
+class CreateHelpItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :help_items do |t|
+      t.string :title, nil: false
+      t.string :slug, unique: true
+      t.integer :position, nil: false, default: 0
+
+      t.belongs_to :help_section, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,9 +82,9 @@ ActiveRecord::Schema.define(version: 2020_01_14_134749) do
   end
 
   create_table "help_items", force: :cascade do |t|
-    t.string "title"
+    t.string "title", null: false
     t.string "slug"
-    t.integer "position", default: 0
+    t.integer "position", default: 0, null: false
     t.bigint "help_section_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -92,9 +92,9 @@ ActiveRecord::Schema.define(version: 2020_01_14_134749) do
   end
 
   create_table "help_sections", force: :cascade do |t|
-    t.string "title"
+    t.string "title", null: false
     t.string "slug"
-    t.integer "position", default: 0
+    t.integer "position", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_07_124150) do
+ActiveRecord::Schema.define(version: 2020_01_14_134749) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -69,6 +79,24 @@ ActiveRecord::Schema.define(version: 2020_01_07_124150) do
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  end
+
+  create_table "help_items", force: :cascade do |t|
+    t.string "title"
+    t.string "slug"
+    t.integer "position", default: 0
+    t.bigint "help_section_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["help_section_id"], name: "index_help_items_on_help_section_id"
+  end
+
+  create_table "help_sections", force: :cascade do |t|
+    t.string "title"
+    t.string "slug"
+    t.integer "position", default: 0
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "messages", force: :cascade do |t|

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "mp",
   "private": true,
   "dependencies": {
-    "@rails/ujs": "^6.0.0",
-    "turbolinks": "^5.2.0",
-    "@rails/activestorage": "^6.0.0",
-    "@rails/actioncable": "^6.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.2",
     "@fortawesome/free-regular-svg-icons": "^5.2.0",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
+    "@rails/actioncable": "^6.0.0",
+    "@rails/actiontext": "^6.0.2",
+    "@rails/activestorage": "^6.0.0",
+    "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "^4.0.7",
     "bootstrap": "^4.1.1",
     "bootstrap-datepicker": "^1.8.0",
@@ -19,7 +19,9 @@
     "jquery": "^3.4.1",
     "lodash.debounce": "^4.0.8",
     "popper.js": "^1.14.3",
-    "stimulus": "^1.0.1"
+    "stimulus": "^1.0.1",
+    "trix": "^1.0.0",
+    "turbolinks": "^5.2.0"
   },
   "devDependencies": {
     "babel-jest": "^24.9.0",

--- a/spec/factories/help_items.rb
+++ b/spec/factories/help_items.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :help_item do
+    sequence(:title) { |n| "Help item #{n}" }
+    sequence(:content) { |n| "Help content #{n}" }
+    help_section
+  end
+end

--- a/spec/factories/help_sections.rb
+++ b/spec/factories/help_sections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :help_section do
+    sequence(:title) { |n| "Help section #{n}" }
+  end
+end

--- a/spec/features/admin/help_builder_spec.rb
+++ b/spec/features/admin/help_builder_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Marketplace help builder" do
+  include OmniauthHelper
+
+  let(:admin) { create(:user, roles: [:admin]) }
+
+  before { checkin_sign_in_as(admin) }
+
+  context "help section" do
+    scenario "can be created" do
+      visit admin_help_path
+
+      click_on "Add new help section"
+      fill_in "Title", with: "Ordering process"
+      click_on "Create Help section"
+
+      expect(page).to have_current_path(admin_help_path)
+      expect(page).to have_content("Ordering process")
+    end
+
+    scenario "can be updated" do
+      section = create(:help_section)
+
+      visit edit_admin_help_section_path(section)
+
+      fill_in "Title", with: "Updated section title"
+      click_on "Update Help section"
+
+      expect(page).to have_current_path(admin_help_path)
+      expect(page).to have_content("Updated section title")
+    end
+
+    scenario "can be deleted", js: true do
+      section = create(:help_section)
+
+      visit admin_help_path
+
+      accept_confirm do
+        click_on "Remove"
+      end
+
+      expect(page).to have_current_path(admin_help_path)
+      expect(page).to_not have_content(section.title)
+    end
+  end
+
+  context "help item", js: true do
+    let!(:section) { create(:help_section) }
+
+    scenario "can be created" do
+      visit admin_help_path
+
+      click_on "Add new help item"
+      fill_in "Title", with: "How to order a service"
+      find("trix-editor").click.set("It is quite simple")
+      click_on "Create Help item"
+
+      expect(page).to have_current_path(admin_help_path)
+      expect(page).to have_content("How to order a service")
+      click_on "How to order a service"
+      expect(page).to have_content("It is quite simple")
+    end
+
+    scenario "can be updated" do
+      item = create(:help_item, help_section: section)
+
+      visit edit_admin_help_item_path(item)
+      fill_in "Title", with: "Updated item title"
+      find("trix-editor").click.set("Update item content")
+      click_on "Update Help item"
+
+      expect(page).to have_current_path(admin_help_path)
+      expect(page).to have_content("Updated item title")
+      click_on "Updated item title"
+      expect(page).to have_content("Update item content")
+    end
+
+    scenario "can be deleted", js: true do
+      item = create(:help_item, help_section: section)
+
+      visit admin_help_path
+
+      accept_confirm do
+        within("div.accordion") do
+          click_on "Remove"
+        end
+      end
+
+      expect(page).to have_current_path(admin_help_path)
+      expect(page).to_not have_content(item.title)
+    end
+  end
+end

--- a/spec/features/help_spec.rb
+++ b/spec/features/help_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Help" do
+  include OmniauthHelper
+
+  scenario "anonynous user is redirected to old help page" do
+    visit help_path
+
+    expect(page).to have_current_path(page_path("help"))
+  end
+
+  scenario "non admin user is redirected to old help page" do
+    checkin_sign_in_as(create(:user))
+
+    visit help_path
+
+    expect(page).to have_current_path(page_path("help"))
+  end
+
+  context "as admin" do
+    let(:admin) { create(:user, roles: [:admin]) }
+
+    before { checkin_sign_in_as(admin) }
+
+    scenario "I can see gemerated help page" do
+      section = create(:help_section)
+      item = create(:help_item, help_section: section, content: "Help item content")
+
+      visit help_path
+
+      expect(page).to have_content(section.title)
+      expect(page).to have_content(item.title)
+      click_on item.title
+      expect(page).to have_content("Help item content")
+    end
+  end
+end

--- a/spec/features/help_spec.rb
+++ b/spec/features/help_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Help" do
 
     before { checkin_sign_in_as(admin) }
 
-    scenario "I can see gemerated help page" do
+    scenario "I can see generated help page" do
       section = create(:help_section)
       item = create(:help_item, help_section: section, content: "Help item content")
 

--- a/spec/features/help_spec.rb
+++ b/spec/features/help_spec.rb
@@ -35,5 +35,33 @@ RSpec.feature "Help" do
       click_on item.title
       expect(page).to have_content("Help item content")
     end
+
+    scenario "sections are sorted using postion field" do
+      second_section = create(:help_section, position: 2)
+      third_section = create(:help_section, position: 3)
+      first_section = create(:help_section, position: 1)
+
+      visit help_path
+
+      expect(page.body.index(first_section.title))
+        .to be < page.body.index(second_section.title)
+      expect(page.body.index(second_section.title)).
+        to be < page.body.index(third_section.title)
+    end
+
+    scenario "section items are sorted using postion field" do
+      section = create(:help_section)
+
+      second_item = create(:help_item, help_section: section, position: 2)
+      third_item = create(:help_item, help_section: section, position: 3)
+      first_item = create(:help_item, help_section: section, position: 1)
+
+      visit help_path
+
+      expect(page.body.index(first_item.title))
+        .to be < page.body.index(second_item.title)
+      expect(page.body.index(second_item.title)).
+        to be < page.body.index(third_item.title)
+    end
   end
 end

--- a/spec/models/help_item_spec.rb
+++ b/spec/models/help_item_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HelpItem, type: :model do
+  it { should validate_presence_of(:title) }
+  it { should validate_presence_of(:content) }
+  it { should belong_to(:help_section) }
+end

--- a/spec/models/help_section_spec.rb
+++ b/spec/models/help_section_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HelpSection do
+  it { should validate_presence_of(:title) }
+  it { should have_many(:help_items).dependent(:destroy) }
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,7 +915,14 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.2.tgz#bcba9bcd6ee09a47c6628336e07399a68ca87814"
   integrity sha512-vN78gohsXPlC5jxBHlmiwkUI9bv6SulcZaE72kAIg/G4ou+wTdiMWPJK1bf2IxUNf+sfOjhl+tbRmY4AzJcgrw==
 
-"@rails/activestorage@^6.0.0":
+"@rails/actiontext@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-6.0.2.tgz#1ad5ecfe5a64affb9cca7908a996c635cb0b2224"
+  integrity sha512-fxCGPRud14H4LTlAMLCtXDvhrNA9xswg2LwTYMEHzLQ0EPz2VU5ixDLygtYQymVq+9GtZ6CFGsvbOT0HhUJsGQ==
+  dependencies:
+    "@rails/activestorage" "^6.0.0-alpha"
+
+"@rails/activestorage@^6.0.0", "@rails/activestorage@^6.0.0-alpha":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-6.0.2.tgz#3882da2716d1f21091840fc52b71091d406a9c43"
   integrity sha512-X0uGBLNsSKvVw5n93rH7k+7rbxc3Cq7p0ShiQbrk1cN0xflGjElzEJRY3okZZHsKkCV+h6rFCk0BOBVrLSrJ0A==
@@ -8229,6 +8236,11 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trix@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.2.2.tgz#bb2afacb981df9a6edb49bc66f57427b9728909d"
+  integrity sha512-xNWwKDa1PG5do/qV3FRESXjM17U5ACB9Ih+x4mylLYfAgmYYTA17ExVdrrA7vCJ5J9nS1tVZFyhVTPgPTtIFVg==
 
 "true-case-path@^1.0.2":
   version "1.0.3"


### PR DESCRIPTION
This is a proof of concept in which the main goal is to check how [trix](https://trix-editor.org/) and [action text](https://edgeguides.rubyonrails.org/action_text_overview.html) can be used to create customizable page content. The idea is quite simple: 2 new models are created (`HelpCategory` and `HelpItem`). Inside `TextItem` rich text field is defined. It stores help item content with all formatting. 

This feature has 2 types of views. The first one is in the admin section, where help can be built. The second view is located at `/help`. For now, this section is only visible for admin, other users are redirected to the old help page. 

The plan for this feature in this release is to validate the idea and check if rich text editing is good enough for the help creation. So after the release @MinLidia and @agpul will try to move already existing static help into help stored in the DB. If everything will be ok we will start phase 2 (planned for next release), where old static help will be removed and the user will see the new help section rendered from the DB.

This kind of views is also a perfect candidate to use [cache](https://guides.rubyonrails.org/caching_with_rails.html). This is also something worth to add in the next help section version. 

Another improvement that can be added here is to have moved up/down capability on the main help builder view instead of manually changing the `position` field. To make it simpler we can use [this](https://github.com/brendon/acts_as_list) gem.