### PR TITLE
Fix modal routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Redirects for modals which don't have html view (@goreck888)
 
 ### Security
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,14 +18,14 @@ Rails.application.routes.draw do
       resource :information, only: [:show, :update]
       resource :summary, only: [:show, :create]
       resource :cancel, only: :destroy
-      resource :question, only: [:new, :create]
+      resource :question, only: [:new, :create], constraints: lambda { |req| req.format == :js }
       resources :opinions, only: :index
     end
   end
   get "services/c/:category_id" => "services#index", as: :category_services
   resources :categories, only: :show
 
-  resource :reports, only: [:new, :create]
+  resource :reports, only: [:new, :create], constraints: lambda { |req| req.format == :js }
 
   resources :projects do
     scope module: :projects do


### PR DESCRIPTION
Add redirects for report and question modal,
which don't have pure html view:
- root path for report modal
- service path for question