### PR TITLE
Custom scss loader and unified way to define customization directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - Customization for translation files (@goreck888)
+- Customization for scss files (@michal-szostak, @mkasztelnik)
 
 ### Changed
 - Template unification for all modals (@goreck888)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ ssh -R <port_number - from 9001 to 9015>:localhost:5000 mszostak@docker-fid.grid
 If you can not connect, try different port - it is possible that other developer connected
 to this port and is blocking it
 
-## XGUS 
+## XGUS
 
 Marketplace is integrated with xGUS Helpdesk.
 All variables needed to establish a connection to the test instance are stored in encrypted credentials.
@@ -112,7 +112,7 @@ To run on different than test instance, there is a need do set environmental var
 
 ReCaptcha is now used in the ask service question form. To work it needs to set 2 environment variables:
 `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY`. For test, development and internal docker instances
-values of these variables are stored in encrypted credentials. 
+values of these variables are stored in encrypted credentials.
 
 ## For Admins
 
@@ -219,13 +219,17 @@ You can read documentation [here](https://github.com/bkeepers/dotenv).
 
 In shourt you can store your env variables in `.env` file in the root of the project.
 
-## View Customization
+## Views, locales and scss customization
 
-View can be customized by adding two env variables:
-  * CUSTOM_VIEWS_PATH="path to external folder" to customize views
-In the folder app/view/custom, add the files you want to overwrite in
-the same structure as they are in app/view/.
+Views, JS and SCSS can be customized by adding `CUSTOMIZATION_PATH` env variable.
+This variable should point to the directory with the following structure:
 
+```
+/my/customization/dir
+  - views
+  - javascript
+  - config/locales
+```
 
-
-
+**Warning**: when new SCSS is added to customization directory rails application
+needs to be restarted.

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,15 +27,21 @@ module Mp
 
     config.redis_url = ENV["REDIS_URL"] || default_redis_url
 
-    # View customization
-    config.paths['app/views'].unshift(ENV["CUSTOM_VIEWS_PATH"]) if ENV["CUSTOM_VIEWS_PATH"].present?
+    # Hierachical locales file structure
+    # see https://guides.rubyonrails.org/i18n.html#configure-the-i18n-module
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 
-    # Locales customization
-    config.i18n.load_path += if ENV["CUSTOM_LOCALES_PATH"].present?
-                               Dir[Pathname.new(ENV["CUSTOM_LOCALES_PATH"]).join('**', '*.{rb,yml}')]
-                             else
-                               Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-                             end
+    # Views and locales customization
+    # The dir structure pointed by `$CUSTOMIZATION_PATH` should looks as follow:
+    #   - views          // custom views
+    #   - javascript     // custom scss files (see `config/webpack/environment.js`)
+    #   - config/locales // custom locales
+    if ENV["CUSTOMIZATION_PATH"].present?
+      config.paths['app/views'].unshift(File.join(ENV["CUSTOMIZATION_PATH"], "views"))
+      config.i18n.load_path +=
+        Dir[Pathname.new(ENV["CUSTOMIZATION_PATH"]).join('config', 'locales', '**', '*.{rb,yml}')]
+    end
+
 
     config.portal_base_url = "https://eosc-portal.eu"
     config.portal_base_url = ENV["PORTAL_BASE_URL"] if ENV["PORTAL_BASE_URL"].present?

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,7 @@
-const { environment } = require('@rails/webpacker')
-const webpack = require('webpack')
+const {environment} = require('@rails/webpacker');
+const webpack = require('webpack');
+const fs = require('fs');
+const path = require('path');
 
 /**
  * Automatically load modules instead of having to import or require them
@@ -10,25 +12,81 @@ const webpack = require('webpack')
  * http://j.mp/2JzG1Dm
  */
 environment.plugins.prepend(
-  'Provide',
-  new webpack.ProvidePlugin({
-    $: 'jquery',
-    jQuery: 'jquery',
-    jquery: 'jquery',
-    'window.jQuery': 'jquery',
-    Popper: ['popper.js', 'default']
-  })
-)
+    'Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery',
+        jQuery: 'jquery',
+        jquery: 'jquery',
+        'window.jQuery': 'jquery',
+        Popper: ['popper.js', 'default']
+    })
+);
 
 /**
  * To use jQuery in views
  */
 environment.loaders.append('expose', {
-  test: require.resolve('jquery'),
-  use: [{
-    loader: 'expose-loader',
-    options: '$'
-  }]
+    test: require.resolve('jquery'),
+    use: [{
+        loader: 'expose-loader',
+        options: '$'
+    }]
 })
 
-module.exports = environment
+const CUSTOMIZATION_PATH = process.env.CUSTOMIZATION_PATH;
+
+if (CUSTOMIZATION_PATH) {
+    const rootDir = path.resolve('.');
+    const relRE = new RegExp(`${rootDir}/app/(.+)/.+\..+`);
+    const sassLoader = environment.loaders.get('sass').use.find(element => element.loader === 'sass-loader');
+
+    sassLoader.options.importer = function (url, prev, done) {
+        if (url.startsWith('~')) {
+            return null;
+        }
+
+        const match = prev.match(relRE);
+        if (!match) {
+            return null;
+        }
+
+        const relPath = match[1];
+
+        function findPath(path, url) {
+            function checkAndReturn(path) {
+                if(fs.existsSync(path)) {
+                    return path
+                }
+                return null;
+            }
+
+            const check = checkAndReturn(path + '/' + url)
+                || checkAndReturn(path + '/' + url + '.scss')
+                || checkAndReturn(path + '/' + url + '.sass');
+
+            if(check) {return check;}
+
+            const pos = url.search(new RegExp('[^/\.]\..+$'));
+            if(pos === -1 || url.charAt(1) === '_') {
+                return null;
+            }
+
+            const urlSub = url.slice(0, pos) + '_' + url.slice(pos);
+            return checkAndReturn(path + '/' + urlSub)
+            || checkAndReturn(path + '/' + urlSub + '.scss')
+            || checkAndReturn(path + '/' + urlSub + '.sass');
+        }
+
+
+        const filePath = findPath(CUSTOMIZATION_PATH + '/' + relPath, url);
+
+        if (filePath) {
+            return {file: filePath};
+        }
+
+        return null;
+    };
+
+}
+
+module.exports = environment;

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -12,80 +12,80 @@ const path = require('path');
  * http://j.mp/2JzG1Dm
  */
 environment.plugins.prepend(
-    'Provide',
-    new webpack.ProvidePlugin({
-        $: 'jquery',
-        jQuery: 'jquery',
-        jquery: 'jquery',
-        'window.jQuery': 'jquery',
-        Popper: ['popper.js', 'default']
-    })
+  'Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery',
+    jQuery: 'jquery',
+    jquery: 'jquery',
+    'window.jQuery': 'jquery',
+    Popper: ['popper.js', 'default']
+  })
 );
 
 /**
  * To use jQuery in views
  */
 environment.loaders.append('expose', {
-    test: require.resolve('jquery'),
-    use: [{
-        loader: 'expose-loader',
-        options: '$'
-    }]
+  test: require.resolve('jquery'),
+  use: [{
+    loader: 'expose-loader',
+    options: '$'
+  }]
 })
 
 const CUSTOMIZATION_PATH = process.env.CUSTOMIZATION_PATH;
 
 if (CUSTOMIZATION_PATH) {
-    const rootDir = path.resolve('.');
-    const relRE = new RegExp(`${rootDir}/app/(.+)/.+\..+`);
-    const sassLoader = environment.loaders.get('sass').use.find(element => element.loader === 'sass-loader');
+  const rootDir = path.resolve('.');
+  const relRE = new RegExp(`${rootDir}/app/(.+)/.+\..+`);
+  const sassLoader = environment.loaders.get('sass').use.find(element => element.loader === 'sass-loader');
 
-    sassLoader.options.importer = function (url, prev, done) {
-        if (url.startsWith('~')) {
-            return null;
+  sassLoader.options.importer = function (url, prev, done) {
+    if (url.startsWith('~')) {
+      return null;
+    }
+
+    const match = prev.match(relRE);
+    if (!match) {
+      return null;
+    }
+
+    const relPath = match[1];
+
+    function findPath(path, url) {
+      function checkAndReturn(path) {
+        if(fs.existsSync(path)) {
+          return path
         }
-
-        const match = prev.match(relRE);
-        if (!match) {
-            return null;
-        }
-
-        const relPath = match[1];
-
-        function findPath(path, url) {
-            function checkAndReturn(path) {
-                if(fs.existsSync(path)) {
-                    return path
-                }
-                return null;
-            }
-
-            const check = checkAndReturn(path + '/' + url)
-                || checkAndReturn(path + '/' + url + '.scss')
-                || checkAndReturn(path + '/' + url + '.sass');
-
-            if(check) {return check;}
-
-            const pos = url.search(new RegExp('[^/\.]\..+$'));
-            if(pos === -1 || url.charAt(1) === '_') {
-                return null;
-            }
-
-            const urlSub = url.slice(0, pos) + '_' + url.slice(pos);
-            return checkAndReturn(path + '/' + urlSub)
-            || checkAndReturn(path + '/' + urlSub + '.scss')
-            || checkAndReturn(path + '/' + urlSub + '.sass');
-        }
-
-
-        const filePath = findPath(CUSTOMIZATION_PATH + '/' + relPath, url);
-
-        if (filePath) {
-            return {file: filePath};
-        }
-
         return null;
-    };
+      }
+
+      const check = checkAndReturn(path + '/' + url)
+        || checkAndReturn(path + '/' + url + '.scss')
+        || checkAndReturn(path + '/' + url + '.sass');
+
+      if(check) {return check;}
+
+      const pos = url.search(new RegExp('[^/\.]\..+$'));
+      if(pos === -1 || url.charAt(1) === '_') {
+        return null;
+      }
+
+      const urlSub = url.slice(0, pos) + '_' + url.slice(pos);
+      return checkAndReturn(path + '/' + urlSub)
+        || checkAndReturn(path + '/' + urlSub + '.scss')
+        || checkAndReturn(path + '/' + urlSub + '.sass');
+    }
+
+
+    const filePath = findPath(CUSTOMIZATION_PATH + '/' + relPath, url);
+
+    if (filePath) {
+      return {file: filePath};
+    }
+
+    return null;
+  };
 
 }
 


### PR DESCRIPTION
Thanks to @michal-szostak we have now a way to customize CSS files. This PR contains this change and 2 additions elements:
  * Starting from now we can use one ENV variable (`$CUSTOMIZATION_PATH`) to point to the directory where customization is located
  * Not that obvious bug with hierarchical locales was fixed. We need to add
    ```ruby
    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
    ```
    even if the customization directory is defined. What is more it need to be added before customization dir is defined.