### PR TITLE
1800 details view countries order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Highcharts scalability for the resource and provider views (@kmarszalek, @jarekzet)
 
 ### Changed
-- Geographical availabilities order in the Resource details view (@kmarszalek)
+- Geographical availabilities order in the Resource details view (@kmarszalek, @jarekzet)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Highcharts scalability for the resource and provider views (@kmarszalek, @jarekzet)
 
 ### Changed
+- Geographical availabilities order in the Resource details view (@kmarszalek)
 
 ### Deprecated
 

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -141,4 +141,12 @@ module ServiceHelper
       edit_backoffice_service_offer_path(service, offer)
     end
   end
+
+  def get_only_regions(locations)
+    Country.regions & locations
+  end
+
+  def get_only_countries(locations)
+    locations.reject { |c| Country.regions.include? c }
+  end
 end

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -4069,8 +4069,8 @@ textarea.form-control.is-invalid {
       padding-left: 0;
 
       li {
-        margin: 0 0 6px 1rem;
-        padding: 0 0.2rem;
+        margin: 0 0 10px 1rem;
+        padding: 0;
         color: $palette-yellow;
         line-height: 1.15;
         font-size: 1.1rem;
@@ -4107,6 +4107,12 @@ textarea.form-control.is-invalid {
         span {
           color: $body-color;
           font-size: 0.875rem;
+
+          &.geographical {
+            padding-top: 15px;
+            float: left;
+            width: 100%;
+          }
         }
       }
     }

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -6,6 +6,8 @@ class Country
               "IS", "IT", "LI", "LT", "LU", "LV",
               "MT", "NL", "NO", "PL", "PT", "SE", "SI", "SK"].freeze
 
+  REGIONS = ["WW", "EO", "EU", "EZ", "AH"].freeze
+
   ISO3166::Data.register(
     alpha2: "WW",
     name: "World",
@@ -130,6 +132,10 @@ class Country
 
     def convert(name)
       regions_for_country(name).blank? ? convert_name_to_code(name) : convert_to_regions_add_country(name)
+    end
+
+    def regions
+      Country::REGIONS.map { |p| ISO3166::Country.new(p) }
     end
 
     def convert_name_to_code(name)

--- a/app/views/services/details/_array.html.haml
+++ b/app/views/services/details/_array.html.haml
@@ -12,10 +12,9 @@
       - elsif field == "geographical_availabilities"
         %span
           = get_only_regions(service.send(field)).join(", ")
-          - unless get_only_regions(service.send(field)).empty?
-            %br
-        %span
-          = get_only_countries(service.send(field)).sort.join(", ")
+        - if get_only_countries(service.send(field)).present?
+          %span.geographical
+            = get_only_countries(service.send(field)).sort.join(", ")
       - else
         - Array(service.send(field)).map.with_index do |element, idx|
           - if nested.present? && nested[field.to_sym].present?

--- a/app/views/services/details/_array.html.haml
+++ b/app/views/services/details/_array.html.haml
@@ -9,6 +9,13 @@
       - if service.send(field).is_a?(ActiveSupport::TimeWithZone)
         %span
           = service.send(field).to_date
+      - elsif field == "geographical_availabilities"
+        %span
+          = get_only_regions(service.send(field)).join(", ")
+          - unless get_only_regions(service.send(field)).empty?
+            %br
+        %span
+          = get_only_countries(service.send(field)).sort.join(", ")
       - else
         - Array(service.send(field)).map.with_index do |element, idx|
           - if nested.present? && nested[field.to_sym].present?

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe ServiceHelper, type: :helper do
     service = create(:service)
     expect(trl_description_text(service)).to eq("Super description")
   end
+
+  it "return only regions from geographical_availabilities" do
+    poland = Country.load("PL")
+    europe = Country.load("EO")
+    expect(get_only_regions([poland, europe])).to eq([europe])
+  end
+
+  it "return only countries from geographical_availabilities" do
+    poland = Country.load("PL")
+    europe = Country.load("EO")
+    expect(get_only_countries([poland, europe])).to eq([poland])
+  end
 end


### PR DESCRIPTION
On local instance: Resource with geographical_availabilities: {EZ,AT,EU,PL,FR,EO,WW,UK,DK}
![Zrzut ekranu 2021-02-26 o 10 24 43](https://user-images.githubusercontent.com/6060538/109281640-d9988180-781c-11eb-9df9-3635041c5c00.png)


Closes #1800 