### PR TITLE
Dedicated pack for design system

### DIFF
--- a/app/javascript/packs/designsystem.js
+++ b/app/javascript/packs/designsystem.js
@@ -1,0 +1,29 @@
+require("@rails/ujs").start()
+require("turbolinks").start()
+require("@rails/activestorage").start()
+
+import 'bootstrap/dist/js/bootstrap';
+import 'stylesheets/designsystem';
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+import { library, dom } from '@fortawesome/fontawesome-svg-core';
+import { far } from '@fortawesome/free-regular-svg-icons';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+
+library.add(fas, far);
+
+const application = Application.start();
+const context = require.context("controllers", true, /.js$/);
+application.load(definitionsFromContext(context));
+
+document.addEventListener("turbolinks:before-render", function(event) {
+  dom.i2svg({ node: event.data.newBody });
+  dom.watch();
+});
+
+document.addEventListener('DOMContentLoaded', function () {
+  dom.i2svg();
+  dom.watch();
+});

--- a/app/javascript/stylesheets/designsystem.scss
+++ b/app/javascript/stylesheets/designsystem.scss
@@ -1,0 +1,3 @@
+body {
+  margin: 50px;
+}

--- a/app/views/layouts/designsystem.html.haml
+++ b/app/views/layouts/designsystem.html.haml
@@ -1,6 +1,16 @@
 !!!
 %html{ lang: "en" }
-  = render "layouts/head"
+  %head
+    %meta{ content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type" }/
+    %meta{ charset: "utf-8" }/
+    %meta{ content: "width=device-width, initial-scale=1, shrink-to-fit=no", name: "viewport" }/
+    %title EOSC Marketplace - design system
+    = csrf_meta_tags
+    = csp_meta_tag
+    = favicon_link_tag asset_path("favicon.ico")
+    = favicon_link_tag asset_path("favicon-180x180.png"), rel: "apple-touch-icon", type: "image/png"
+    = stylesheet_pack_tag "designsystem"
+    = javascript_pack_tag "designsystem"
   %body
     = yield
 


### PR DESCRIPTION
For the design system, @jswk and @abacz want to have separate js and csses. This PR introduces a dedicated webpack `designsystem` pack for this purpose.

No changelog entry because there is already one connected with design system.