### PR TITLE
Use category used used to enter service in breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Changed
 - Text label by offer selection in the first step of service ordering (@goreck888)
 - Rack and linked gems update (@goreck888)
+- Use category user used to enter the service in breadcrumbs (@mkasztelnik)
 
 ### Deprecated
 

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -12,5 +12,5 @@
         = render "services/active_filters", category: category, active_filters: active_filters
         = render "services/pagination", sort_options: sort_options, services: services
 
-      = render services, highlights: highlights
+      = render services, highlights: highlights, category: category
   = render "services/paginate", services: services

--- a/app/views/services/_service.html.haml
+++ b/app/views/services/_service.html.haml
@@ -1,2 +1,3 @@
 = render "service_details", service: service, highlights: highlights do
-  = link_to highlighted_for(:title, service, highlights), service
+  = link_to highlighted_for(:title, service, highlights),
+    service_path(service, category.present? ? { fromc: category.slug } : nil)

--- a/config/breadcrumbs/marketplace.rb
+++ b/config/breadcrumbs/marketplace.rb
@@ -16,7 +16,9 @@ end
 
 crumb :service do |service|
   link service.title, service_path(service)
-  if service.main_category
+  if params[:fromc] && category = service.categories.find_by(slug: params[:fromc])
+    parent :category, category
+  elsif service.main_category
     parent :category, service.main_category
   else
     parent :services


### PR DESCRIPTION
This is an alternative implementation of the #1398. The difference here is that we are not storing anything in the user session, but query param is used to give a hint about the category which was used to access this service. This has this advantage, that problems with entering services from pasting service URL does not exist (the service category breadcrumb is URL dependent). What is more, I'm checking if selected service has this category (if not default one is shown).

Fixes #1099