### PR TITLE
[#1572] Remove tagline and offer title in ordering form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Deprecated
 
 ### Removed
+- tagline and unnecessary offer titles in ordering form (@goreck888)
 
 ### Fixed
  

--- a/app/controllers/services/application_controller.rb
+++ b/app/controllers/services/application_controller.rb
@@ -107,7 +107,7 @@ class Services::ApplicationController < ApplicationController
     end
 
     def wizard_title
-      if step.offer
+      if step.offer && (@service.offers_count > 1)
         "#{@service.title} - #{step.offer.name}"
       else
         @service.title

--- a/app/views/layouts/order.html.haml
+++ b/app/views/layouts/order.html.haml
@@ -16,7 +16,7 @@
             %button.btn.btn-primary{ form: "order-form", type: "submit" }= next_title
       = render "layouts/flash"
     %main.container.order-container
-      %h1.font-weight-bold.mt-4
+      %h1.font-weight-bold.mt-4.mb-4
         = wizard_title
       = render "layouts/order/nav", service: @service, wizard: @wizard
       = yield

--- a/app/views/layouts/order.html.haml
+++ b/app/views/layouts/order.html.haml
@@ -18,7 +18,6 @@
     %main.container.order-container
       %h1.font-weight-bold.mt-4
         = wizard_title
-      %p.summary= @service.tagline
       = render "layouts/order/nav", service: @service, wizard: @wizard
       = yield
       %hr.bottom-hr.mt-5.mb-4


### PR DESCRIPTION
Remove offer title if there's just one offer
Fixes #1572