### PR TITLE
[#1424] Remove duplicated ids on services page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 - instance badge display on backoffice section (@goreck888)
 - contact form tab layout modifications (@jarekzet)
 - Service preview (@goreck888)
- 
+- Duplicated "sort" ids on services page (@goreck888)
+
 ### Security
 
 ## [2.11.0] 2020-06-09

--- a/app/views/backoffice/services/_search.html.haml
+++ b/app/views/backoffice/services/_search.html.haml
@@ -11,7 +11,7 @@
                                      "data-target": "autocomplete.input",
                                      "data-toggle": "dropdown"
     = hidden_field_tag "service_id", nil, "data-target": "autocomplete.hidden"
-    = hidden_field_tag "sort", "_score"
+    = hidden_field_tag "sort", "_score", id: nil
     = hidden_field_tag "anchor", nil, "data-target": "autocomplete.anchor"
     %ul.autocomplete-results{ "data-target": "autocomplete.results" }
   .input-group-append

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -6,7 +6,7 @@
            "data-search-categories-path": "/services/c", class: "searchbar" do
   = hidden_field_tag "service_id", nil, "data-target": "autocomplete.hidden"
   = hidden_field_tag "anchor", nil, "data-target": "autocomplete.anchor"
-  = hidden_field_tag "sort", "_score"
+  = hidden_field_tag "sort", "_score", id: nil
 
   .searchbar__input
     %label.sr-only{ for: "search" } Search


### PR DESCRIPTION
Remove duplicated "sort" ids in services index
Fixes #1424