### PR TITLE
Fix research area counter issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Fixed
 - Fix moving offer parameter up and down (@mkasztelnik)
 - Fix `dev:prime` after introducing offer parameters (@mkasztelnik)
+- Fix counter for research area filter (@mkasztelnik)
 
 ### Security
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,33 +2,7 @@
 
 
 class Service < ApplicationRecord
-  # ELASTICSEARCH
-  # scope :search_import working with should_indexe?
-  # and define which services are indexed in elasticsearch
-  searchkick word_middle: [:title, :tagline, :description, :offer_names],
-    highlight: [:title, :tagline]
-
-  # search_data are definition whitch
-  # fields are mapped to elasticsearch
-  def search_data
-    {
-      service_id: id,
-      title: title,
-      tagline: tagline,
-      description: description,
-      status: status,
-      rating: rating,
-      categories: categories.map(&:id),
-      research_areas: research_areas.map(&:id),
-      providers: providers.map(&:id),
-      platforms: platforms.map(&:id),
-      target_groups: target_groups.map(&:id),
-      tags: tag_list,
-      source: upstream&.source_type,
-      offers: offers.ids,
-      offer_names:  offers.map(&:name)
-    }
-  end
+  include Service::Search
 
   extend FriendlyId
   friendly_id :title, use: :slugged

--- a/app/models/service/search.rb
+++ b/app/models/service/search.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Service::Search
+  extend ActiveSupport::Concern
+
+  included do
+    # ELASTICSEARCH
+    # scope :search_import working with should_indexe?
+    # and define which services are indexed in elasticsearch
+    searchkick word_middle: [:title, :tagline, :description, :offer_names],
+      highlight: [:title, :tagline]
+  end
+
+  # search_data are definition whitch
+  # fields are mapped to elasticsearch
+  def search_data
+    {
+      service_id: id,
+      title: title,
+      tagline: tagline,
+      description: description,
+      status: status,
+      rating: rating,
+      categories: categories.map(&:id),
+      research_areas: search_research_area_ids,
+      providers: providers.map(&:id),
+      platforms: platforms.map(&:id),
+      target_groups: target_groups.map(&:id),
+      tags: tag_list,
+      source: upstream&.source_type,
+      offers: offers.ids,
+      offer_names:  offers.map(&:name)
+    }
+  end
+
+  private
+    def search_research_area_ids
+      (research_areas.map(&:ancestor_ids) + research_areas.map(&:id))
+        .flatten.uniq
+    end
+end


### PR DESCRIPTION
This is another try to fix the research area issue in the filter zone. The issue
is connected with the research area tree-like structure. The intuition says
that parents should count also its children.

Here I'm trying to do exactly this by adding all parents to service
research areas elaticsearch record.

Closes #1230