### PR TITLE
[#1574] Change "support" section title to "links" in service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 
 ### Changed
+- Sidebar links section name change from 'support' to 'links' (@goreck888)
 
 ### Deprecated
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -41,7 +41,7 @@ class Service < ApplicationRecord
                     { name: "platforms",
                       template: "array",
                       fields: ["platforms"] },
-                    { name: "support",
+                    { name: "links",
                       template: "links",
                       fields: ["webpage_url", "helpdesk_url", "helpdesk_email",
                                "manual_url", "tutorial_url"] },


### PR DESCRIPTION
In the service view change "support" section title
to links

Fixes #1574