### PR TITLE
[#1829] Change Geographical availabilities to filters links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - `Provided by` field in `Popular resources`, `Suggested compatible resources` and `Recently added resources` to `Organisation` (@kmarszalek, @jarekzet)
+- Geographical availabilities in the resource details view are links to filters now (@goreck888)
 
 ### Deprecated
 

--- a/app/views/services/details/_array.html.haml
+++ b/app/views/services/details/_array.html.haml
@@ -11,10 +11,12 @@
           = service.send(field).to_date
       - elsif field == "geographical_availabilities"
         %span
-          = get_only_regions(service.send(field)).join(", ")
+          = safe_join(get_only_regions(service.send(field)).map { |c| link_to c,
+            services_path(geographical_availabilities: c) }.sort, ", ")
         - if get_only_countries(service.send(field)).present?
           %span.geographical
-            = get_only_countries(service.send(field)).sort.join(", ")
+            = safe_join(get_only_countries(service.send(field)).map { |c| link_to c,
+            services_path(geographical_availabilities: c) }.sort, ", ")
       - else
         - Array(service.send(field)).map.with_index do |element, idx|
           - if nested.present? && nested[field.to_sym].present?


### PR DESCRIPTION
Geographical availabilities in the resource details are
links to filters now instead of plain text
Fixes #1829