### PR TITLE
[#1365] Services information for monitoring tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add static pages for design system and UI documentation (@mkasztelnik)
 - Comment changes in jira propagate to mp (@martaswiatkowska)
 - Dynamic help sections visible currently only for admin (@mkasztelnik)
+- Service information for a monitoring tool through `api/services` (@goreck888)
 
 ### Changed
 - Move research area and category logos to active storage (@mkasztelnik)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Api::ServicesController < ActionController::API
+  def index
+    @json = Service.where(status: [:published, :unverified]).map { |s| { "serviceUniqueId": s.id,
+                                                                         "serviceType": "eu.eosc.portal.services.url",
+                                                                         "contactEmail": s.contact_emails,
+                                                                         "sitenameServicegroup": s.title,
+                                                                         "countryName": s.places,
+                                                                         "url": s.webpage_url } }
+    render json: @json
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
+    get "/services" => "services#index", defaults: { format: :json }, as: :services_api
     namespace :webhooks do
       post "/jira" => "jiras#create", as: :jira
     end


### PR DESCRIPTION
Add api endpoint for downloading services information
for ARGO monitoring tool
JSON is available from #{root_path}/api/services
Fixes #1365