### PR TITLE
Constant parameter type

### DIFF
--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -38,8 +38,9 @@ class Parameter
     end
 
     def all
-      [Parameter::Input, Parameter::Select, Parameter::Multiselect,
-       Parameter::Date, Parameter::Range, Parameter::QuantityPrice]
+      [Parameter::Constant, Parameter::Input, Parameter::Select,
+       Parameter::Multiselect, Parameter::Date, Parameter::Range,
+       Parameter::QuantityPrice]
     end
   end
 

--- a/app/models/parameter/constant.rb
+++ b/app/models/parameter/constant.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Parameter::Constant < Parameter
+  attribute :value
+  attribute :value_type, :string
+
+  validates :value, presence: true
+  validates :value_type, presence: true, inclusion: %w[string integer]
+  validate :correct_value_type
+
+  def dump
+    ActiveSupport::HashWithIndifferentAccess.new(
+      id: id, type: type, label: name, description: hint,
+      value: value, value_type: value_type)
+  end
+
+  def self.load(hsh)
+    new(id: hsh["id"], name: hsh["label"], hint: hsh["description"],
+        value: hsh["value"], value_type: hsh["value_type"])
+  end
+
+  def self.type
+    "attribute"
+  end
+
+  private
+    def correct_value_type
+      Integer(value) if value_type == "integer"
+    rescue
+      errors.add(:value, "is not an integer")
+    end
+end

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -46,7 +46,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
     [:name, :description, :webpage, :offer_type,
      parameters_attributes: [:type, :name, :hint, :min, :max,
                              :unit, :value_type, :start_price, :step_price, :currency,
-                             :exclusive_min, :exclusive_max, :mode, :values]]
+                             :exclusive_min, :exclusive_max, :mode, :values, :value]]
   end
 
   private

--- a/app/views/parameters/template/_attribute.html.haml
+++ b/app/views/parameters/template/_attribute.html.haml
@@ -1,0 +1,5 @@
+.row
+  .col
+    = f.input :value
+  .col
+    = f.input :value_type, collection: %w[string integer]

--- a/config/locales/views/parameters/template.en.yml
+++ b/config/locales/views/parameters/template.en.yml
@@ -1,5 +1,8 @@
 en:
   parameters:
+    attribute:
+      title: Constant parameter
+      add: Constant
     input:
       title: Input parameter
       add: Input

--- a/spec/factories/parameters.rb
+++ b/spec/factories/parameters.rb
@@ -7,6 +7,11 @@ FactoryBot.define do
     initialize_with { new(attributes) }
   end
 
+  factory :constant_parameter, class: "Parameter::Input", parent: :parameter do
+    sequence(:name) { |n| "constant parameter #{n}" }
+    sequence(:value) { |n| "value #{n}" }
+  end
+
   factory :input_parameter, class: "Parameter::Input", parent: :parameter do
     sequence(:name) { |n| "input parameter #{n}" }
     value_type { "string" }

--- a/spec/models/parameter/constant_spec.rb
+++ b/spec/models/parameter/constant_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Parameter::Constant do
+  subject { build(:input_parameter) }
+
+  it "serializes to attribute schema" do
+    expect(Attribute.from_json(subject.dump)).to be_config_valid
+  end
+end


### PR DESCRIPTION
Missing parameter type - Constant added. It is serialized to `attribute` type.

No changelog since there is already changelog connected with parameter UI. 