### PR TITLE
[#1422] Fix displaying details in service description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Displaying empty links in service details (@goreck888)
 
 ### Security
 

--- a/app/views/services/sidebar/_links.html.haml
+++ b/app/views/services/sidebar/_links.html.haml
@@ -1,5 +1,5 @@
 - fields.each do |field|
-  - if !!service.send(field)
+  - if service.send(field).present?
     %li.list-group-item
       %span
         - if field.end_with? "_url"

--- a/app/views/services/sidebar/_text.html.haml
+++ b/app/views/services/sidebar/_text.html.haml
@@ -1,5 +1,5 @@
 - fields.each do |field|
-  - if !!service.send(field)
+  - if service.send(field).present?
     %li.list-group-item
       %span
         = t(".fields.#{field}.#{service.send(field)}")


### PR DESCRIPTION
Fix displaying empty links, in particular helpdesk e-mail
Fixes #1422