### PR TITLE
Fix `dev:prime` after introducing offer parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Fix moving offer parameter up and down (@mkasztelnik)
+- Fix `dev:prime` after introducing offer parameters (@mkasztelnik)
 
 ### Security
 

--- a/db/data.yml
+++ b/db/data.yml
@@ -4102,6 +4102,7 @@ services:
               value_type:  "integer"
               config:
                 values: [1, 2, 3, 4, 5, 6, 7, 8]
+                mode: "dropdown"
             - id:  "id5"
               label:  "Amount od RAM"
               description:  "Type amount of RAM"

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -121,7 +121,7 @@ namespace :dev do
       service.offers.create!(name: h["name"],
                             description: h["description"],
                             webpage: h["webpage"],
-                            parameters: h["parameters"] || [],
+                            parameters: Parameter::Array.load(h["parameters"] || []),
                             offer_type: service.service_type,
                             status: :published)
       puts "    - #{h["name"]} offer generated"


### PR DESCRIPTION
The problem was connected with the situation that parameters are now converted into the model.