### PR TITLE
Remove outdated filter variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Removed
 - Static help removed in favour of help stored in DB (@mkasztelnik)
+- Remove outdated filter variables from service index views (@mkasztelnik)
 
 ### Fixed
 

--- a/app/views/backoffice/services/index.html.haml
+++ b/app/views/backoffice/services/index.html.haml
@@ -19,15 +19,10 @@
                            services_count: @services_total,
                            categories: @siblings_with_counters,
                            subcategories: @subcategories_with_counters,
-                           provider_options: @provider_options,
-                           research_areas: @research_areas,
-                           target_groups_options: @target_groups_options,
-                           rating_options: @rating_options,
-                           tag_options: @tag_options,
-                           active_filters: @active_filters,
-                           related_platform_options: @related_platform_options,
                            sort_options: @sort_options,
-                           highlights: @highlights
+                           highlights: @highlights,
+                           filters: @filters,
+                           active_filters: @active_filters
 
 
 

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -8,5 +8,5 @@
     "data-target": "filter.form" do
     = hidden_field_tag :q, params[:q] if params[:q].present?
     = hidden_field_tag :sort, params[:sort] if params[:sort].present?
-    - @filters.each do |filter|
+    - filters.each do |filter|
       = render "services/filters/#{filter.type}", filter: filter

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -5,13 +5,7 @@
                                           categories: categories,
                                           subcategories: subcategories,
                                           services_count: services_count
-      = render "services/filters", provider_options: provider_options,
-                                   research_areas: research_areas,
-                                   target_groups_options: target_groups_options,
-                                   rating_options: rating_options,
-                                   tag_options: tag_options,
-                                   active_filters: active_filters,
-                                   related_platform_options: related_platform_options
+      = render "services/filters", filters: filters
 
     .col-lg-9
       .row.mb-4

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -5,12 +5,7 @@
                            services_count: @services_total,
                            categories: @siblings_with_counters,
                            subcategories: @subcategories_with_counters,
-                           provider_options: @provider_options,
-                           research_areas: @research_areas,
-                           target_groups_options: @target_groups_options,
-                           rating_options: @rating_options,
-                           tag_options: @tag_options,
-                           active_filters: @active_filters,
-                           related_platform_options: @related_platform_options,
                            sort_options: @sort_options,
-                           highlights: @highlights
+                           highlights: @highlights,
+                           filters: @filters,
+                           active_filters: @active_filters


### PR DESCRIPTION
On the main services view, we had some outdated variables which were not used anymore (not even defined). Here I'm doing the simple cleanup.