### PR TITLE
[HOTFIX] Disable split experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Split experiments in recommendations view (@goreck888)
 
 ## [3.4.0] 2020-12-22
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -32,8 +32,7 @@ class ServicesController < ApplicationController
       @client = @client&.credentials&.expires_at.blank? ? Google::Analytics.new : @client
       @analytics = Analytics::PageViewsAndRedirects.new(@client).call(request.path)
     end
-
-    ab_finished(:recommendation_panel, reset: false) if params[:from_recommendation_panel]
+    # TODO: add ab_finished to run split recommendations experiment
   end
 
   private

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -1,3 +1,4 @@
+-# TODO: add ab_test for enable split experiment
 .container
   .row
     .col-lg-3.mb-5
@@ -10,22 +11,10 @@
     .col-lg-9
       .row.mb-4
         = render "services/active_filters", category: category, active_filters: active_filters
-        - ab_test(:recommendation_panel) do |version|
-          = render partial: "services/recommendation_panel_v1",
-                   locals: { highlights: highlights, category: category } if version == "v1"
         = render "services/pagination", sort_options: sort_options, services: services
 
       %p
-        = render partial: "service", collection: services[0..1],
-                 locals: { highlights: highlights,
-                           category: category,
-                           offers: offers,
-                           comparison_enabled: comparison_enabled,
-                           remote: true }
-        - ab_test(:recommendation_panel) do |version|
-          = render partial: "services/recommendation_panel_v2",
-                   locals: { highlights: highlights, category: category } if version == "v2"
-        = render partial: "service", collection: services[2..],
+        = render partial: "service", collection: services,
                  locals: { highlights: highlights,
                            category: category,
                            offers: offers,


### PR DESCRIPTION
Disable split experiment in recommendations view.
May fix possible problem with puma memory use increasing and overflow