### PR TITLE
[#1099] Dynamic breadcrumbs in the service view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Breadcrumbs depending on chosen category in service view (@goreck888)
 
 ### Security
 

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -10,6 +10,7 @@ module Service::Searchable
     before_action only: :index do
       @filters = visible_filters
       @active_filters = active_filters
+      session[:category] = @category&.id
     end
   end
 

--- a/config/breadcrumbs/marketplace.rb
+++ b/config/breadcrumbs/marketplace.rb
@@ -16,7 +16,9 @@ end
 
 crumb :service do |service|
   link service.title, service_path(service)
-  if service.main_category
+  if !session[:category].blank?
+    parent :category, Category.find(session[:category])
+  elsif service.main_category
     parent :category, service.main_category
   else
     parent :services


### PR DESCRIPTION
Fix category parent in the breadcrumbs in the service view
Fixes #1099