### PR TITLE
Add matomo tracker for marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
-
 - White label customization for development (@michal-szostak)
+- Send analytics to PC component by matomo (@goreck888)
 
 ### Changed
 - Unification of top links comparing with Portal (@goreck888)

--- a/app/controllers/projects/services/opinions_controller.rb
+++ b/app/controllers/projects/services/opinions_controller.rb
@@ -15,6 +15,7 @@ class Projects::Services::OpinionsController < ApplicationController
 
     @service_opinion = ServiceOpinion::Create.new(template).call
     if @service_opinion.persisted?
+      Matomo::SendRequestJob.perform_later(@project_item, "Rate", @service_opinion.service_rating)
       redirect_to project_service_path(@project, @project_item),
                   notice: "Rating submitted sucessfully"
     else

--- a/app/controllers/services/summaries_controller.rb
+++ b/app/controllers/services/summaries_controller.rb
@@ -37,8 +37,9 @@ class Services::SummariesController < Services::ApplicationController
       if @project_item.persisted?
         session.delete(session_key)
         session.delete(:selected_project)
+        Matomo::SendRequestJob.perform_later(@project_item, "AddToProject")
         redirect_to project_service_path(@project_item.project, @project_item),
-                    notice: "Service ordered sucessfully"
+                                  notice: "Service ordered sucessfully"
       else
         redirect_to url_for([@service, prev_visible_step_key]),
                     alert: "Service request configuration is invalid"

--- a/app/jobs/matomo/send_request_job.rb
+++ b/app/jobs/matomo/send_request_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Matomo::SendRequestJob < ApplicationJob
+  queue_as :matomo
+
+  def perform(project_item, action, value = nil)
+    Matomo::CreateEvent.new(project_item, action, value).call
+  end
+end

--- a/app/services/matomo/create_event.rb
+++ b/app/services/matomo/create_event.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+class Matomo::CreateEvent
+  ACTIONS = {
+      add_to_project: "AddToProject",
+      rate: "Rate"
+  }
+
+  def initialize(project_item, action, value = nil, category = "Service")
+    @project_item = project_item
+    @action = action
+    @category = category
+    @value = value
+  end
+
+  def call
+    sid = @project_item.service.sources&.first&.eid || @project_item.service.slug
+    url = Mp::Application.config.matomo_url
+    site_id = Mp::Application.config.matomo_site_id
+    request = "https:" + url + "matomo.php?e_c=#{@category}&e_a=#{@action}&e_n=#{sid}&idsite=#{site_id}&rec=1"
+    if @action == ACTIONS[:rate] && @value.present?
+      request += "&e_v=#{@value}"
+    end
+    Net::HTTP.get_response(URI(request))
+  end
+end

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -9,5 +9,7 @@
   = favicon_pack_tag "favicon-180x180.png", rel: "apple-touch-icon", type: "image/png"
   = stylesheet_pack_tag "application"
   = javascript_pack_tag "application"
-  = render "layouts/google_analytics"
-  = render "layouts/hotjar_trackingcode"
+  - if Rails.env.production?
+    = render "layouts/matomo"
+    = render "layouts/google_analytics"
+    = render "layouts/hotjar_trackingcode"

--- a/app/views/layouts/_matomo.html.haml
+++ b/app/views/layouts/_matomo.html.haml
@@ -1,0 +1,28 @@
+%script
+:javascript
+  let _paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    let u="#{Mp::Application.config.matomo_url}";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+  (function() {
+    let previousPageUrl = null;
+    addEventListener('turbolinks:load', function(event) {
+      if (previousPageUrl) {
+        _paq.push(['setReferrerUrl', previousPageUrl]);
+        _paq.push(['setCustomUrl', window.location.href]);
+        _paq.push(['setDocumentTitle', document.title]);
+        if (event.data && event.data.timing) {
+          _paq.push(['setGenerationTimeMs', event.data.timing.visitEnd - event.data.timing.visitStart]);
+        }
+        _paq.push(['trackPageView']);
+      }
+      previousPageUrl = window.location.href;
+  });
+  })();

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -1,3 +1,6 @@
+- id = @service.sources&.first&.eid || @service.slug
+:javascript
+  _paq.push(['trackEvent', 'Service', 'Visit', '#{id}']);
 - breadcrumb :service, @service
 .container{ "data-controller": "comparison" }
   .pt-4.pl-3.pr-3.shadow-sm.rounded.service-box.service-detail

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,9 @@ module Mp
 
     config.redis_url = ENV["REDIS_URL"] || default_redis_url
 
+    config.matomo_url = ENV["MP_MATOMO_URL"] || "//catalogue.eosc-portal.eu/matomo/"
+    config.matomo_site_id = ENV["MP_MATOMO_SITE_ID"] || 1
+
     # Hierachical locales file structure
     # see https://guides.rubyonrails.org/i18n.html#configure-the-i18n-module
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]

--- a/config/google_api_key.json
+++ b/config/google_api_key.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "eosc-marketplace",
+  "private_key_id": "18a111baf18de5b56ed4c3fe4c956261efe11101",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDmFDYeg43FKnQ3\n7+JaH2nW0OadSfmWzB/KLTFixgg/XlKvjW/25hbXmWx3FEHnoxyHwJG+87lQqstK\nLFNqazF3MWz24ibnVG7m07dw4Q2tVTTDEREUGbxY38UCvBM+K6KFb3VrVNf+E61e\n3eUBe4SvjwYscldw36D69ZUuSe4JGrN5wIPzN3KJWVfrQox0LvnBGiGMkLvwZNS9\nyus74G8uXAz/7WWFpW2Vpb21GX9Q60LK+n6wEOd5aI6EzXXI8ftQHlKAqugvckVn\nupzHCp1maKVZ0FjaGJqw+j0hpKPips7pqSFQZUMDDU8vMbyoXXOrxjFlNb29CUON\nhCrk97wxAgMBAAECggEAEmL1xY/TJI6KpcMQiQ3kR2Z/sieB6qslXzgoBNy5NqyI\nWb8pKMdPzABWyq1ebER8uIc1ySzGV8v5CFRtK3P64ADzKZz+aZOLHqc3Ya3v3zTl\nTTFv9qCX4gJVRtgA3FcLBd7XuLFvEWmWe/OqTr6wO9dnhuXHAcjdSduWWxH4E9dc\n7/GYJOWYlQEDD5vlWco63dsscAya1E22eIDkLt9f/kAMmKp4XLX+cNu14AS7o7oB\n4qi9IRL9+NXMdrTv1VwtWutbcF8u2/62veCN7P86RIp3W0YbZ7L7089OaavZL+vI\no82i3jqc6gFd8GTOOsOfPLo6dcXz3AWjVpIN6yF+AQKBgQD7dTYKKiNai99P7t7u\nrhRBOJNvND1SkRAkftV3uhCJ00IMSesNo3LoWars/rmZaOzRXhim0+R70hpY9N6G\noPTUYntNPfX1WoxDNz83E5uiHw8OGv32C6m4CGCL5YgP9CfUq8mhuUsWGXzYPeST\nrwXjwPJEcLbx+0DCAbHWf0a17QKBgQDqPCPjkewR/1qdVRNXXqFFbvGZSpao79u4\nzj2QdJqCaKfPiRXYUIz0/0N65IUg7jw2q/jLY3eL7DRnAQFiZn1HsHg3hbT8c8df\nrxUmeOq3UIDlLC0KifMlEFVIQiCb9Y1rJEdzBLdZhpXPwK2u/a7tOmXSoALBwQ7s\nnYu5KYAW1QKBgA7q9TnFJjPI+IaVdURTr3/vC1AdmUW8tWh03dUshK6oidKQ0BEP\nEVIXf7xvoDMptmL1YiEDkRqHbGi6njj+c4fmD8qVUnIr3QZf0LBDyYfkr8/2afqe\n1oLEfHXQODI6GeLUDjI5++pjuLRbd6QLTh4k5DqLNU9FyKG52AMRqfBBAoGAfAVT\ny06b+/uEcwF0uDH2mdjgOxXvJ4u4fuVUW4QhuyLGl3AyDNK5j48In60XgBQj9Z6g\noLANwBxUsqUponw5oReiz2MQLQrwaY0+WZx0SpNpa+4z+vyHrPw064l30pv1QOF4\no0HAArrr35BZZeoUEK928kqeqxAZYtcX//YlR/ECgYEAxu8JszzdPe8H9C39dQGi\nyJH21OmIoBMHsFRxORzxCjuZP2MYvf3+CW+oG/8yrw9EGwkSB3D26wx5z/PIiDC1\nKu6JQS8+E9kNIbjyctHsI+6Ry3PFqc6X+znWMVE4zJO7XGOCtfrcqyOf+ElQoYPf\nGbneifL0RBWTXltp0bG/Ru8=\n-----END PRIVATE KEY-----\n",
+  "client_email": "mp-795@eosc-marketplace.iam.gserviceaccount.com",
+  "client_id": "116869641897982604995",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/mp-795%40eosc-marketplace.iam.gserviceaccount.com"
+}

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,4 +12,5 @@ staging:
   - orders
   - mailers
   - reports
+  - matomo
   - default


### PR DESCRIPTION
This PR contains integration with PC matomo tracking service.
Service pages visits, orders and ratings are marked as matomo events:
- Category of events => "Service"
- Order/AddToProject => "AddToProject"
- Service rate => "Rate"
- Page visit => "Visit"
With event name => service ID recognizable by PC applications
For rating event value is `ServiceOpinion.service_rating`

For test case you need:
- visit a few services pages
- add to project service
- rate a service

Then I'll check if all cases make events for matomo