### PR TITLE
[#1725] Fix split rspec issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- split rspec issues (@kmarszalek)
 
 ## [3.7.0] 2021-02-02
 

--- a/app/helpers/recommender_system_helper.rb
+++ b/app/helpers/recommender_system_helper.rb
@@ -2,12 +2,11 @@
 
 module RecommenderSystemHelper
   def get_naive_recommendation
-    ab_test(:recommendation_panel) do |version|
-      if version == "v1"
-        Recommender::SimpleRecommender.new.call 3
-      elsif version == "v2"
-        Recommender::SimpleRecommender.new.call 2
-      end
+    version = ab_test(:recommendation_panel)
+    if version == "v1"
+      Recommender::SimpleRecommender.new.call 3
+    elsif version == "v2"
+      Recommender::SimpleRecommender.new.call 2
     end
   end
 end

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -10,9 +10,9 @@
     .col-lg-9
       .row.mb-4
         = render "services/active_filters", category: category, active_filters: active_filters
-        - ab_test(:recommendation_panel) do |version|
+        - if ab_test(:recommendation_panel) == "v1"
           = render partial: "services/recommendation_panel_v1",
-                   locals: { highlights: highlights, category: category } if version == "v1"
+                   locals: { highlights: highlights, category: category }
         = render "services/pagination", sort_options: sort_options, services: services, pagy: pagy
 
       %p
@@ -22,9 +22,9 @@
                            offers: offers,
                            comparison_enabled: comparison_enabled,
                            remote: true }
-        - ab_test(:recommendation_panel) do |version|
+        - if ab_test(:recommendation_panel) == "v2"
           = render partial: "services/recommendation_panel_v2",
-                   locals: { highlights: highlights, category: category } if version == "v2"
+                   locals: { highlights: highlights, category: category }
         = render partial: "service", collection: services[2..],
                  locals: { highlights: highlights,
                            category: category,

--- a/config/initializers/split.rb
+++ b/config/initializers/split.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'split/dashboard'
+include Split::Helper
 
 cookie_adapter = Split::Persistence::CookieAdapter
 redis_adapter = Split::Persistence::RedisAdapter.with_config(

--- a/spec/features/service_recommendations_spec.rb
+++ b/spec/features/service_recommendations_spec.rb
@@ -4,35 +4,40 @@ require "rails_helper"
 
 RSpec.feature "recommended services panel", type: :feature do
   include OmniauthHelper
+  include SimpleRecommenderSpecHelper
 
   before do
     checkin_sign_in_as(create(:user))
     resources_selector = "body main div:nth-child(2).container div.container div.row div.col-lg-9"
-    bar_selector = "div.row.mb-4 div:nth-child(2).col-md-12"
+    bar_selector = "div.row.mb-4 div:nth-child(2).mb-4"
     recommended_service_selector = "div.container div.row mb-4 div:nth-child(1).service-info-box.recommendation"
 
     @recommended_services_bar = resources_selector + " " + bar_selector
     @recommended_services = resources_selector + " " + recommended_service_selector
+
+    @categories, @services = populate_database
   end
 
-  xit "has no recommendations if they are disabled" do
+  it "has no recommendations if they are disabled", js: true do
     use_ab_test(recommendation_panel: "disabled")
     visit services_path
 
     expect(page).to_not have_content(_("RECOMMENDED"))
   end
 
-  xit "has header with 'RECOMMENDED' box in version 1" do
+  it "has header with 'RECOMMENDED' box in version 1", js: true do
     use_ab_test(recommendation_panel: "v1")
     visit services_path
 
+    expect(page).to have_content(_("RECOMMENDED"))
     expect(find(@recommended_services_bar)).to have_content(_("RECOMMENDED"))
   end
 
-  xit "has 'RECOMMENDED' box in each recommended service in version 2" do
+  it "has 'RECOMMENDED' box in each recommended service in version 2", js: true do
     use_ab_test(recommendation_panel: "v2")
     visit services_path
 
+    expect(page).to have_content(_("RECOMMENDED"))
     all(@recommended_services).each do |element|
       expect(element.has_css?(".recommend-box"))
       expect(element).to have_text(_("RECOMMENDED"))

--- a/spec/helpers/recommender_system_helper_spec.rb
+++ b/spec/helpers/recommender_system_helper_spec.rb
@@ -3,14 +3,20 @@
 require "rails_helper"
 
 RSpec.describe RecommenderSystemHelper, type: :helper do
-  xit "returns list of 3 services for version 1 of recommendation" do
+  include SimpleRecommenderSpecHelper
+
+  before do
+    @categories, @services = populate_database
+  end
+
+  it "returns list of 3 services for version 1 of recommendation" do
     use_ab_test(recommendation_panel: "v1")
 
     recommended_services = get_naive_recommendation
     expect(recommended_services.count).to eq 3
   end
 
-  xit "returns list of 2 services for version 2 of recommendation" do
+  it "returns list of 2 services for version 2 of recommendation" do
     use_ab_test(recommendation_panel: "v2")
 
     recommended_services = get_naive_recommendation


### PR DESCRIPTION
- make tests green
* [x] has no recommendations if they are disabled
* [x] has header with 'RECOMMENDED' box in version 1
* [x] has 'RECOMMENDED' box in each recommended service in version 2
* [x] returns list of 3 services for version 1 of recommendation
* [x] returns list of 2 services for version 2 of recommendation

Closes #1725 