### PR TITLE
Update message order 

### DIFF
--- a/app/jobs/service/pc_create_or_update_job.rb
+++ b/app/jobs/service/pc_create_or_update_job.rb
@@ -7,9 +7,10 @@ class Service::PcCreateOrUpdateJob < ApplicationJob
     raise exception
   end
 
-  def perform(infra_service, eic_base_url, is_active)
+  def perform(infra_service, eic_base_url, is_active, modified_at)
     Service::PcCreateOrUpdate.new(infra_service,
-                                          eic_base_url,
-                                          is_active).call
+                                  eic_base_url,
+                                  is_active,
+                                  modified_at).call
   end
 end

--- a/lib/import/eic.rb
+++ b/lib/import/eic.rb
@@ -63,7 +63,6 @@ module Import
           .each do |service_data|
         service = service_data["service"]
         eid = service["id"]
-
         output.append(service_data)
         # TODO this should be moved to Offer.webpage
         url = service["webpage"]
@@ -189,13 +188,14 @@ module Import
             scientific_domains: [@scientific_domain_other],
             version: version || "",
             target_users: map_target_users(target_users),
-            last_update: last_update,
+            last_update: last_update ? Time.at(last_update&./1000) : Time.now,
             changelog: changelog,
             certifications: Array(certifications),
             standards: Array(standards),
             grant_project_names: Array(grant_project_names),
             open_source_technologies: Array(open_source_technologies)
         }
+
         begin
 
           if (service_source = ServiceSource.find_by(eid: eid, source_type: "eic")).nil?

--- a/spec/factories/eic_services_response.rb
+++ b/spec/factories/eic_services_response.rb
@@ -183,7 +183,7 @@ FactoryBot.define do
                         "West-Life"
                     ],
                     "version" => "1.0",
-                    "lastUpdate" => 1518912000000,
+                    "lastUpdate" => 1533513600000,
                     "changeLog" => [""],
                     "lifeCycleStatus" => "production",
                     "trl" => "trl-9",
@@ -318,7 +318,7 @@ FactoryBot.define do
                         "West-Life"
                     ],
                     "version" => "6.26",
-                    "lastUpdate" => 1537228800000,
+                    "lastUpdate" => 1518912000000,
                     "changeLog" => [""],
                     "lifeCycleStatus" => "production",
                     "trl" => "trl-9",

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     sequence(:status) { :published }
     sequence(:version) { nil }
     sequence(:trl) { [create(:trl)] }
+    sequence(:last_update) { Time.now - 2.days }
 
     upstream { nil }
 

--- a/spec/lib/import/eic_spec.rb
+++ b/spec/lib/import/eic_spec.rb
@@ -157,6 +157,7 @@ describe Import::Eic do
       expect(service.funding_programs).to eq([funding_program])
       expect(Service.find_by(name: "MetalPDB")).to_not be_nil
       expect(Service.find_by(name: "PDB_REDO server")).to_not be_nil
+      expect(service.last_update).to eq(Time.at(1533513600000/1000))
     end
 
     it "should create an offer for a new services" do

--- a/spec/services/jms/manage_message_spec.rb
+++ b/spec/services/jms/manage_message_spec.rb
@@ -20,9 +20,11 @@ describe Jms::ManageMessage do
   it "should receive service message" do
     original_stdout = $stdout
     $stdout = StringIO.new
-    expect(Service::PcCreateOrUpdateJob).to receive(:perform_later).with(parser.parse(service_resource["resource"])["infraService"]["service"],
+    resource = parser.parse(service_resource["resource"])
+    expect(Service::PcCreateOrUpdateJob).to receive(:perform_later).with(resource["infraService"]["service"],
                                                                          eic_base,
-                                                                         true)
+                                                                         true,
+                                                                         Time.new(resource["infraService"]["metadata"]["modifiedAt"]))
     expect {
       described_class.new(json_service, eic_base, logger).call
     }.to_not raise_error


### PR DESCRIPTION
Only accept the latest changes from jms.
Changed eic import of last_update to date format because we receiving int 
For provider this changes can be appied if Porvider model will be 

To merge after  #1601