### PR TITLE
[#1774] Migrate PC categories to MP categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Changed
 - `Provided by` field in `Popular resources`, `Suggested compatible resources` and `Recently added resources` to `Organisation` (@kmarszalek, @jarekzet)
 - Geographical availabilities in the resource details view are links to filters now (@goreck888)
+- Categories imported from Provider's component as `categories` instead of `pc_categories` (@goreck888)
 
 ### Deprecated
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,11 +6,9 @@ class HomeController < ApplicationController
   def index
     @learn_more_section = LeadSection.includes(:leads).find_by(slug: "learn-more")
     @use_cases_section = LeadSection.includes(:leads).find_by(slug: "use-cases")
-    @root_categories = @root_categories.with_attached_logo
+    @root_categories = @root_categories.with_attached_logo.reject { |c| c.name == "Other" }
     @main_scientific_domains =
-      ScientificDomain.with_attached_logo.roots[0...8]
-      .push(ScientificDomain.with_attached_logo.find_by(name: "Other"))
-      .reject(&:nil?)
+      ScientificDomain.with_attached_logo.roots.partition { |sd|  sd.name != "Other" }.flatten(1)
   end
 
   def robots

--- a/app/helpers/service/sidebar_helper.rb
+++ b/app/helpers/service/sidebar_helper.rb
@@ -25,7 +25,7 @@ module Service::SidebarHelper
       {
         name: "categorisation",
         template: "array",
-        fields: ["pc_categories"],
+        fields: ["categories"],
         type: "tree",
         nested: {
             pc_categories: "name"

--- a/app/models/concerns/importable.rb
+++ b/app/models/concerns/importable.rb
@@ -5,8 +5,8 @@ module Importable
     TargetUser.where(eid: target_users)
   end
 
-  def map_pc_categories(categories)
-    Vocabulary::PcCategory.where(eid: categories)
+  def map_categories(categories)
+    Category.where(eid: categories)
   end
 
   def map_scientific_domains(domains)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -52,8 +52,6 @@ class Service < ApplicationRecord
   has_many :service_related_platforms, dependent: :destroy
   has_many :platforms, through: :service_related_platforms
   has_many :service_vocabularies, dependent: :destroy
-  has_many :pc_categories, through: :service_vocabularies,
-           source: :vocabulary, source_type: "Vocabulary::PcCategory"
   has_many :funding_bodies, through: :service_vocabularies,
            source: :vocabulary, source_type: "Vocabulary::FundingBody"
   has_many :funding_programs, through: :service_vocabularies,

--- a/app/models/vocabulary/pc_category.rb
+++ b/app/models/vocabulary/pc_category.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class Vocabulary::PcCategory < Vocabulary
-end

--- a/app/services/importers/service.rb
+++ b/app/services/importers/service.rb
@@ -97,7 +97,7 @@ class Importers::Service
       use_cases_url: use_cases_url,
       # Classification
       scientific_domains: map_scientific_domains(scientific_domains),
-      pc_categories: map_pc_categories(categories) || [],
+      categories: map_categories(categories) || [],
       target_users: map_target_users(target_users),
       access_types: map_access_types(access_types),
       access_modes: map_access_modes(access_modes),

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -90,7 +90,7 @@
               = link_to_add_array_field("service", "use_cases_url")
         .card.shadow-sm.rounded
           %button.btn.btn-link{ type: "button", class: ("collapsed" if collapsed?(service,
-              [:scientific_domains, :pc_categories, :categories, :target_users, :access_types,
+              [:scientific_domains, :categories, :target_users, :access_types,
               :access_modes, :tag_list])),
               data: { toggle: "collapse", target: "#classification" },
               aria: { expanded: true, controls: "classification" } }
@@ -104,18 +104,15 @@
                     %i.fas.fa-chevron-up
         .collapse{ id: "classification", "aria-labelledby": "classification-header",
             "data-parent": "#accordion-form",
-            class: ("show" unless collapsed?(service, [:scientific_domains, :pc_categories,
+            class: ("show" unless collapsed?(service, [:scientific_domains,
                               :categories, :target_users, :access_types, :access_modes, :tag_list])) }
           .card-body
             = f.association :scientific_domains, input_html: { data: { choice: true } }, include_hidden: false,
             disabled: cant_edit([scientific_domain_ids: []]),
             collection: ScientificDomain.child_names.map { |name, sd| [name, sd.id] },
             label_method: :first, value_method: :second
-            = f.association :pc_categories, multiple: true, input_html: { data: { choice: true } },
-            disabled: cant_edit([pc_category_ids: []]),
-            collection: Vocabulary.where(type: "Vocabulary::PcCategory").child_names.map { |name, pcc| [name, pcc.id] },
-            label_method: :first, value_method: :second
             = f.association :categories, multiple: true, input_html: { data: { choice: true } },
+                            collection: Category.child_names.map { |name, c| [name, c.id] },
                             disabled: cant_edit([category_ids: []])
             = f.association :target_users,
               label: _("Dedicated For"),

--- a/app/views/comparisons/show.html.haml
+++ b/app/views/comparisons/show.html.haml
@@ -59,7 +59,7 @@
         - @services.each do |service|
           %td
             %dl
-              - field_tree(service, :pc_categories).each do |parent, children|
+              - field_tree(service, :categories).each do |parent, children|
                 %dt
                   %span
                     = parent

--- a/app/views/home/products/_cards.html.haml
+++ b/app/views/home/products/_cards.html.haml
@@ -1,11 +1,12 @@
 - cards.each do |card|
-  .col-6.col-lg-4
-    .branch-box
-      = link_to url.call(card) do
-        .branch-icon
-          - if card.logo.attached?
-            = image_tag card.logo, alt: card.name
-          - else
-            = image_pack_tag(default_logo, alt: "#{card.name}")
-        .branch-name
-          = card.name
+  - if card.present?
+    .col-6.col-lg-4
+      .branch-box
+        = link_to url.call(card) do
+          .branch-icon
+            - if card.logo.attached?
+              = image_tag card.logo.variant(resize: "84x84"), alt: card.name
+            - else
+              = image_pack_tag(default_logo, alt: "#{card.name}")
+          .branch-name
+            = card.name

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -52,30 +52,9 @@
             .title
               %a{ href: "#{portal_base}/services-resources" }
                 = _("Services & Resources")
-          %li.mb-1
-            %a{ href: "#{root_url}services/c/sharing-discovery?q=&service_id=&sort=_score" }
-              = _("Sharing & Discovery")
-          %li.mb-1
-            %a{ href: "#{root_url}services/c/processing-analysis?q=&service_id=&sort=_score" }
-              = _("Processing & Analysis")
-          %li.mb-1
-            %a{ href: "#{root_url}services/c/data-management?q=&service_id=&sort=_score" }
-              = _("Data Management")
-          %li.mb-1
-            %a{ href: "#{root_url}services/c/compute?q=&service_id=&sort=_score" }
-              = _("Compute")
-          %li.mb-1
-            %a{ href: "#{root_url}services/c/storage?q=&service_id=&sort=_score" }
-              = _("Storage")
-          %li.mb-1
-            %a{ href: "#{root_url}services/c/networking?q=&service_id=&sort=_score" }
-              = _("Networking")
-          %li.mb-1
-            %a{ href: "#{root_url}services/c/training-support?q=&service_id=&sort=_score" }
-              = _("Training & Support")
-          %li.mb-1
-            %a{ href: "#{root_url}services/c/security-operations?q=&service_id=&sort=_score" }
-              = _("Security & Operations")
+          - Category.roots.partition { |sd|  sd.name != "Other" }.flatten(1).each do |category|
+            %li.mb-1
+              = link_to category.name, category_path(category)
           %li.mb-1
             %a{ href: "#{portal_base}/helpdesk" }
               = _("Help Desk")

--- a/app/views/profiles/_form.html.haml
+++ b/app/views/profiles/_form.html.haml
@@ -6,8 +6,10 @@
           = _("Additional information")
 
       = f.association :categories, multiple: true, include_hidden: false,
+      collection: Category.child_names.map { |name, c| [name, c.id] },
       input_html: { data: { choice: true } }
       = f.association :scientific_domains, multiple: true, include_hidden: false,
+      collection: ScientificDomain.child_names.map { |name, sd| [name, sd.id] },
       input_html: { data: { choice: true } }
     .col-12.col-md-5.profile-edit.ml-auto
       .bordered-header

--- a/app/views/services/nav/_category.html.haml
+++ b/app/views/services/nav/_category.html.haml
@@ -1,5 +1,6 @@
 - active = "font-weight-bolder" if local_assigns[:current] && current == category
 %li{ class: "d-flex justify-content-between align-items-center #{active}" }
   = link_to category.name, category_services_path(category, category_query_params.merge(page: nil).permit!),
+  class: "mr-2",
   "data-probe": ""
   %span= counter

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_26_164811) do
+ActiveRecord::Schema.define(version: 2021_03_02_061137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/vocabulary.yml
+++ b/db/vocabulary.yml
@@ -1217,125 +1217,154 @@ access_type:
     type: ACCESS_TYPE
 
 category:
+  sharing_and_discovery:
+    eid: supercategory-sharing_and_discovery
+    name: Sharing & Discovery
+    type: SUPERCATEGORY
+  training_and_support:
+    eid: supercategory-training_and_support
+    name: Training & Support
+    type: SUPERCATEGORY
+  security_and_operations:
+    eid: supercategory-security_and_operations
+    name: Security & Operations
+    type: SUPERCATEGORY
+  processing_and_analysis:
+    eid: supercategory-processing_and_analysis
+    name: Processing & Analysis
+    type: SUPERCATEGORY
+  aggregators_and_integrators:
+    eid: supercategory-aggregators_and_integrators
+    name: Aggregators & Integrators
+    type: SUPERCATEGORY
+  other:
+    eid: supercategory-other
+    name: Other
+    type: SUPERCATEGORY
+  access_physical_and_eInfrastructures:
+    eid: supercategory-access_physical_and_eInfrastructures
+    name: Access physical & eInfrastructures
+    description: Ultra-fast connectivity and ubiquitous access, high performance computing, cloud capacity and storage.
+    type: SUPERCATEGORY
   data-management:
     eid: category-processing_and_analysis-data_management
     name: Data Management
     description: Robust, feature-rich and user-friendly data management services.
-    # parentId: supercategory-processing_and_analysis
+    parentId: supercategory-processing_and_analysis
     type: CATEGORY
   development-resources:
     eid: category-sharing_and_discovery-development_resources
     name: Development Resources
     description: Developer tools, development kits, libraries, APIs.
-    # parentId: supercategory-sharing_and_discovery
+    parentId: supercategory-sharing_and_discovery
     type: CATEGORY
   securirty-indentity:
     eid: category-security_and_operations-security_and_identity
     name: Security & Identity
     description: Protect infrastructure and manage user identities and access against advanced threats across devices, data, apps, etc.
-    # parentId: supercategory-security_and_operations
+    parentId: supercategory-security_and_operations
     type: CATEGORY
   data:
     eid: category-sharing_and_discovery-data
     name: Data
     description: Vast range of datasets to facilitate research and scientific activities.
-    # parentId: supercategory-sharing_and_discovery
+    parentId: supercategory-sharing_and_discovery
     type: CATEGORY
   samples:
     eid: category-sharing_and_discovery-samples
     name: Samples
     description: Collection, preparation and delivery of biological, chemical, environmental or other samples.
-    # parentId: supercategory-sharing_and_discovery
+    parentId: supercategory-sharing_and_discovery
     type: CATEGORY
   software:
     eid: category-sharing_and_discovery-software
     name: Software
     description: Software, platforms and tools offered-as-a-service or deployed-on-demand.
-    # parentId: supercategory-sharing_and_discovery
+    parentId: supercategory-sharing_and_discovery
     type: CATEGORY
   operations-infrastructure-management:
     eid: category-security_and_operations-operations_and_infrastructure_management_services
     name: Operations & Infrastructure Management Services
     description: Services for monitoring, scaling, creating, tracking and automating operations on infrastructures and services.
-    # parentId: supercategory-security_and_operations
+    parentId: supercategory-security_and_operations
     type: CATEGORY
   aggregators-integrators:
     eid: category-aggregators_and_integrators-aggregators_and_integrators
     name: Aggregators & Integrators
     description: Thematic, Regional and other Aggregators & Integrators.
-    # parentId: supercategory-aggregators_and_integrators
+    parentId: supercategory-aggregators_and_integrators
     type: CATEGORY
   data-analysis:
     eid: category-processing_and_analysis-data_analysis
     name: Data Analysis
     description: Processes for data with the goal of discovering useful information, informing conclusions, and supporting decision-making.
-    # parentId: supercategory-processing_and_analysis
+    parentId: supercategory-processing_and_analysis
     type: CATEGORY
-  other:
+  other-other:
     eid: category-other-other
     name: Other
     description: null
-    # parentId: supercategory-other
+    parentId: supercategory-other
     type: CATEGORY
   applications:
     eid: category-sharing_and_discovery-applications
     name: Applications
     description: End-user applications offered-as-a-service or deployed-on-demand.
-    # parentId: supercategory-sharing_and_discovery
+    parentId: supercategory-sharing_and_discovery
     type: CATEGORY
   instrument-equipment:
     eid: category-access_physical_and_eInfrastructures-instrument_and_equipment
     name: Instrument & Equipment
     description: Access to instruments and equipment.
-    # parentId: supercategory-access_physical_and_eInfrastructures
+    parentId: supercategory-access_physical_and_eInfrastructures
     type: CATEGORY
   education-training:
     eid: category-training_and_support-education_and_training
     name: Education & Training
     description: Highly-specialized seminars and courses to help advance research knowledge and sharpen scientific skills.
-    # parentId: supercategory-training_and_support
+    parentId: supercategory-training_and_support
     type: CATEGORY
   data-storage:
     eid: category-access_physical_and_eInfrastructures-data_storage
     name: Data Storage
     description: Reliable, secure and scalable cloud storage for scientific data, apps and workloads.
-    # parentId: supercategory-access_physical_and_eInfrastructures
+    parentId: supercategory-access_physical_and_eInfrastructures
     type: CATEGORY
   consultancy-support:
     eid: category-training_and_support-consultancy_and_support
     name: Consultancy & Support
     description: Dedicated professional support for a wide range of scientific disciplines and research activities.
-    # parentId: supercategory-training_and_support
+    parentId: supercategory-training_and_support
     type: CATEGORY
   material-storage:
     eid: category-access_physical_and_eInfrastructures-material_storage
     name: Material Storage
     description: Access to biological, chemical, historical, archeological, cultural, etc. storage. Includes the acquisition, preparation and processing of samples and materials in view of their preservation.
-    # parentId: supercategory-access_physical_and_eInfrastructures
+    parentId: supercategory-access_physical_and_eInfrastructures
     type: CATEGORY
   scholarly-communication:
     eid: category-sharing_and_discovery-scholarly_communication
     name: Scholarly Communication
     description: Research findings available to the wider academic community and beyond.
-    # parentId: supercategory-sharing_and_discovery
+    parentId: supercategory-sharing_and_discovery
     type: CATEGORY
   measurement-materials-analysis:
     eid: category-processing_and_analysis-measurement_and_materials_analysis
     name: Measurement & Materials Analysis
     description: Processess and techiques for material analysis, characterisation and monitoring.
-    # parentId: supercategory-processing_and_analysis
+    parentId: supercategory-processing_and_analysis
     type: CATEGORY
   network:
     eid: category-access_physical_and_eInfrastructures-network
     name: Network
     description: Ultra-fast connectivity and ubiquitous access to eInfrastructures' resources and services.
-    # parentId: supercategory-access_physical_and_eInfrastructures
+    parentId: supercategory-access_physical_and_eInfrastructures
     type: CATEGORY
   compute:
     eid: category-access_physical_and_eInfrastructures-compute
     name: Compute
     description: High-performance computing resources and scalable cloud compute capacity for demanding job processes.
-    # parentId: supercategory-access_physical_and_eInfrastructures
+    parentId: supercategory-access_physical_and_eInfrastructures
     type: CATEGORY
   sharing_and_discovery-software-other:
     eid: subcategory-sharing_and_discovery-software-other
@@ -1572,8 +1601,8 @@ category:
     parentId: category-training_and_support-consultancy_and_support
     type: SUBCATEGORY
   processing_and_analysis-data_analysis-data_exploitation:
-    eid: subcategory-processing_and_analysis-data_analysis-data_exploitation
-    name: Data Exploitation
+    eid: subcategory-processing_and_analysis-data_analysis-data_extrapolation
+    name: Data Extrapolation
     parentId: category-processing_and_analysis-data_analysis
     type: SUBCATEGORY
   processing_and_analysis-data_management-other:
@@ -2028,7 +2057,7 @@ category:
     type: SUBCATEGORY
   processing_and_analysis-data_management-publishing:
     eid: subcategory-processing_and_analysis-data_management-publishing
-    name: processing_and_analysis-data_management-publishing
+    name: Publishing
     parentId: category-processing_and_analysis-data_management
     type: SUBCATEGORY
     extras: {}
@@ -2124,7 +2153,7 @@ category:
     type: SUBCATEGORY
   training_and_support-consultancy_and_support-application_porting:
     eid: subcategory-training_and_support-consultancy_and_support-application_porting
-    name: Application_Porting
+    name: Application Porting
     parentId: category-training_and_support-consultancy_and_support
     type: SUBCATEGORY
   access_physical_and_eInfrastructures-compute-job_execution:
@@ -2134,7 +2163,7 @@ category:
     type: SUBCATEGORY
   processing_and_analysis-measurement_and_materials_analysis-testing_and_validation:
     eid: subcategory-processing_and_analysis-measurement_and_materials_analysis-testing_and_validation
-    name: TEsting & Validation
+    name: Testing & Validation
     parentId: category-processing_and_analysis-measurement_and_materials_analysis
     type: SUBCATEGORY
   processing_and_analysis-data_management-embargo:

--- a/docs/upgrade/3.9.0.md
+++ b/docs/upgrade/3.9.0.md
@@ -1,0 +1,17 @@
+# Upgrade to 3.7.0
+
+# Standard procedure
+
+All steps run in production scope.
+
+- make database dump and all applicatin files.
+- bundle install --deployment --without development test
+- bundle exec rake assets:clean assets:precompile
+- rails db:migrate
+
+# Special steps
+
+- Run task `rake rdt:remove_vocabularies` to remove invalid entries for services
+- Run task `rake rdt:add_vocabularies` to recover vocabularies
+- Run task `rake import:providers` to update data about providers - ask @bwilk for token
+- Run task `rake import:eic` to recover all associated vocabularies deleted in previous steps

--- a/spec/factories/vocabularies/pc_categories.rb
+++ b/spec/factories/vocabularies/pc_categories.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :pc_category, class: "vocabulary/pc_category" do
-    sequence(:name) { |n| "pc_category #{n}" }
-    sequence(:eid) { |n| "category-#{n}" }
-  end
-end

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -583,7 +583,6 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_field "Order type", disabled: true
       expect(page).to have_field "Order url", disabled: true
       expect(page).to have_field "Categories", disabled: false
-      expect(page).to have_field "Pc categories", disabled: true
       expect(page).to have_field "Access types", disabled: true
       expect(page).to have_field "Access modes", disabled: true
       expect(page).to have_field "Providers", disabled: true

--- a/spec/lib/import/eic_spec.rb
+++ b/spec/lib/import/eic_spec.rb
@@ -54,8 +54,8 @@ describe Import::Eic do
   let!(:training) { create(:category, name: "Training & Support") }
   let!(:security) { create(:category, name: "Security & Operations") }
   let!(:analytics) { create(:category, name: "Processing & Analysis") }
-  let!(:data) { create(:pc_category, name: "Data management", eid: "category-data") }
-  let!(:data_subcategory) { create(:pc_category, name: "Access", eid: "data-applications-software") }
+  let!(:data) { create(:category, name: "Data management", eid: "category-data") }
+  let!(:data_subcategory) { create(:category, name: "Access", eid: "data-applications-software") }
 
   let!(:compute) { create(:category, name: "Compute") }
   let!(:networking) { create(:category, name: "Networking") }

--- a/spec/services/service/pc_create_or_update_spec.rb
+++ b/spec/services/service/pc_create_or_update_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Service::PcCreateOrUpdate do
   let!(:training) { create(:category, name: "Training & Support") }
   let!(:security) { create(:category, name: "Security & Operations") }
   let!(:analytics) { create(:category, name: "Processing & Analysis") }
-  let!(:data) { create(:pc_category, name: "Data management", eid: "category-data") }
-  let!(:data_subcategory) { create(:pc_category, name: "Access", parent: data,
+  let!(:data) { create(:category, name: "Data management", eid: "category-data") }
+  let!(:data_subcategory) { create(:category, name: "Access", parent: data,
                                    eid: "subcategory-access") }
   let!(:compute) { create(:category, name: "Compute") }
   let!(:networking) { create(:category, name: "Networking") }


### PR DESCRIPTION
Change `rake rdt:add_vocabularies` pc_categories to categories
Change pc_categories to categories in importers
Remove model `Vocabulary::PcCategory`
Fix counters for categories
Fix duplicated "Other" ScientificDomain
Add docs for upgrade
Closes #1774, #1860