### PR TITLE
[#945] automatic offer creating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- Automatic offer creating by services import (@goreck888)
+- Information about offers statuses in the backoffice (@goreck888)
 
 ### Changed
 - Text label by offer selection in the first step of service ordering (@goreck888)

--- a/app/helpers/backoffice/services_helper.rb
+++ b/app/helpers/backoffice/services_helper.rb
@@ -11,6 +11,14 @@ module Backoffice::ServicesHelper
     content_tag(:span, service.status, class: "badge #{BADGES[service.status]}")
   end
 
+  def offers_status(service)
+    if service.offers.blank?
+      content_tag(:span, "NO OFFERS", class: "badge badge-error")
+    elsif service.published? && service.offers.published.blank?
+      content_tag(:span, "NO PUBLISHED OFFERS", class: "badge badge-warning")
+    end
+  end
+
   def offer_status(offer)
     content_tag(:span, offer.status, class: "badge #{BADGES[offer.status]}")
   end

--- a/app/views/backoffice/services/_service.html.haml
+++ b/app/views/backoffice/services/_service.html.haml
@@ -2,3 +2,5 @@
   = service_status(service)
   = link_to [:backoffice, service] do
     = highlighted_for(:title, service, highlights)
+  %br
+  = offers_status(service)

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -1,5 +1,12 @@
 - breadcrumb :backoffice_service, @service
 .container
+  - if @service.offers.blank?
+    .alert.alert-danger.mb-0.text-center
+      The service has no offers. Add one offer to make possible for a user to Access the service.
+  - elsif @service.published? && @service.offers.published.blank?
+    .alert.alert-warning.mb-0.text-center
+      The service is published but has no published offers.
+      Publish one offer to make possible for a user to Access the service.
   .row
     .col-5.col-md-2
       - if @service.logo.attached?

--- a/lib/import/eic.rb
+++ b/lib/import/eic.rb
@@ -192,6 +192,7 @@ module Import
               if @default_upstream == :eic
                 service.update(upstream_id: service_source.id)
               end
+              create_default_offer!(service, name, eid, url)
             end
           else
             service = Service.find_by(id: service_source.service_id)
@@ -200,6 +201,7 @@ module Import
               log "Updating [EXISTING] service #{service.title}, id: #{service_source.id}, eid: #{eid}"
               unless @dry_run
                 service.update!(updated_service_data.except(:research_areas, :categories, :status))
+                create_default_offer!(service, name, eid, url)
               end
             else
               not_modified += 1
@@ -219,6 +221,20 @@ module Import
           file << JSON.pretty_generate(output)
         end
       end
+    end
+
+    def create_default_offer!(service, name, eid, url)
+      if service&.offers.blank? && !url.blank?
+        log "Adding [NEW] default offer for service: #{name}, eid: #{eid}"
+        Offer.create!(name: "Offer", description: "#{name} Offer", offer_type: "open_access",
+                      webpage: url, status: service.status, service: service)
+      elsif url.blank?
+        log "[WARNING] Offer cannot be created, because url is empty"
+      end
+    rescue ActiveRecord::RecordInvalid => reason
+      log "ERROR - Default offer for #{service.title} (eid: #{eid}) cannot be created. #{reason}"
+    rescue error
+      log "ERROR - Default offer for #{service.title} (eid: #{eid}) cannot be created. Unexpected #{error}!"
     end
 
     def map_category(category)

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -89,6 +89,16 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_content("Alpha (min. TRL 5)")
     end
 
+    scenario "I can see warning about no offers" do
+      service = create(:service)
+
+      visit backoffice_service_path(service)
+
+      expect(page)
+          .to have_content("The service has no offers." \
+                           " Add one offer to make possible for a user to Access the service.")
+    end
+
     scenario "I can preview service before create" do
       provider = create(:provider)
       research_area = create(:research_area)
@@ -209,6 +219,17 @@ RSpec.feature "Services in backoffice" do
 
       expect(page).to have_content("test offer")
       expect(service.offers.last.name).to eq("new offer 1")
+    end
+
+    scenario "I can see warning about no published offers", js: true do
+      service = create(:service)
+      offer = create(:offer, status: "draft", service: service)
+
+      visit backoffice_service_path(service)
+
+      expect(page).to have_content("The service is published but has no published offers. " \
+                                   "Publish one offer to make possible for a user to Access the service.")
+      expect(service.offers).to eq([offer])
     end
 
     scenario "Offer are converted from markdown to html on service view" do


### PR DESCRIPTION
Add automatic offer creating by service import from external sources.

Add warnings on the backoffice services view and backoffice service view about offers statuses.
Fixes #945 