### PR TITLE
Change link description for portal home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Text label by offer selection in the first step of service ordering (@goreck888)
 - Rack and linked gems update (@goreck888)
 - Use category user used to enter the service in breadcrumbs (@mkasztelnik)
+- Portal link description from `Info` to `Portal Home` (@goreck888)
 
 ### Deprecated
 

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -22,7 +22,7 @@
       .container.text-right.top-row
         %ul.list-inline.mb-0
           %li.list-inline-item.ml-2
-            %a{ href: Mp::Application.config.portal_base_url } Info
+            %a{ href: Mp::Application.config.portal_base_url } Portal Home
           %li.list-inline-item.ml-2
             = link_to "Catalogue & Marketplace", root_path,
               class: "#{"active" if local_assigns[:section] == nil}"

--- a/app/views/layouts/_sections.html.haml
+++ b/app/views/layouts/_sections.html.haml
@@ -2,7 +2,7 @@
   .container.text-right.pr-1.top-row
     %ul.list-inline.mb-0
       %li.list-inline-item.ml-2
-        %a{ href: Mp::Application.config.portal_base_url } Info
+        %a{ href: Mp::Application.config.portal_base_url } Portal Home
       %li.list-inline-item.ml-2
         = link_to "Catalogue & Marketplace", root_path,
           class: "#{"active" if local_assigns[:section] == nil}"


### PR DESCRIPTION
Change name from `Info` to `Portal Home`