### PR TITLE
Add `remove array element` in forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Default resource logo if not set (@goreck888)
 - Tours (@michal-szostak)
 - JIRA collector button (@michal-szostak)
+- Remove element for array inputs (@goreck888)
 
 ### Changed
 - Improved README readability and accessibility (@JanKapala, @wujuu)

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FormsHelper
+  def link_to_add_array_field(model, field_name)
+    content_tag(:a, "Add new " + t("simple_form.add_new_array_item.#{model}.#{field_name}"),
+                class: "text-primary",
+                data:  {
+                    action: "click->service#addNewArrayField",
+                    wrapper: "#{model}_#{field_name}",
+                    name: "#{model}[#{field_name}][]",
+                    class: "form-control text optional" })
+  end
+end

--- a/app/inputs/array_input.rb
+++ b/app/inputs/array_input.rb
@@ -5,14 +5,24 @@ class ArrayInput < SimpleForm::Inputs::TextInput
     input_html_options[:type] ||= input_type
     existing_value = Array(object.public_send(attribute_name)).map.with_index do |array_el, index|
       @builder.text_area(nil, input_html_options.merge(value: array_el,
-                                                        name: "#{object_name}[#{attribute_name}][]",
-                                                        id: "#{object_name}_#{attribute_name}_#{index}"))
+                                                       name: "#{object_name}[#{attribute_name}][]",
+                                                       id: "#{object_name}_#{attribute_name}_#{index}")) +
+          template.content_tag(:a, "Remove", id: "remove_#{object_name}_#{attribute_name}_#{index}",
+                               class: "btn btn-danger",
+                               "data-target": "#{attribute_name}",
+                               "data-action": "click->service#removeField",
+                               "data-value": "#{object_name}_#{attribute_name}_#{index}")
     end
     number = Array(object.public_send(attribute_name)).length
     existing_value.push @builder.text_area(nil,
-                                             input_html_options.merge(value: nil,
-                                                                      name: "#{object_name}[#{attribute_name}][]",
-                                                                      id: "#{object_name}_#{attribute_name}_#{number}"))
+                                           input_html_options.merge(value: nil,
+                                           name: "#{object_name}[#{attribute_name}][]",
+                                           id: "#{object_name}_#{attribute_name}_#{number}")) +
+                        template.content_tag(:a, "Remove", id: "remove-#{object_name}_#{attribute_name}_#{number}",
+                                             class: "btn btn-danger",
+                                             "data-target": "#{attribute_name}",
+                                             "data-action": "click->service#removeField",
+                                             "data-value": "#{object_name}_#{attribute_name}_#{number}")
     existing_value.join.html_safe
   end
 

--- a/app/javascript/app/controllers/service_controller.js
+++ b/app/javascript/app/controllers/service_controller.js
@@ -11,27 +11,34 @@ export default class extends Controller {
   }
 
   addNewArrayField(event) {
-    console.log(event)
-    event.preventDefault()
-    const lastArrayField = document.createElement("textarea")
-    const parent_name = event.target.dataset.wrapper
-    const parent = document.getElementsByClassName(parent_name)[0]
+    event.preventDefault();
+    const lastArrayField = document.createElement("textarea");
+    const parentName = event.target.dataset.wrapper;
+    const parent = document.getElementsByClassName(parentName)[0];
 
-    lastArrayField.name = event.target.dataset.name
-    lastArrayField.id = parent_name + "_" + (parent.children.length - 1)
-    lastArrayField.classList = event.target.dataset.class
+    lastArrayField.name = event.target.dataset.name;
+    lastArrayField.id = parentName + "_" + (parent.getElementsByTagName("textarea").length);
+    lastArrayField.classList = event.target.dataset.class;
 
-    parent.appendChild(lastArrayField)
+    const removeLink = document.createElement("a");
+
+    const linkText = document.createTextNode("Remove")
+
+    removeLink.id = "remove_" + lastArrayField.id;
+    removeLink.dataset.target= event.target;
+    removeLink.dataset.action= "click->service#removeField";
+    removeLink.dataset.value= lastArrayField.id;
+    removeLink.appendChild(linkText);
+    removeLink.classList.add("btn", "btn-danger");
+
+    parent.appendChild(lastArrayField);
+    parent.appendChild(removeLink);
   }
 
-  _clearEmptyFields(target){
-    for (let i = 0; i < target.childElementCount; i++) {
-      var el = target.children[i]
-      if(!el.value) {
-        target.children[i].remove()
-        i = i - 1
-      }
-    }
+  removeField(event) {
+    event.preventDefault();
+    document.getElementById(event.target.dataset.value).remove();
+    event.target.remove();
   }
 
   addContact(event){
@@ -44,17 +51,5 @@ export default class extends Controller {
     event.preventDefault();
     event.target.parentElement.previousElementSibling.value = "true";
     event.target.closest(".contact").classList.add("d-none");
-  }
-
-  onSubmit(event) {
-    this._clearEmptyFields(this.multimediaTarget)
-    this._clearEmptyFields(this.changelogTarget)
-    this._clearEmptyFields(this.certificationsTarget)
-    this._clearEmptyFields(this.standardsTarget)
-    this._clearEmptyFields(this.openSourceTechnologiesTarget)
-    this._clearEmptyFields(this.grantProjectNamesTarget)
-    this._clearEmptyFields(this.useCasesUrlTarget)
-    this._clearEmptyFields(this.relatedPlatformsTarget)
-    this.element.submit();
   }
 }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -9,6 +9,8 @@ class Service < ApplicationRecord
 
   acts_as_taggable
 
+  before_save :remove_empty_array_fields
+
   has_one_attached :logo
 
   enum order_type: {
@@ -308,6 +310,15 @@ class Service < ApplicationRecord
 
 
   private
+    def remove_empty_array_fields
+      array_fields = [:multimedia, :use_cases_url, :certifications,
+                      :standards, :open_source_technologies,
+                      :changelog, :related_platforms, :grant_project_names]
+      array_fields.each do |field|
+        send(field).present? ? send(:"#{field}=", send(field).reject(&:blank?)) : send(:"#{field}=", [])
+      end
+    end
+
     def open_access_or_external?
       open_access? || external
     end

--- a/app/views/backoffice/services/_array_field.html.haml
+++ b/app/views/backoffice/services/_array_field.html.haml
@@ -1,1 +1,0 @@
-%textarea{ name: name, id: id, class: classList }

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -49,17 +49,11 @@
         = f.input :multimedia, multiple: true, input_html: { class: "form-control" },
           wrapper_html: { "data-target" => "service.multimedia" },
           disabled: cant_edit([multimedia: []]), as: :array
-        %a.text-primary{ "data-action" => "click->service#addNewArrayField",
-          "data-wrapper" => "service_multimedia",
-          "data-name" => "service[multimedia[]]",
-          "data-class" => "form-control text optional" } Add additional entry
+        = link_to_add_array_field("service", "multimedia")
         = f.input :use_cases_url, multiple: true, as: :array, input_html: { class: "form-control text optional" },
           wrapper_html: { "data-target" => "service.useCasesUrl" },
           disabled: cant_edit([use_cases_url: []])
-        %a.text-primary{ "data-action" => "click->service#addNewArrayField",
-          "data-wrapper" => "service_use_cases_url",
-          "data-name" => "service[service_use_cases_url[]]",
-          "data-class" => "form-control text optional" } Add new
+        = link_to_add_array_field("service", "use_cases_url")
     .card.shadow-sm.rounded
       %button.btn.btn-link{ type: "button", class: ("collapsed" if collapsed?(service,
         [:scientific_domains, :pc_categories, :categories, :target_users, :access_types, :access_modes, :tag_list])),
@@ -215,24 +209,15 @@
         = f.input :certifications, multiple: true, input_html: { class: "form-control text optional" },
           wrapper_html: { "data-target" => "service.certifications" },
           disabled: cant_edit([certifications: []]), as: :array
-        %a.text-primary{ "data-action" => "click->service#addNewArrayField",
-          "data-wrapper" => "service_certifications",
-          "data-name" => "service[service_certifications[]]",
-          "data-class" => "form-control text optional" } Add new
+        = link_to_add_array_field("service", "certifications")
         = f.input :standards, multiple: true, input_html: { class: "form-control text optional" },
           wrapper_html: { "data-target" => "service.standards" },
           disabled: cant_edit([standards: []]), as: :array
-        %a.text-primary{ "data-action" => "click->service#addNewArrayField",
-          "data-wrapper" => "service_standards",
-          "data-name" => "service[service_standards[]]",
-          "data-class" => "form-control text optional" } Add new
+        = link_to_add_array_field("service", "standards")
         = f.input :open_source_technologies, multiple: true, input_html: { class: "form-control text optional" },
           wrapper_html: { "data-target" => "service.openSourceTechnologies" },
           disabled: cant_edit([open_source_technologies: []]), as: :array
-        %a.text-primary{ "data-action" => "click->service#addNewArrayField",
-          "data-wrapper" => "service_open_source_technologies",
-          "data-name" => "service[service_open_source_technologies[]]",
-          "data-class" => "form-control text optional" } Add new
+        = link_to_add_array_field("service", "open_source_technologies")
         = f.input :version, disabled: cant_edit(:version)
         = f.input :last_update, as: :date_time_picker, disabled: cant_edit(:last_update)
 
@@ -242,10 +227,7 @@
              wrapper_html: { "data-target" => "service.changelog" },
              input_html: { class: "form-control text optional" }
 
-            %a.text-primary{ "data-action" => "click->service#addNewArrayField",
-              "data-wrapper" => "service_changelog",
-              "data-name" => "service[changelog[]]",
-              "data-class" => "form-control text optional" } Add new
+            = link_to_add_array_field("service", "changelog")
 
     .card.shadow-sm.rounded
       %button.btn.btn-link{ type: "button", class: ("collapsed" if collapsed?(service,
@@ -275,10 +257,7 @@
           input_html: { class: "form-control" },
           wrapper_html: { "data-target" => "service.relatedPlatforms" },
           disabled: cant_edit([related_platforms: []]), as: :array
-        %a.text-primary{ "data-action" => "click->service#addNewArrayField",
-          "data-wrapper" => "service_related_platforms",
-          "data-name" => "service[related_platforms[]]",
-          "data-class" => "form-control text optional" } Add additional entry
+        = link_to_add_array_field("service", "related_platforms")
 
     .card.shadow-sm.rounded
       %button.btn.btn-link{ type: "button", class: ("collapsed" if collapsed?(service,
@@ -305,10 +284,7 @@
             = f.input :grant_project_names, input_html: { class: "form-control text optional" },
               wrapper_html: { "data-target" => "service.grantProjectNames" },
               disabled: cant_edit([grant_project_names: []]), as: :array
-            %a.text-primary{ "data-action" => "click->service#addNewArrayField",
-              "data-wrapper" => "service_grant_project_names",
-              "data-name" => "service[service_grant_project_names[]]",
-              "data-class" => "form-control text optional" } Add new
+            = link_to_add_array_field("service", "grant_project_names")
 
     .card.shadow-sm.rounded
       %button.btn.btn-link{ type: "button", class: ("collapsed" if collapsed?(service,

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,5 +1,15 @@
 en:
   simple_form:
+    add_new_array_item:
+      service:
+        multimedia: multimedia
+        use_cases_url: use case url
+        certifications: certification
+        standards: standard
+        open_source_technologies: open source technology
+        grant_project_names: grant/project name
+        changelog: changelog entry
+        related_platforms: related platform
     "yes": 'Yes'
     "no": 'No'
     required:
@@ -23,6 +33,7 @@ en:
       project_item:
         additional_comment: Please enter additional details of your request
       service:
+        grant_project_names: Grant/Project names
         required_services: Required Resources
         related_services: Related Resources
       user:


### PR DESCRIPTION
In the backoffice service form added remove link for array fields: multimedia, use_cases_url, changelog, related_platforms etc.