### PR TITLE
Display "lead-error" only to admin user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 - Customization for translation files (@goreck888)
 - Customization for scss files (@michal-szostak, @mkasztelnik)
+- Lead section error box displayed to admin user (@martaswiatkowska)
 
 ### Changed
 - Template unification for all modals (@goreck888)

--- a/app/controllers/admin/lead_sections_controller.rb
+++ b/app/controllers/admin/lead_sections_controller.rb
@@ -4,7 +4,7 @@ class Admin::LeadSectionsController < Admin::ApplicationController
   before_action :find_and_authorize, only: [:edit, :update, :destroy]
 
   def new
-    @lead_section = LeadSection.new
+    @lead_section = LeadSection.new(slug: params[:slug])
     authorize(@lead_section)
   end
 

--- a/app/helpers/lead_section_helper.rb
+++ b/app/helpers/lead_section_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module LeadSectionHelper
+  def render_sections(section)
+    sec = LeadSection.find_by(slug: section)
+    if sec
+      render "leads/section", section: sec
+    else
+      render "leads/error", slug: section if policy(LeadSection).error?
+    end
+  end
+end

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -3124,3 +3124,7 @@ textarea.form-control.is-invalid {
   border-width: 1px;
   border-style: solid;
 }
+
+.lead-error {
+  margin-top: 20px;
+}

--- a/app/models/lead_section.rb
+++ b/app/models/lead_section.rb
@@ -13,4 +13,5 @@ class LeadSection < ApplicationRecord
 
   validates :title, presence: true
   validates :slug, presence: true
+  validates :slug, uniqueness: true
 end

--- a/app/policies/lead_section_policy.rb
+++ b/app/policies/lead_section_policy.rb
@@ -6,4 +6,8 @@ class LeadSectionPolicy < ApplicationPolicy
       scope
     end
   end
+
+  def error?
+    user&.admin?
+  end
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -9,8 +9,7 @@
   providers: @home_providers, more_providers_count: @home_providers_counter,
   target_groups: @home_target_groups, more_target_groups_count: @home_target_groups_counter
 
-- if @learn_more_section
-  = render "leads/section", section: @learn_more_section
+= render_sections("learn-more")
 
 = render "services", services: @services
 
@@ -20,5 +19,4 @@
     .col-12.col-lg-4.col-sm-5
       = render "opinions", opinion: @opinion
     .col-12.col-lg-8.col-sm-7
-      - if @use_cases_section
-        = render "leads/section", section: @use_cases_section
+      = render_sections("use-cases")

--- a/app/views/leads/_error.html.haml
+++ b/app/views/leads/_error.html.haml
@@ -1,0 +1,10 @@
+.container.lead-error
+  .row.alert.alert-danger
+    %h2 Cannot find lead_section with slug "#{slug}"
+    .col-12
+      .card-title
+        Please add such section using
+        = link_to "link", new_admin_lead_section_path(slug: slug)
+      .card-description
+        This message are displayed only for admin user.
+

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -35,6 +35,10 @@ en:
     #     edit:
     #       email: 'E-mail.'
     hints:
+      lead_section:
+        slug: |
+          You can add sections with slugs: "learn-more" or "use-cases". You will see
+          them on home page
       report:
         text: |
           We will send your report to our customer service.

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -35,4 +35,46 @@ RSpec.feature "Home" do
       expect(descriptions.map(&:text)).to match_array([service1, service2].map(&:description))
     end
   end
+
+  context "lead_sections" do
+    context "admin user" do
+      let(:admin) { create(:user, roles: [:admin]) }
+      before { checkin_sign_in_as(admin) }
+
+      it "should see error" do
+        visit "/"
+        expect(page).to have_text("Cannot find lead_section with slug \"learn-more\"")
+        expect(page).to have_text("Cannot find lead_section with slug \"use-cases\"")
+      end
+
+      it "should see section" do
+        lead_section = create(:lead_section, slug: "learn-more", title: "Learn More Section")
+        create(:lead, lead_section: lead_section)
+        visit "/"
+        expect(page).to_not have_text("Cannot find lead_section with slug \"learn-more\"")
+        expect(page).to have_text("Cannot find lead_section with slug \"use-cases\"")
+        expect(page).to have_text("Learn More Section")
+      end
+    end
+
+    context "user" do
+      let(:admin) { create(:user) }
+      before { checkin_sign_in_as(admin) }
+
+      it "should see error" do
+        visit "/"
+        expect(page).to_not have_text("Cannot find lead_section with slug \"learn-more\"")
+        expect(page).to_not have_text("Cannot find lead_section with slug \"use-cases\"")
+      end
+
+      it "should see section" do
+        lead_section = create(:lead_section, slug: "learn-more", title: "Learn More Section")
+        create(:lead, lead_section: lead_section)
+        visit "/"
+        expect(page).to_not have_text("Cannot find lead_section with slug \"learn-more\"")
+        expect(page).to_not have_text("Cannot find lead_section with slug \"use-cases\"")
+        expect(page).to have_text("Learn More Section")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Displayed lead-error (Cannot find lead_section with slug) for admin user. Plain user cannot see this message. 