### PR TITLE
[#1049] Service popularity based on number of orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Services search view refactoring and unification with backoffice view (@goreck888)
 - Webpack entry structure (@martaswiatkowska)
 - Sidebar in the service view generic rendering (@goreck888)
+- Popular services main page section based on number of orders (@goreck888)
 
 ### Deprecated
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -16,7 +16,7 @@ class HomeController < ApplicationController
       @providers_number = Provider.count
       @services_number = Service.count
       @countries_number = 32
-      @services = Service.published.includes(:providers).order(rating: :asc, title: :desc).limit(6)
+      @services = Service.published.includes(:providers).popular(6)
     end
 
     def load_platforms

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -29,11 +29,13 @@ class ProjectItem < ApplicationRecord
   enum issue_status: ISSUE_STATUSES
 
   belongs_to :offer
+  belongs_to :service, inverse_of: :project_items
   belongs_to :project
   belongs_to :research_area, required: false
   has_one :service_opinion, dependent: :restrict_with_error
   has_many :messages, as: :messageable, dependent: :destroy
   has_many :statuses, as: :status_holder
+  counter_culture [:offer, :service], column_name: "project_items_count"
 
   validates :offer, presence: true
   validates :status, presence: true

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -77,6 +77,7 @@ class Service < ApplicationRecord
   enum status: STATUSES
 
   has_many :offers, dependent: :restrict_with_error
+  has_many :project_items, through: :offers
   has_many :categorizations, dependent: :destroy
   has_many :categories, through: :categorizations
   has_many :service_opinions, through: :project_items
@@ -137,6 +138,10 @@ class Service < ApplicationRecord
   validates :order_target, allow_blank: true, email: true
 
   after_save :set_first_category_as_main!, if: :main_category_missing?
+
+  def self.popular(count)
+    order(project_items_count: :desc, rating: :desc, title: :asc).limit(count)
+  end
 
   def main_category
     @main_category ||= categories.joins(:categorizations).

--- a/db/migrate/20200128142804_add_project_items_count_to_services.rb
+++ b/db/migrate/20200128142804_add_project_items_count_to_services.rb
@@ -1,0 +1,5 @@
+class AddProjectItemsCountToServices < ActiveRecord::Migration[6.0]
+  def change
+    add_column :services, :project_items_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -337,6 +337,7 @@ ActiveRecord::Schema.define(version: 2020_01_14_134749) do
     t.integer "upstream_id"
     t.string "order_target", default: "", null: false
     t.string "helpdesk_email", default: ""
+    t.integer "project_items_count", default: 0, null: false
     t.index ["provider_id"], name: "index_services_on_provider_id"
     t.index ["title"], name: "index_services_on_title"
   end

--- a/lib/tasks/counter_cache.rake
+++ b/lib/tasks/counter_cache.rake
@@ -2,8 +2,6 @@
 
 desc "Counter cache for services has many offers"
 task service_counter: :environment do
-  Service.reset_column_information
-  Service.pluck(:id).each do |id|
-    Service.reset_counters(id, :offers)
-  end
+  Offer.counter_culture_fix_counts
+  ProjectItem.counter_culture_fix_counts
 end


### PR DESCRIPTION
Change the way of sorting services by popularity
After the fix it is populated based of number of orders
Fixes #1049

After merge and deploy in a production instance I'll ask to run task `rake service_counter` to get proper counter values.