### PR TITLE
Add `errored` status to the imported resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - Add and configure split gem (@goreck888)
+- Errored status for imported resources (@goreck888)
 
 ### Changed
 - Backoffice front-end mods (@jarekzet)

--- a/app/helpers/backoffice/services_helper.rb
+++ b/app/helpers/backoffice/services_helper.rb
@@ -5,6 +5,7 @@ module Backoffice::ServicesHelper
     "published" => "badge-success",
     "unverified" => "badge-warning",
     "draft" => "badge-error",
+    "errored" => "badge-error",
     "deleted" => "badge-error"
   }
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -33,6 +33,7 @@ class Service < ApplicationRecord
     published: "published",
     unverified: "unverified",
     draft: "draft",
+    errored: "errored",
     deleted: "deleted"
   }
 

--- a/app/services/service/pc_create_or_update.rb
+++ b/app/services/service/pc_create_or_update.rb
@@ -33,9 +33,15 @@ class Service::PcCreateOrUpdate
     if mapped_service.nil? && @is_active
       service = Service.new(service)
       save_logo(service, @eic_service["logo"])
-
-      if Service::Create.new(service).call
+      if service.valid?
+        if Service::Create.new(service).call
+          ServiceSource.create!(service_id: service.id, source_type: "eic", eid: @eid)
+        end
+      else
+        service.status = "errored"
+        service.save(validate: false)
         ServiceSource.create!(service_id: service.id, source_type: "eic", eid: @eid)
+
       end
       service
     elsif is_newer_update

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -141,6 +141,8 @@ en:
           draft: "Draft"
           published: "Published"
           unverified: "Published as unverified"
+          errored: "Errored"
+          deleted: "Deleted"
     project_item:
         status:
           created: Created


### PR DESCRIPTION
When resource has validation errors it saves as resource
with errored state