### PR TITLE
[HOTFIX] Fix no parameters info in offer box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Differences in the behaviour of the offer UI and API (@kmarszalek)
+- Show no parameters information in `ordering_configuration` page and in backoffice (@goreck888)
 
 ## [3.7.1] 2021-02-26
 

--- a/app/views/layouts/common_parts/services/_default_parameters.html.haml
+++ b/app/views/layouts/common_parts/services/_default_parameters.html.haml
@@ -17,22 +17,7 @@
                   -# haml-lint:enable MultilinePipe
       - else
         = render "services/offers/description", offer: offer
-    - if technical_parameters.present?
-      .card-body.pt-0.collapse-group
-        %h5.text-uppercase.parameters-title.mb-0
-          %i.fas.fa-tachometer-alt
-          = _("Technical Parameters")
-        %table.offer-params.table.table-hover
-          %tbody
-            - technical_parameters.each do |parameter|
-              %tr
-                %td= parameter["label"]
-                %td.text-right.text-nowrap.font-weight-bold= parse_offer_parameter_value(parameter)
-    - else
-      .card-body.pt-0.collapse-group
-        %p
-          = image_pack_tag "icon-speed.png", class: "icon-speed"
-          = _("The technical parameters configuration is empty")
+    = render "layouts/common_parts/services/parameters", technical_parameters: technical_parameters
 
     .card-button.text-center
       %label

--- a/app/views/layouts/common_parts/services/_offer.html.haml
+++ b/app/views/layouts/common_parts/services/_offer.html.haml
@@ -1,7 +1,7 @@
 .col-md-6.edit-offer{ id: "offer-#{offer.id}" }
   .card.m-0.mb-5
     = render "services/offers/description", offer: offer
-    = render "services/offers/parameters", technical_parameters: offer.attributes.map(&:to_json)
+    = render "layouts/common_parts/services/parameters", technical_parameters: offer.attributes.map(&:to_json)
 
     .card-button.text-center
       %label

--- a/app/views/layouts/common_parts/services/_parameters.html.haml
+++ b/app/views/layouts/common_parts/services/_parameters.html.haml
@@ -1,0 +1,16 @@
+- if technical_parameters.present?
+  .card-body.pt-0.collapse-group
+    %h5.text-uppercase.parameters-title.mb-0
+      %i.fas.fa-tachometer-alt
+      = _("Technical Parameters")
+    %table.offer-params.table.table-hover
+      %tbody
+        - technical_parameters.each do |parameter|
+          %tr
+            %td= parameter["label"]
+            %td.text-right.text-nowrap.font-weight-bold= parse_offer_parameter_value(parameter)
+- else
+  .card-body.pt-0.collapse-group
+    %p
+      = image_pack_tag "icon-speed.png", class: "icon-speed"
+      = _("The technical parameters configuration is empty")


### PR DESCRIPTION
Add information when no parameters added in offer box in ordering_configuration and in backoffice