### PR TITLE
[#1471] Fix highlights in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Fix moving offer parameter up and down (@mkasztelnik)
 - Fix `dev:prime` after introducing offer parameters (@mkasztelnik)
 - Fix counter for research area filter (@mkasztelnik)
+- Highlights show when at least 3 signs in query (@goreck888)
 
 ### Security
 

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -92,7 +92,10 @@ module Service::Searchable
     end
 
     def highlights(from_search)
-      Hash[(from_search.try(:with_highlights) || [])].transform_keys { |s| s.id }
+      result = from_search
+      result = result.try(:with_highlights) if (params[:q]&.size || 0) > 2
+
+      Hash[(result || [])].transform_keys { |s| s.id }
     end
 
     def visible_filters


### PR DESCRIPTION
Allow highlights only when query phrase has at least 3 signs
Fixes #1471