### PR TITLE
[#1749] Change title for related_resources in details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Geographical availabilities order in the Resource details view (@kmarszalek, @jarekzet)
+- Title of section `Related resources` instead of `Suggested compatible resources`  in `details` and `opinions` page (@goreck888)
 
 ### Deprecated
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -78,6 +78,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
       if @service.valid?
         @offers = @service.offers.where(status: :published).order(:created_at)
         @related_services = @service.target_relationships
+        @related_services_title = "Suggested compatible resources"
         if current_user&.executive?
           @client = @client&.credentials&.expires_at.blank? ? Google::Analytics.new : @client
           @analytics = Analytics::PageViewsAndRedirects.new(@client).call(request.path)

--- a/app/controllers/services/details_controller.rb
+++ b/app/controllers/services/details_controller.rb
@@ -17,6 +17,7 @@ class Services::DetailsController < ApplicationController
   def index
     @service = Service.friendly.find(params[:service_id])
     @related_services = @service.related_services
+    @related_services_title = "Related resources"
     @question = Service::Question.new(service: @service)
   end
 end

--- a/app/controllers/services/opinions_controller.rb
+++ b/app/controllers/services/opinions_controller.rb
@@ -17,6 +17,7 @@ class Services::OpinionsController < ApplicationController
   def index
     @service = Service.friendly.find(params[:service_id])
     @related_services = @service.related_services
+    @related_services_title = "Related resources"
     @service_opinions = ServiceOpinion.includes(project_item: :offer).
         where(offers: { service_id: @service }).includes(project_item: :project)
     @question = Service::Question.new(service: @service)

--- a/app/controllers/services/ordering_configurations_controller.rb
+++ b/app/controllers/services/ordering_configurations_controller.rb
@@ -9,6 +9,8 @@ class Services::OrderingConfigurationsController < Services::ApplicationControll
   def show
     @service = Service.includes(:offers).friendly.find(params[:service_id])
     @offers = @service.offers.order(:iid)
+    @related_services = @service.related_services
+    @related_services_title = "Related resources"
     if current_user&.executive?
       @client = @client&.credentials&.expires_at.blank? ? Google::Analytics.new : @client
       @analytics = Analytics::PageViewsAndRedirects.new(@client).call(request.path)

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -25,6 +25,7 @@ class ServicesController < ApplicationController
     authorize @service
     @offers = policy_scope(@service.offers).order(:created_at)
     @related_services = @service.target_relationships
+    @related_services_title = "Suggested compatible resources"
 
     @service_opinions = ServiceOpinion.joins(project_item: :offer).
                         where(offers: { service_id: @service })

--- a/app/views/backoffice/services/preview.html.haml
+++ b/app/views/backoffice/services/preview.html.haml
@@ -27,4 +27,4 @@
   = render "services/tags", service: @service
 
 .container.mt-4.pt-4.related-container
-  = render "services/related", related_services: @related_services
+  = render "services/related", related_services: @related_services, title: @related_services_title

--- a/app/views/services/_related.html.haml
+++ b/app/views/services/_related.html.haml
@@ -1,7 +1,6 @@
 - if related_services&.count&.positive?
   %h2.mb-4.mt-3.font-weight-light
-    = _("Suggested compatible resources")
-
+    = _(title)
   .card-columns
     = render partial: "services/service_box",
             collection: related_services,

--- a/app/views/services/details/index.html.haml
+++ b/app/views/services/details/index.html.haml
@@ -17,4 +17,4 @@
   = render "services/details", service: @service
 
 .container.mt-4.pt-4.related-container
-  = render "services/related", related_services: @related_services
+  = render "services/related", related_services: @related_services, title: @related_services_title

--- a/app/views/services/opinions/index.html.haml
+++ b/app/views/services/opinions/index.html.haml
@@ -17,4 +17,4 @@
   = render "services/opinions", service_opinions: @service_opinions
 
 .container.mt-4.pt-4.related-container
-  = render "services/related", related_services: @related_services
+  = render "services/related", related_services: @related_services, title: @related_services_title

--- a/app/views/services/ordering_configurations/show.html.haml
+++ b/app/views/services/ordering_configurations/show.html.haml
@@ -10,4 +10,4 @@
   = render "services/tags", service: @service
 
 .container.mt-4.pt-4.related-container
-  = render "services/related", related_services: @related_services
+  = render "services/related", related_services: @related_services, title: @related_services_title

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -15,4 +15,4 @@
   = render "services/tags", service: @service
 
 .container.mt-4.pt-4.related-container
-  = render "services/related", related_services: @related_services
+  = render "services/related", related_services: @related_services, title: @related_services_title


### PR DESCRIPTION
Change the title of related resources section
in details and opinions
from "Suggested compatible resources"
to "Related resources"

Closes #1749