### PR TITLE
[#1726] remove recommendations from services list at backoffice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Added
 
 ### Changed
+- Replace will_paginate with pagy gem (@goreck888)
 
 ### Deprecated
 
@@ -18,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - split rspec issues (@kmarszalek)
+- Show recommendations only in the regular services catalogue - not in backoffice (@JanKapala)
 
 ## [3.7.0] 2021-02-02
 

--- a/app/views/backoffice/services/index.html.haml
+++ b/app/views/backoffice/services/index.html.haml
@@ -26,5 +26,6 @@
                            filters: @filters,
                            active_filters: @active_filters,
                            offers: @offers,
-                           comparison_enabled: @comparison_enabled
+                           comparison_enabled: @comparison_enabled,
+                           show_recommendations: false
 

--- a/app/views/backoffices/show.html.haml
+++ b/app/views/backoffices/show.html.haml
@@ -24,13 +24,18 @@
 .row
   .col-12
     .btn-toolbar
-      %a.btn.btn-primary.d-block.mt-4{ href: "/backoffice/services" }
-        = _("Owned resources")
-      %a.btn.btn-primary.d-block.mt-4.ml-3{ href: "/backoffice/scientific_domains" }
-        = _("Scientific domains")
-      %a.btn.btn-primary.d-block.mt-4.ml-3{ href: "/backoffice/categories" }
-        = _("Categories")
-      %a.btn.btn-primary.d-block.mt-4.ml-3{ href: "/backoffice/providers" }
-        = _("Providers")
-      %a.btn.btn-primary.d-block.mt-4.ml-3{ href: "/backoffice/platforms" }
-        = _("Platforms")
+      %a
+        = link_to _("Owned resources"), backoffice_services_path,
+                  class: "btn btn-primary d-block mt-4"
+      %a
+        = link_to _("Scientific domains"), backoffice_scientific_domains_path,
+                  class: "btn btn-primary d-block mt-4 ml-3"
+      %a
+        = link_to _("Categories"), backoffice_categories_path,
+                  class: "btn btn-primary d-block mt-4 ml-3"
+      %a
+        = link_to _("Providers"), backoffice_providers_path,
+                  class: "btn btn-primary d-block mt-4 ml-3"
+      %a
+        = link_to _("Platforms"), backoffice_platforms_path,
+                  class: "btn btn-primary d-block mt-4 ml-3"

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -10,9 +10,10 @@
     .col-lg-9
       .row.mb-4
         = render "services/active_filters", category: category, active_filters: active_filters
-        - if ab_test(:recommendation_panel) == "v1"
-          = render partial: "services/recommendation_panel_v1",
-                   locals: { highlights: highlights, category: category }
+        - if (not defined? show_recommendations) || show_recommendations
+          - if ab_test(:recommendation_panel) == "v1"
+            = render partial: "services/recommendation_panel_v1",
+                     locals: { highlights: highlights, category: category }
         = render "services/pagination", sort_options: sort_options, services: services, pagy: pagy
 
       %p
@@ -22,9 +23,11 @@
                            offers: offers,
                            comparison_enabled: comparison_enabled,
                            remote: true }
-        - if ab_test(:recommendation_panel) == "v2"
-          = render partial: "services/recommendation_panel_v2",
-                   locals: { highlights: highlights, category: category }
+
+        - if (not defined? show_recommendations) || show_recommendations
+          - if ab_test(:recommendation_panel) == "v2"
+            = render partial: "services/recommendation_panel_v2",
+                     locals: { highlights: highlights, category: category }
         = render partial: "service", collection: services[2..],
                  locals: { highlights: highlights,
                            category: category,


### PR DESCRIPTION
This PR closes #1726  issue that include turning off recommendations in the backoffice.

### What has changed?
* **Old behaviour**
Recommendations are visible in `services catalog` and in `Owned resources` view at backoffice.
* **New behaviour**
Now recommendations are displayed only in `services catalog` - not in backoffice `Owned resources` view.



### How to manually test (for reviewers):
On master turn on recommendations and go to both `/services` and `/backoffice/services`. You should see recommendations on services lists in both cases.

On this branch turn on recommendations and  go to both `/services` and `/backoffice/services`. You should see recommendations on services list only in the first case.

PS.: **How to turn on recommendations**: go to `Admin` -> `AB experiments`, choose version `v1` or `v2` and click `Force for current user` button.


