### PR TITLE
JMS service deletion

### DIFF
--- a/app/helpers/backoffice/services_helper.rb
+++ b/app/helpers/backoffice/services_helper.rb
@@ -4,7 +4,8 @@ module Backoffice::ServicesHelper
   BADGES = {
     "published" => "badge-success",
     "unverified" => "badge-warning",
-    "draft" => "badge-error"
+    "draft" => "badge-error",
+    "deleted" => "badge-error"
   }
 
   def service_status(service)

--- a/app/jobs/service/delete_job.rb
+++ b/app/jobs/service/delete_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Service::DeleteJob < ApplicationJob
+  queue_as :jms
+
+  def perform(service_id)
+    Service::Delete.new(service_id).call
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -29,7 +29,8 @@ class Service < ApplicationRecord
   STATUSES = {
     published: "published",
     unverified: "unverified",
-    draft: "draft"
+    draft: "draft",
+    deleted: "deleted"
   }
 
   SIDEBAR_FIELDS = [{ name: "geographical_availabilities_and_languages",

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -15,31 +15,32 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def new?
-    service_portfolio_manager? || record.service.owned_by?(user)
+    (service_portfolio_manager? || record.service.owned_by?(user)) &&
+      !service_deleted?
   end
 
   def create?
-    managed?
+    managed? && !service_deleted?
   end
 
   def edit?
-    managed?
+    managed? && !service_deleted?
   end
 
   def update?
-    managed?
+    managed? && !service_deleted?
   end
 
   def destroy?
-    managed? && orderless?
+    managed? && orderless? && !service_deleted?
   end
 
   def publish?
-    service_portfolio_manager? && record.draft?
+    service_portfolio_manager? && record.draft? && !service_deleted?
   end
 
   def draft?
-    service_portfolio_manager? && record.published?
+    service_portfolio_manager? && record.published? && !service_deleted?
   end
 
   def permitted_attributes
@@ -61,5 +62,9 @@ class Backoffice::OfferPolicy < ApplicationPolicy
 
     def orderless?
       record.project_items.count.zero?
+    end
+
+    def service_deleted?
+      record.service.deleted?
     end
 end

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -65,19 +65,27 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   def update?
-    service_portfolio_manager? || (record.draft? && owned_service?)
+    (service_portfolio_manager? ||
+     (record.draft? && owned_service?)) &&
+    !record.deleted?
   end
 
   def publish?
-    service_portfolio_manager? && (record.draft? || record.unverified?)
+    service_portfolio_manager? &&
+      (record.draft? || record.unverified?) &&
+      !record.deleted?
   end
 
   def publish_unverified?
-    service_portfolio_manager? && (record.draft? || record.published?)
+    service_portfolio_manager? &&
+      (record.draft? || record.published?) &&
+      !record.deleted?
   end
 
   def draft?
-    service_portfolio_manager? && (record.published? || record.unverified?)
+    service_portfolio_manager? &&
+      (record.published? || record.unverified?) &&
+      !record.deleted?
   end
 
   def preview?

--- a/app/services/service/delete.rb
+++ b/app/services/service/delete.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Service::Delete
+  def initialize(service_eid, source: "eic")
+    @service = Service.joins(:sources).find_by("service_sources.source_type": source,
+                                               "service_sources.eid": service_eid)
+  end
+
+  def call
+    if @service
+      @service.update(status: :deleted)
+      @service.offers.each { |o| Offer::Draft.new(o).call }
+      @service
+    end
+  end
+end

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -23,7 +23,7 @@
       - if policy([:backoffice, @offer]).new?
         = link_to t("backoffice.services.offers.new.link"), new_backoffice_service_offer_path(@service),
             class: "btn btn-primary float-right ml-3 mb-3"
-      - if policy([:backoffice, @service]).edit?
+      - if policy([:backoffice, @service]).update?
         = link_to t("backoffice.services.edit.link"),
                   edit_backoffice_service_path(@service),
                   class: "btn btn-primary float-right"

--- a/spec/factories/jms_xml_provider.rb
+++ b/spec/factories/jms_xml_provider.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
         "resourceType" => "provider",
         "resource" => "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
                       "<tns:providerBundle xmlns:tns=\"http://einfracentral.eu\">" +
-                      "<tns:active>false</tns:active>" +
+                      "<tns:active>true</tns:active>" +
                       "<tns:metadata>" +
                         "<tns:modifiedAt>1594190519802</tns:modifiedAt>" +
                         "<tns:modifiedBy>Ignacio Blanquer</tns:modifiedBy>" +

--- a/spec/factories/jms_xml_service.rb
+++ b/spec/factories/jms_xml_service.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
               <tns:changeLog></tns:changeLog>
               <tns:description>&lt;p style=\"text-align: justify;\"&gt;A catalogue of corpora (datasets) made up of mainly Open Access scholarly publications.&lt;br /&gt; Users can view publicly available corpora that have been created with the OpenMinTeD Corpus Builder for Scholarly Works, or manually uploaded to the OpenMinTeD platform.&amp;nbsp;&lt;/p&gt; &lt;p style=\"text-align: justify;\"&gt;The catalogue can be browsed and searched via the faceted navigation facility or a google-like free text search query. All users can view the descriptions of the corpora (with administrative and technical information, such as language, domain, keywords, licence, resource creator, etc.), as well as the contents and, when available, the metadata descriptions of the individual files that compose them.&amp;nbsp;&lt;/p&gt; &lt;p style=\"text-align: justify;\"&gt;In addition, registered users can process them with the TDM applications offered by OpenMinTeD and download them in accordance with their licensing conditions.&lt;/p&gt;</tns:description>
               <tns:helpdeskPage>https://services.openminted.eu/support</tns:helpdeskPage>
-              <tns:id>tp.openminted_catalogue_of_corpora_2aaaaaaaaaaaaa</tns:id>
+              <tns:id>tp.openminted_catalogue_of_corpora_2</tns:id>
               <tns:languageAvailabilities>
                 <tns:languageAvailability>english</tns:languageAvailability>
               </tns:languageAvailabilities>

--- a/spec/jobs/service/delete_job_spec.rb
+++ b/spec/jobs/service/delete_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Service::DeleteJob do
+  let(:service) { create(:service) }
+  let(:source) { create(:service_source, service: service) }
+  let(:delete_service) { instance_double(Service::Delete) }
+
+  it "triggers ready process for project_item" do
+    allow(Service::Delete).to receive(:new).with(service.id).and_return(delete_service)
+    expect(delete_service).to receive(:call)
+    described_class.perform_now(service.id)
+  end
+
+  it "triggers ready process for project_item" do
+    ActiveJob::Base.queue_adapter = :test
+    expect {
+      described_class.perform_later(service.id)
+    }.to have_enqueued_job.on_queue("jms")
+  end
+end

--- a/spec/policies/backoffice/offer_policy_spec.rb
+++ b/spec/policies/backoffice/offer_policy_spec.rb
@@ -72,4 +72,40 @@ RSpec.describe Backoffice::OfferPolicy do
       end
     end
   end
+
+  context "When offer is published and service is deleted" do
+    let(:service) { create(:service, owners: [owner], status: :deleted) }
+    let(:offer) { build(:offer, service: service, status: :published) }
+
+    permissions :create?, :edit?, :update?, :destroy?, :draft? do
+      it "danies access to service portfolio manager" do
+        expect(subject).to_not permit(service_portfolio_manager, offer)
+      end
+
+      it "danies access to service owner" do
+        expect(subject).to_not permit(owner, offer)
+      end
+      it "denies access to other users" do
+        expect(subject).to_not permit(stranger, offer)
+      end
+    end
+  end
+
+  context "When offer is draft and service is deleted" do
+    let(:service) { create(:service, owners: [owner], status: :deleted) }
+    let(:offer) { build(:offer, service: service, status: :draft) }
+
+    permissions :create?, :edit?, :update?, :destroy?, :publish? do
+      it "danies access to service portfolio manager" do
+        expect(subject).to_not permit(service_portfolio_manager, offer)
+      end
+
+      it "danies access to service owner" do
+        expect(subject).to_not permit(owner, offer)
+      end
+      it "denies access to other users" do
+        expect(subject).to_not permit(stranger, offer)
+      end
+    end
+  end
 end

--- a/spec/policies/backoffice/service_policy_spec.rb
+++ b/spec/policies/backoffice/service_policy_spec.rb
@@ -283,4 +283,18 @@ RSpec.describe Backoffice::ServicePolicy do
       expect(subject).to_not permit(service_portfolio_manager, build(:service, status: :draft))
     end
   end
+
+  context "When offer is draft and service is deleted" do
+    let(:service) { create(:service, owners: [service_owner], status: :deleted) }
+
+    permissions :edit?, :update?, :destroy?, :publish?, :draft?, :publish_unverified? do
+      it "danies access to service portfolio manager" do
+        expect(subject).to_not permit(service_portfolio_manager, service)
+      end
+
+      it "danies access to service owner" do
+        expect(subject).to_not permit(service_owner, service)
+      end
+    end
+  end
 end

--- a/spec/services/jms/manage_message_spec.rb
+++ b/spec/services/jms/manage_message_spec.rb
@@ -10,18 +10,19 @@ describe Jms::ManageMessage do
   let(:parser) { Nori.new(strip_namespaces: true) }
   let(:service_resource) { create(:jms_xml_service) }
   let(:provider_resource) { create(:jms_xml_provider) }
-  let(:json_service) { double(body: service_resource.to_json) }
-  let(:json_provider) { double(body: provider_resource.to_json) }
+  let(:json_service) { double(body: service_resource.to_json,
+                              headers: { "destination"=> "/topic/registry.infra_service.update" }) }
+  let(:json_provider) { double(body: provider_resource.to_json,
+                               headers: { "destination"=> "/topic/registry.infra_service.update" }) }
   let(:service_create_or_update) { instance_double(Service::PcCreateOrUpdate) }
   let(:provider_create_or_update) { instance_double(Provider::PcCreateOrUpdate) }
 
   it "should receive service message" do
     original_stdout = $stdout
     $stdout = StringIO.new
-    allow(Service::PcCreateOrUpdate).to receive(:new).with(parser.parse(service_resource["resource"])["infraService"]["service"],
-                                                            eic_base,
-                                                            true).and_return(service_create_or_update)
-    allow(service_create_or_update).to receive(:call).and_return(true)
+    expect(Service::PcCreateOrUpdateJob).to receive(:perform_later).with(parser.parse(service_resource["resource"])["infraService"]["service"],
+                                                                         eic_base,
+                                                                         true)
     expect {
       described_class.new(json_service, eic_base, logger).call
     }.to_not raise_error
@@ -31,9 +32,7 @@ describe Jms::ManageMessage do
   it "should receive provider message" do
     original_stdout = $stdout
     $stdout = StringIO.new
-    allow(Provider::PcCreateOrUpdate).to receive(:new).with(parser.parse(provider_resource["resource"])["providerBundle"]["provider"])
-                                                            .and_return(provider_create_or_update)
-    allow(provider_create_or_update).to receive(:call).and_return(true)
+    expect(Provider::PcCreateOrUpdateJob).to receive(:perform_later).with(parser.parse(provider_resource["resource"])["providerBundle"]["provider"])
 
     expect {
       described_class.new(json_provider, eic_base, logger).call
@@ -41,43 +40,18 @@ describe Jms::ManageMessage do
     $stdout = original_stdout
   end
 
-  it "should receive error and unreceive if service cannot be created" do
+  it "should receive service delete message" do
+    service = create(:service)
+    create(:service_source, service: service, eid: "tp.openminted_catalogue_of_corpora_2")
     original_stdout = $stdout
     $stdout = StringIO.new
-    service_hash = { "resource": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"+
-                                   "<tns:infraService xmlns:tns=\"http://einfracentral.eu\">" +
-                                   "<tns:latest>true</tns:latest>" +
-                                   "<tns:service></tns:service>" +
-                                   "</tns:infraService>",
-                     "resourceType": "infra_service" }
-    allow(Service::PcCreateOrUpdate).to receive(:new).with(parser.parse(service_hash[:resource])["infraService"]["service"],
-                                                           eic_base,
-                                                           true).and_return(service_create_or_update)
-    allow(service_create_or_update).to receive(:call).and_raise(StandardError)
+    json_service  =  double(body: service_resource.to_json,
+                            headers: { "destination"=> "/topic/registry.infra_service.delete" })
+    expect(Service::DeleteJob).to receive(:perform_later).with("tp.openminted_catalogue_of_corpora_2")
 
     expect {
-      described_class.new(double(body: service_hash), eic_base, logger).call
-    }.to raise_error(StandardError)
-    $stdout = original_stdout
-  end
-
-  it "should receive error and unreceive if provider cannot be created" do
-    original_stdout = $stdout
-    $stdout = StringIO.new
-    provider_hash = { "resource": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"+
-                                   "<tns:provider xmlns:tns=\"http://einfracentral.eu\">" +
-                                   "<tns:active>true</tns:active>" +
-                                   "</tns:provider>",
-                     "resourceType": "provider" }
-
-    allow(Provider::PcCreateOrUpdate).to receive(:new).with(parser.parse(provider_hash[:resource])["provider"])
-      .and_return(provider_create_or_update)
-
-    allow(provider_create_or_update).to receive(:call).and_raise(StandardError)
-
-    expect {
-      described_class.new(double(body: provider_hash), eic_base, logger).call
-    }.to raise_error(StandardError)
+      described_class.new(json_service, eic_base, logger).call
+    }.to_not raise_error
     $stdout = original_stdout
   end
 
@@ -85,7 +59,7 @@ describe Jms::ManageMessage do
     original_stdout = $stdout
     $stdout = StringIO.new
     service_hash = { "some_happy_key": "some_happy_value" }
-    error_service_message = double(body: service_hash.to_json)
+    error_service_message = double(body: service_hash.to_json, headers: { "destination" => "aaaa.update" })
 
     expect {
       described_class.new(error_service_message, eic_base, logger).call

--- a/spec/services/service/delete_spec.rb
+++ b/spec/services/service/delete_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Service::Delete do
+  it "Set delete status for service" do
+    service = create(:service)
+    create(:service_source,
+           source_type: :eic,
+           service: service,
+           eid: service.id)
+
+    service = described_class.new(service.id).call
+    expect(service.status).to eq("deleted")
+  end
+
+  it "Does nothing if service not exist" do
+    service = create(:service)
+    service = described_class.new(service.id).call
+    expect(service).to be_nil
+  end
+end


### PR DESCRIPTION
Service can be deleted only by JMS
Service deletion mean that Service status is set to "deleted"
Deleted service cannot be edited, published and offers cannot be edited, deleted, published/draft or added.
Deleted service isn't shown for users. In bacoffice are displayed with badge "deleted"