### PR TITLE
Offers in autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 - Automatic offer creating by services import (@goreck888)
 - Information about offers statuses in the backoffice (@goreck888)
+- Offers to autocomplete (@martaswiatkowska)
 
 ### Changed
 - Text label by offer selection in the first step of service ordering (@goreck888)

--- a/app/controllers/backoffice/services/offers_controller.rb
+++ b/app/controllers/backoffice/services/offers_controller.rb
@@ -3,6 +3,7 @@
 class Backoffice::Services::OffersController < Backoffice::ApplicationController
   before_action :find_service
   before_action :find_offer_and_authorize, only: [:destroy, :edit, :update]
+  after_action :reindex_offer, only: [:create, :update, :destroy]
 
   def new
     @documentation_url = documentation_url
@@ -45,6 +46,12 @@ class Backoffice::Services::OffersController < Backoffice::ApplicationController
   end
 
   private
+    def reindex_offer
+      if @service.offers.size == 2
+        @service.offers.reindex
+      end
+    end
+
     def offer_template
       temp = without_blank_parameters(permitted_attributes(Offer))
       Offer.new(temp.merge(service: @service, status: :draft))

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -12,7 +12,8 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
 
   def index
     if params["service_id"].present?
-      redirect_to [:backoffice, Service.find(params["service_id"])]
+      redirect_to backoffice_service_path(Service.find(params["service_id"]),
+                                          anchor: ("offer-#{params["anchor"]}" if params["anchor"].present?))
     end
     @services = search(scope)
     @highlights = highlights(@services)

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -9,7 +9,8 @@ class ServicesController < ApplicationController
 
   def index
     if params["service_id"].present?
-      redirect_to Service.find(params["service_id"])
+      redirect_to service_path(Service.find(params["service_id"]),
+                               anchor: ("offer-#{params["anchor"]}" if params["anchor"].present?))
     end
     @services = search(scope)
     @highlights = highlights(@services)

--- a/app/javascript/app/controllers/autocomplete_controller.js
+++ b/app/javascript/app/controllers/autocomplete_controller.js
@@ -5,7 +5,8 @@ import debounce from 'lodash.debounce'
 
 export default class extends Controller {
 
-  static targets = [ 'form', 'input', 'hidden', 'results' ]
+  static targets = [ 'form', 'input', 'hidden',
+                    'results', 'anchor' ]
 
   connect() {
     this.resultsTarget.hidden = true
@@ -123,10 +124,13 @@ export default class extends Controller {
 
     const textValue = selected.textContent.trim()
     const value = selected.getAttribute('data-autocomplete-value') || textValue
+    const anchor = selected.getAttribute('data-autocomplete-anchor') || null
+
     this.inputTarget.value = textValue
 
     if ( this.hiddenTarget ) {
       this.hiddenTarget.value = value
+      this.anchorTarget.value = anchor
     } else {
       this.inputTarget.value = value
     }
@@ -167,6 +171,7 @@ export default class extends Controller {
 
   fetchResults() {
     const query = this.inputTarget.value.trim()
+    const anchor = this.anchorTarget.value
 
     if (!query) {
       this.resultsTarget.hidden = true
@@ -193,7 +198,7 @@ export default class extends Controller {
   }
 
   success(body) {
-    this.resultsTarget.innerHTML  = body
+    this.resultsTarget.innerHTML = body
     this.identifyOptions()
     const hasResults = !!this.resultsTarget.querySelector('[role="option"]')
     this.resultsTarget.hidden = !hasResults

--- a/app/javascript/stylesheets/_header.scss
+++ b/app/javascript/stylesheets/_header.scss
@@ -114,6 +114,11 @@ header {
 
 .search-box {
   position: relative;
+
+  .list-header {
+    color: $palette-gray-50;
+    margin: 0.5rem;
+  }
 }
 
 .search-box .form-control,
@@ -143,9 +148,15 @@ header {
     cursor: pointer;
   }
 
-  .dropdown-item.active {
-    color: $palette-blue;
-    background-color: transparent;
+  .dropdown-item {
+    .active {
+      color: $palette-blue;
+      background-color: transparent;
+    }
+
+    span {
+      color: $palette-gray-50;
+    }
   }
 
   .dropdown-item:hover {

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -3,10 +3,25 @@
 class Offer < ApplicationRecord
   include Offerable
 
+  searchkick word_middle: [:name, :description],
+            highlight: [:name, :description]
+
   STATUSES = {
     published: "published",
     draft: "draft"
   }
+
+  def search_data
+    {
+      name: name,
+      description: description,
+      service_id: service_id
+    }
+  end
+
+  def should_index?
+    status == STATUSES[:published] && offers_count > 1
+  end
 
   enum status: STATUSES
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -11,6 +11,7 @@ class Service < ApplicationRecord
   # fields are mapped to elasticsearch
   def search_data
     {
+      service_id: id,
       title: title,
       tagline: tagline,
       description: description,

--- a/app/views/backoffice/services/_search.html.haml
+++ b/app/views/backoffice/services/_search.html.haml
@@ -12,7 +12,7 @@
                                        "data-toggle": "dropdown"
       = hidden_field_tag "service_id", nil, "data-target": "autocomplete.hidden"
       = hidden_field_tag "sort", "_score"
-
+      = hidden_field_tag "anchor", nil, "data-target": "autocomplete.anchor"
       .input-group-append
         %button#query-submit.input-group-text.bg-white
           %i.fas.fa-search

--- a/app/views/backoffice/services/offers/_offer.html.haml
+++ b/app/views/backoffice/services/offers/_offer.html.haml
@@ -1,4 +1,4 @@
-.col-md-6.d-flex.align-items-stretch.mb-4
+.col-md-6.d-flex.align-items-stretch.mb-4{ id: "offer-#{offer.id}" }
   .card
 
     .card-body.pt-4.pb-0

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -1,4 +1,4 @@
-.col-md-6
+.col-md-6{ id: "offer-#{offer.id}" }
   .card.m-0.mb-5
     = render "services/offers/description", offer: offer
     = render "services/offers/parameters", parameters: offer.attributes

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -6,6 +6,7 @@
              "data-search-services-path": services_path,
              "data-search-categories-path": "/services/c" do
     = hidden_field_tag "service_id", nil, "data-target": "autocomplete.hidden"
+    = hidden_field_tag "anchor", nil, "data-target": "autocomplete.anchor"
     = hidden_field_tag "sort", "_score"
     .input-group
 

--- a/app/views/services/autocomplete/_offer_item.html.haml
+++ b/app/views/services/autocomplete/_offer_item.html.haml
@@ -1,0 +1,6 @@
+%li.dropdown-item{ "role": "option",
+  "data-autocomplete-value": "#{offer.service_id}",
+  "data-autocomplete-anchor": "#{offer.id}" }
+  %span= service_titles[offer.service_id]
+  >
+  = highlights[:name].html_safe

--- a/app/views/services/autocomplete/_service_item.html.haml
+++ b/app/views/services/autocomplete/_service_item.html.haml
@@ -1,0 +1,3 @@
+%li.dropdown-item{ "role": "option",
+  "data-autocomplete-value": "#{service[:id]}" }
+  = highlights[:title].html_safe

--- a/app/views/services/autocomplete/list.html.haml
+++ b/app/views/services/autocomplete/list.html.haml
@@ -1,0 +1,10 @@
+%p.list-header Services
+- results.each do |elem, highlights|
+  - if highlights[:title]
+    = render "services/autocomplete/service_item", service: elem, highlights: highlights
+%p.list-header Offers
+- results.each do |elem, highlights|
+  - if highlights[:name]
+    = render "services/autocomplete/offer_item", offer: elem,
+      highlights: highlights,
+      service_titles: service_titles

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -65,4 +65,42 @@ RSpec.feature "Service searching in top bar", js: true do
 
     expect(page).to have_selector("li.dropdown-item[role='option']:not([style*=\"display: none\"]", count: 3)
   end
+
+  scenario "After starting searching autocomplete not show draft offers", js: true, search: true do
+    service = create(:service, title: "DDDD Something 1")
+    create(:offer, name: "DDDD Something offer 1", service: service, status: :draft)
+    create(:offer, name: "DDDD Something offer 2", service: service, status: :draft)
+    create(:service, title: "DDDD Something 2")
+    create(:service, title: "DDDD Something 3")
+    Offer.reindex
+
+    visit services_path
+
+    fill_in "q", with: "DDDD Something"
+
+    expect(page).to have_text("DDDD Something 1")
+    expect(page).to have_text("DDDD Something 2")
+    expect(page).to have_text("DDDD Something 3")
+    expect(page).to_not have_text("DDDD Something offer 1")
+    expect(page).to_not have_text("DDDD Something offer 2")
+  end
+
+  scenario "After starting searching autocomplete are shown with published offers", js: true, search: true do
+    service = create(:service, title: "DDDD Something 1")
+    create(:offer, name: "DDDD Something offer 1", service: service)
+    create(:offer, name: "DDDD Something offer 2", service: service)
+    create(:service, title: "DDDD Something 2")
+    create(:service, title: "DDDD Something 3")
+    Offer.reindex
+
+    visit services_path
+
+    fill_in "q", with: "DDDD Something"
+
+    expect(page).to have_text("DDDD Something 1")
+    expect(page).to have_text("DDDD Something 2")
+    expect(page).to have_text("DDDD Something 3")
+    expect(page).to have_text("DDDD Something offer 1")
+    expect(page).to have_text("DDDD Something offer 2")
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     # reindex models
     Service.reindex
+    Offer.reindex
 
     # and disable callbacks
     Searchkick.disable_callbacks


### PR DESCRIPTION
Added offers to autocomplete results.
After click on displayed offers users are redirected to offer on service page by anchor.
Only published offers are indexed and if the service has more than two offers.