### PR TITLE
Restore configuration for designsystem assets build

### DIFF
--- a/app/javascript/designsystem/index.js
+++ b/app/javascript/designsystem/index.js
@@ -1,0 +1,28 @@
+require("@rails/ujs").start()
+require("turbolinks").start()
+require("@rails/activestorage").start()
+
+import 'bootstrap/dist/js/bootstrap';
+import 'stylesheets/designsystem';
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+import { library, dom } from '@fortawesome/fontawesome-svg-core';
+import { far } from '@fortawesome/free-regular-svg-icons';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+
+library.add(fas, far);
+
+document.addEventListener("turbolinks:before-render", function(event) {
+    dom.i2svg({ node: event.data.newBody });
+    dom.watch();
+});
+
+/**
+ * Apart from turbolinks we need to replace FA for the first page load
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    dom.i2svg();
+    dom.watch();
+});


### PR DESCRIPTION
During webpack cleanup, the design system definition was not moved. Here I'm fixing this issue.

No changelog entry, since the design system, has its changelog entry already.