### PR TITLE
[#914] Service breadcrumbs allow filters settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- keep filters and query by using breadcrumbs to go back to the services view (@goreck888)
 
 ### Security
 

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -10,6 +10,7 @@ module Service::Searchable
     before_action only: :index do
       @filters = visible_filters
       @active_filters = active_filters
+      store_query_params
     end
   end
 
@@ -93,6 +94,16 @@ module Service::Searchable
 
     def active_filters
       @active_filters ||= all_filters.flat_map { |f| f.active_filters }
+    end
+
+    def store_query_params
+      session[:query] = {}
+      @filters.each do |filter|
+        session[:query][filter.field_name] = params[filter.field_name] unless params[filter.field_name].blank?
+        session[:query]["#{filter.field_name}-all"] =
+            params["#{filter.field_name}-all"] unless params["#{filter.field_name}-all"].blank?
+      end
+      session[:query][:q] = params[:q] unless params[:q].blank?
     end
 
     def filter_classes

--- a/app/views/services/nav/_categories.html.haml
+++ b/app/views/services/nav/_categories.html.haml
@@ -9,7 +9,7 @@
   - view = content_for(:category_view) || "services/nav/category"
   - categories.each do |cid, category|
     = render view, category: category[:category], current: current, counter: category[:counter]
-    - if current == category[:category] && !subcategories.empty?
+    - if current == category[:category] && !subcategories.blank?
       %ul.ml-3
         - subcategories.each do |sid, subcategory|
           = render view, category: subcategory[:category], current: current, counter: subcategory[:counter]

--- a/config/breadcrumbs/marketplace.rb
+++ b/config/breadcrumbs/marketplace.rb
@@ -10,7 +10,7 @@ crumb :profile do
 end
 
 crumb :services do
-  link "Services", services_path
+  link "Services", services_path(params: (session[:query].blank? ? {} : session[:query]))
   parent :marketplace_root
 end
 
@@ -26,7 +26,7 @@ crumb :service do |service|
 end
 
 crumb :category do |category|
-  link category.name, category_path(category)
+  link category.name, category_services_path(category, params: (session[:query].blank? ? {} : session[:query]))
   if category.parent
     parent category.parent
   else

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -34,6 +34,19 @@ RSpec.feature "Service filter" do
     expect(body).to have_text("Funcy search phrase")
   end
 
+  it "stores filter state by breadcrumbs navigation", js: true do
+    research_area = create(:research_area, name: "Science!")
+    provider = create(:provider, name: "Cyfronet provider")
+    create(:service, title: "dd", providers: [provider], research_areas: [research_area])
+
+    visit services_path(q: "dd", providers: [provider.to_param], research_areas: [research_area.to_param])
+    click_on "dd"
+    click_on "Services"
+
+    expect(page).to have_text("Looking for: dd")
+    expect(page).to have_text("Providers: Cyfronet provider")
+  end
+
   it "reset page after filtering", js: true do
     create_list(:service, 5)
 


### PR DESCRIPTION
Back to the services view from service using breadcrumbs
keeps filters and query settings
Fixes #914