### PR TITLE
[#1716] Add more fields to the comparison view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- More fields to the comparision view (@kmarszalek)
 
 ### Changed
 - Footer content (@goreck888)

--- a/app/views/comparisons/show.html.haml
+++ b/app/views/comparisons/show.html.haml
@@ -30,50 +30,97 @@
           %td.title-col.empty.text-uppercase
             = link_to _("Add next resource"), services_path
       %tr
-        %th
-          = _("Providers")
+        %th{ "data-toggle": "tooltip",
+        title: "The name(s) (or abbreviation(s)) of Provider(s) that manage or deliver the Resource in |
+        federated scenarios." } |
+          = _("Resource Providers")
         - @services.each do |service|
           %td= service.providers.map { |p| p.name }.join(", ")
       %tr.lightgrey-row
-        %th
-          = _("Resource order type")
+        %th{ "data-toggle": "tooltip",
+        title: "The branch of science, scientific discipline that is related to the Resource." }
+          = _("Scientific Domain")
         - @services.each do |service|
           %td
-            = render Services::InlineOrderTypeComponent.new(:span, order_type(service))
+            %dl
+              - field_tree(service, :scientific_domains).each do |parent, children|
+                %dt
+                  %span
+                    = parent
+                - children.each do |child|
+                  %dd
+                    %span= child
       %tr
-        %th
-          = _("Scientific domain")
+        %th{ "data-toggle": "tooltip",
+        title: "A named group of Resources that offer access to the same type of Resource or capabilities." }
+          = _("Categorisation")
         - @services.each do |service|
-          %td= service.scientific_domains .map { |sd| sd.name }.join(", ")
+          %td
+            %dl
+              - field_tree(service, :pc_categories).each do |parent, children|
+                %dt
+                  %span
+                    = parent
+                - children.each do |child|
+                  %dd
+                    %span= child
       %tr.lightgrey-row
-        %th
-          = _("Dedicated for")
+        %th{ "data-toggle": "tooltip",
+        title: "Type of users/customers that commissions a Provider to deliver a Resource." }
+          = _("Target Users")
         - @services.each do |service|
           %td= service.target_users.map { |tg| tg.name }.join(", ")
       %tr
-        %th
-          = _("Resource life cycle status")
+        %th{ "data-toggle": "tooltip",
+        title: "The way a user can access the Resource (Remote, Physical, Virtual, etc.)" }
+          = _("Resource Access Type")
         - @services.each do |service|
-          - if service.life_cycle_status.present?
-            %td= service.life_cycle_status.first.name
+          %td= service.access_types.map { |tg| tg.name }.join(", ")
       %tr.lightgrey-row
-        %th
-          = _("Geographical availabilities")
+        %th{ "data-toggle": "tooltip",
+        title: "Eligibility/criteria for granting access to users (excellence-based, free-conditionally, free etc.)" }
+          = _("Resource Access Mode")
         - @services.each do |service|
-          %td= service.geographical_availabilities.join(", ")
+          %td= service.access_modes.map { |sd| sd.name }.join(", ")
       %tr
-        %th
-          = _("Languages")
-        - @services.each do |service|
-          %td
-            %ul
-            - service.language_availability.each do |language|
-              %li= I18nData.languages[language.upcase] || language
-
-      %tr.lightgrey-row
-        %th
+        %th{ "data-toggle": "tooltip",
+        title: "Keywords associated to the Resource to simplify search by relevant keywords." }
           = _("Tags")
         - @services.each do |service|
           %td
             - service.tag_list.sort.each do |tag|
               = link_to tag, services_path(tag: tag), class: "badge badge-light"
+      %tr.lightgrey-row
+        %th{ "data-toggle": "tooltip", title: "Locations where the Resource is offered." }
+          = _("Geographical Availability")
+        - @services.each do |service|
+          %td= service.geographical_availabilities.join(", ")
+      %tr
+        %th{ "data-toggle": "tooltip", title: "Languages of the (user interface of the) Resource." }
+          = _("Language Availability")
+        - @services.each do |service|
+          %td
+            %ul
+            - service.language_availability.each do |language|
+              %li= I18nData.languages[language.upcase] || language
+      %tr.lightgrey-row
+        %th{ "data-toggle": "tooltip",
+        title: "The Technology Readiness Level of the Resource updated in the context of the EOSC." }
+          = _("Technology Readiness Level")
+        - @services.each do |service|
+          %td{ "data-toggle": "tooltip", title: service.trl.present? ? trl_description_text(service) : nil }
+            = service.trl.map { |trl| trl.name.upcase }.join(", ")
+      %tr
+        %th{ "data-toggle": "tooltip", title: "Phase of the Resource life-cycle." }
+          = _("Resource Life Cycle Status")
+        - @services.each do |service|
+          - if service.life_cycle_status.present?
+            %td= service.life_cycle_status.first.name
+      %tr.lightgrey-row
+        %th{ "data-toggle": "tooltip",
+        title: "Information on the order type (requires an ordering procedure, or no ordering and if fully open or |
+        requires authentication)" } |
+          = _("Resource Order Type")
+        - @services.each do |service|
+          %td
+            = render Services::InlineOrderTypeComponent.new(:span, order_type(service))

--- a/spec/features/comparison_spec.rb
+++ b/spec/features/comparison_spec.rb
@@ -89,42 +89,42 @@ RSpec.feature "Comparison", js: true do
     expect(page).to have_content(service2.name)
     expect(page).to have_content(service3.name)
 
-    expect(page).to have_text("Providers")
+    expect(page).to have_text("Resource Providers")
 
     expect(page).to have_text(service1.providers.map(&:name).join(", "))
     expect(page).to have_text(service2.providers.map(&:name).join(", "))
     expect(page).to have_text(service3.providers.map(&:name).join(", "))
 
-    expect(page).to have_text("Resource order type")
+    expect(page).to have_text("Resource Order Type")
 
     expect(page).to have_text("Open Access")
     expect(page).to have_text("Order Required").twice
 
-    expect(page).to have_text("Scientific domain")
+    expect(page).to have_text("Scientific Domain")
 
     expect(page).to have_text(service1.scientific_domains.map(&:name).join(", "))
     expect(page).to have_text(service2.scientific_domains.map(&:name).join(", "))
     expect(page).to have_text(service3.scientific_domains.map(&:name).join(", "))
 
-    expect(page).to have_text("Dedicated for")
+    expect(page).to have_text("Target Users")
 
     expect(page).to have_text(service1.target_users.map(&:name).join(", "))
     expect(page).to have_text(service2.target_users.map(&:name).join(", "))
     expect(page).to have_text(service3.target_users.map(&:name).join(", "))
 
-    expect(page).to have_text("Resource life cycle status")
+    expect(page).to have_text("Resource Life Cycle Status")
 
     expect(page).to have_text(service1.life_cycle_status.map(&:name).join(", "))
     expect(page).to have_text(service2.life_cycle_status.map(&:name).join(", "))
     expect(page).to have_text(service3.life_cycle_status.map(&:name).join(", "))
 
-    expect(page).to have_text("Geographical availabilities")
+    expect(page).to have_text("Geographical Availability")
 
     expect(page).to have_text("Greece")
     expect(page).to have_text("Poland, Germany")
     expect(page).to have_text("European Union")
 
-    expect(page).to have_text("Languages")
+    expect(page).to have_text("Language Availability")
 
     expect(page).to have_text(service1.languages.join(", "))
     expect(page).to have_text(service2.languages.join(", "))
@@ -135,6 +135,21 @@ RSpec.feature "Comparison", js: true do
     expect(page).to have_selector("a[href='/services?tag=tag1']")
     expect(page).to have_selector("a[href='/services?tag=tag2']")
     expect(page).to have_selector("a[href='/services?tag=tag3']")
+
+    expect(page).to have_text("Technology Readiness Level")
+
+    expect(page).to have_text(service1.trl.first.name.upcase)
+    expect(page).to have_text(service2.trl.first.name.upcase)
+    expect(page).to have_text(service3.trl.first.name.upcase)
+
+    expect(page).to have_text("Resource Access Type")
+    expect(page).to have_text("Resource Access Mode")
+
+    expect(page).to have_text("Categorisation")
+
+    expect(page).to have_text(service1.categories.map(&:name).join(", "))
+    expect(page).to have_text(service2.categories.map(&:name).join(", "))
+    expect(page).to have_text(service3.categories.map(&:name).join(", "))
   end
 
   it "deletes service from comparison on comparison page" do


### PR DESCRIPTION
- added more fields
- using https://docs.cyfronet.pl/display/FID/RDT+%28ERV%29+Resource+Profile as a reference point for fields labels after slack conversation with @bwilk 
Closes #1716 