### PR TITLE
[#1767] Add and configure Puma Killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,3 +123,6 @@ end
 
 gem "unirest"
 gem "reverse_markdown"
+
+# Fix for puma memory leak
+gem "puma_worker_killer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
     ffi (1.12.2)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
     gettext (3.3.6)
       locale (>= 2.0.5)
       text (>= 1.3.0)
@@ -311,6 +313,9 @@ GEM
     public_suffix (4.0.3)
     puma (4.3.5)
       nio4r (~> 2.0)
+    puma_worker_killer (0.3.1)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     racc (1.5.2)
@@ -643,6 +648,7 @@ DEPENDENCIES
   pry-rails
   public_suffix
   puma (~> 4.3)
+  puma_worker_killer
   pundit (~> 2.0)
   rack_session_access
   rails (= 6.0.3.2)


### PR DESCRIPTION
- set up the gem to:
  - kill largest worker
  - prevent cyclic kill of all workers

# ENV PARAMS
**PUMA_KILLER_ENABLE**
Default: false
_Turn on `Puma workers killer`_

**PUMA_KILLER_MACHINE_RAM_MB**
Default: 7168 (MB)
_All available RAM in MB for Machine_

**PUMA_KILLER_RAM_UTILIZATION_PERCENT**
Default: 0.07 (500MB)
_Percent of all available RAM that can be in use by `Puma`_

**PUMA_KILLER_CHECK_FREQ**
Default: 10 sec
_Frequency of `Puma worker killer` RAM usage checkout_

# Logs
On each worker kill:
_"Worker {@cluster.largest_worker.nr} (pid: {@cluster.largest_worker.pid}) - will be terminated"_