### PR TITLE
Back to the old json services api schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Back to the old schema for json services api (@goreck888)
 
 ### Security
 

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -2,12 +2,12 @@
 
 class Api::ServicesController < ActionController::API
   def index
-    @json = Service.where(status: [:published, :unverified]).map { |s| { "serviceUniqueId": s.id,
-                                                                         "serviceType": "eu.eosc.portal.services.url",
-                                                                         "contactEmail": s.contact_emails,
-                                                                         "sitenameServicegroup": s.title,
-                                                                         "countryName": s.places,
-                                                                         "url": s.webpage_url } }
+    @json = Service.where(status: [:published, :unverified]).map { |s| { "Service Unique ID": s.id,
+                                                                         "SERVICE_TYPE": "eu.eosc.portal.services.url",
+                                                                         "CONTACT_EMAIL": s.contact_emails,
+                                                                         "SITENAME-SERVICEGROUP": s.title,
+                                                                         "COUNTRY_NAME": s.places,
+                                                                         "URL": s.webpage_url } }
     render json: @json
   end
 end


### PR DESCRIPTION
Change titles of fields for JSON services api

This is necessary because the tools using this api have parsers set to the old values.