### PR TITLE
Use overmind instead of foreman in present in the classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Research areas and categories of user interests (@goreck888)
 - Subscription mechanism for new added services (@goreck888)
 - Subscriber for eic messages (@martaswiatkowska)
+- Use overmind instead of foreman if present in the classpath (@mkasztelnik)
 
 ### Changed
 - Updated nodejs to version 10.19.0

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ css/js files change) use following command:
 ```
 ./bin/server
 ```
+It uses foremant and start processes defined in `Procfile.dev`.
+Script also checks if [overmind](https://github.com/DarthSim/overmind)
+is present in the classpath and uses it instead of `foreman`.
+`overmind` is more advanced than `foreman` and plays nicely with e.g. `byebug`.
+
+> Currently there is a problem with stopping overmind process when sidekiq is
+> used in versions [2.1.1 and 2.1.0](https://github.com/DarthSim/overmind/issues/76) -
+> use `2.0.3` instead.
 
 By default application should start on [http://localhost:5000](). You can change
 port by setting ENV variable `PORT`.

--- a/bin/server
+++ b/bin/server
@@ -1,1 +1,5 @@
-foreman start -f Procfile.dev
+if command -v overmind foo >/dev/null 2>&1; then
+  overmind start -f Procfile.dev
+else
+  foreman start -f Procfile.dev
+fi


### PR DESCRIPTION
[overmind](https://github.com/DarthSim/overmind) is much more powerful than `foreman` to start multiple processes during development. It uses tmux to start each process. As a result, you can attach/detach/restart each process separately. What is more, it works nicely with the `byebug` (no more starting `rails s` separately when debugging).

`overmind` will be used only when it is defined in the classpath, otherwise `foreman` is used as it used to be.