### PR TITLE
Email signature separator should be two dashes and a space

### DIFF
--- a/app/views/layouts/mailer.text.haml
+++ b/app/views/layouts/mailer.text.haml
@@ -1,6 +1,6 @@
 = yield
 
 :plain
-  ---
+  -- 
   Kind regards,
   EOSC Portal Marketplace Team


### PR DESCRIPTION
Email signature separator should be two dashes *and* a space, as per 
 https://tools.ietf.org/html/rfc3676#section-4.3
I'm not sure how HAML deals with withe space at the end of a line, so please check, but this is required so that the signature can be identified as a signature.
I'm not reading HTML messages but `mailer.html.haml` may also need a similar change.