### PR TITLE
[#1746] Move from deprecated service to resource API in PC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Replace will_paginate with pagy gem (@goreck888)
+- Move from deprecated `service` API to `resource` API in Providers component (@goreck888)
 
 ### Deprecated
 

--- a/lib/import/eic.rb
+++ b/lib/import/eic.rb
@@ -31,13 +31,13 @@ module Import
       begin
         unless @token.blank?
           http_response = RestClient::Request.execute(method: :get,
-                                              url: "#{@eic_base_url}/service/rich/all?quantity=10000&from=0",
+                                              url: "#{@eic_base_url}/resource/rich/all?quantity=10000&from=0",
                                               headers: { Accept: "application/json",
                                                          Authorization: "Bearer #{@token}" })
 
           r = Unirest::HttpResponse.new(http_response)
         else
-          r = @unirest.get("#{@eic_base_url}/service/rich/all?quantity=10000&from=0",
+          r = @unirest.get("#{@eic_base_url}/resource/rich/all?quantity=10000&from=0",
                            headers: { "Accept" => "application/json" })
         end
       rescue Errno::ECONNREFUSED

--- a/spec/lib/import/eic_spec.rb
+++ b/spec/lib/import/eic_spec.rb
@@ -63,7 +63,7 @@ describe Import::Eic do
 
   def expect_responses(unirest, test_url, services_response = nil, providers_response = nil)
     unless services_response.nil?
-      expect(unirest).to receive(:get).with("#{test_url}/service/rich/all?quantity=10000&from=0",
+      expect(unirest).to receive(:get).with("#{test_url}/resource/rich/all?quantity=10000&from=0",
                                             headers: { "Accept" => "application/json" }).and_return(services_response)
     end
 


### PR DESCRIPTION
Run import:eic task with `resource` api
instead of deprecated `service` api
Fixes #1746