### PR TITLE
[#1514] Fix empty fields in comparison view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Empty service phase and service type in comparison view (@goreck888)
 
 ### Security
 

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -71,7 +71,7 @@
         %p= category.name
 
       %h5 Service type
-      %p= @service.service_type
+      %p= t("offers.type.#{@service.service_type}") if @service.service_type.present?
 
       %h5 Dedicated For
       %ul
@@ -88,10 +88,7 @@
       %hr
 
       %h5 Phase
-      %p= t "simple_form.options.service.phase.#{@service.phase}"
-
-      %h5 Service type
-      %p= @service.service_type
+      %p= t "simple_form.options.service.phase.#{@service.phase}" if @service.phase.present?
 
       %h5 Activate message
       %p= @service.activate_message

--- a/app/views/comparisons/show.html.haml
+++ b/app/views/comparisons/show.html.haml
@@ -36,7 +36,7 @@
         - @services.each do |service|
           %td{ "data-toggle" => "tootltip",
             "title" => "#{t("project_items.offer_type.#{service.service_type}.tooltip")}" }
-            = t("offers.type.#{service.service_type}")
+            = t("offers.type.#{service.service_type}") if service.service_type.present?
       %tr
         %th Research area
         - @services.each do |service|
@@ -48,7 +48,7 @@
       %tr
         %th Service phase
         - @services.each do |service|
-          %td= t("services.about.sidebar.fields.phase.#{service.phase}")
+          %td= t("services.about.sidebar.fields.phase.#{service.phase}") if service.phase.present?
       %tr.lightgrey-row
         %th Places
         - @services.each do |service|

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_content("service title")
       expect(page).to have_content("service description")
       expect(page).to have_content("service tagline")
-      expect(page).to have_content("open_access")
+      expect(page).to have_content("Open Access")
       expect(page).to have_content("person1@test.ok")
       # expect(page).to have_content("person2@test.ok")
       expect(page).to have_content("Welcome!!!")


### PR DESCRIPTION
Fix displaying empty fields like service phase
and service_type in comparison view
Fixes #1514