### PR TITLE
[#1731] Add ActiveStorage queues to sidekiq configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Fixed
 - Filter save by breadcrumbs navigation test (@goreck888)
 - Filter Provider location to use geographical_availabilities (@kmarszalek)
+- ActiveStorage analysis and purge queues in sidekiq configurations (@goreck888)
 
 ## [3.4.0] 2020-12-22
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -p $PORT
-jobs: bundle exec sidekiq -q pc_subscriber -q orders -q mailers -q reports -q default -q active_storage_analysis -q active_storage_purge
+jobs: bundle exec sidekiq -q active_storage_analysis -q active_storage_purge -q pc_subscriber -q orders -q mailers -q reports -q default

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,5 @@
 web: bundle exec rails s
 # watcher: ./bin/webpack-watcher
 webpacker: ./bin/webpack-dev-server
-jobs: bundle exec sidekiq -q pc_subscriber -q orders -q mailers -q reports -q default
+jobs: bundle exec sidekiq -q active_storage_analysis -q active_storage_purge -q pc_subscriber -q orders -q mailers -q reports -q default
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,9 @@ module Mp
 
     config.redis_url = ENV["REDIS_URL"] || default_redis_url
 
+    config.active_storage.queues.analysis = :active_storage_analysis
+    config.active_storage.queues.purge = :active_storage_purge
+
     config.matomo_url = ENV["MP_MATOMO_URL"] || "//providers.eosc-portal.eu/matomo/"
     config.matomo_site_id = ENV["MP_MATOMO_SITE_ID"] || 1
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,6 +9,8 @@ staging:
   :concurrency: 5
 
 :queues:
+  - active_storage_analysis
+  - active_storage_purge
   - pc_subscriber
   - orders
   - mailers


### PR DESCRIPTION
Add missing ActiveStorage analysis and purge queues
to sidekiq jobs and add queues names to config before update
rails to 6.1
Fixes #1731