### PR TITLE
Representation of the RO and RP in the resource / resource list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- Representation of the Resource Organisation and Resource Providers in the Resource views (@kmarszalek, @jarekzet)
 
 ### Changed
 

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -67,7 +67,10 @@ module ServiceHelper
   end
 
   def providers(service)
-    service.providers.map { |target| link_to(target.name, provider_path(target)) }
+    service.providers
+           .reject(&:blank?)
+           .reject { |p| p == service.resource_organisation }
+           .uniq.map { |target| link_to(target.name, provider_path(target)) }
   end
 
   def providers_text(service)

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -2501,7 +2501,8 @@ label[data-multicheckbox].small {
       display: inline;
       float: left;
       color: $palette-solid-100;
-      padding-right: 10px;
+      padding-right: 0;
+      width: 105px;
       margin-bottom: 0;
       font-weight: 300;
     }
@@ -2509,7 +2510,7 @@ label[data-multicheckbox].small {
     dd {
       display: inline;
       float: left;
-      max-width: 83%;
+      max-width: 82%;
       margin-bottom: 0;
 
       a {
@@ -2580,6 +2581,11 @@ label[data-multicheckbox].small {
   }
 
   dl {
+    dt {
+      width: auto;
+      padding-right: 5px;
+    }
+
     dd {
       a {
         font-weight: bold;

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -224,6 +224,13 @@ class Service < ApplicationRecord
     order_type == "order_required" && order_url.blank?
   end
 
+  def providers?
+    providers
+      .reject(&:blank?)
+      .reject { |p| p == resource_organisation }
+      .empty?
+  end
+
   private
     def remove_empty_array_fields
       array_fields = [:multimedia, :use_cases_url, :certifications,

--- a/app/views/services/_about.html.haml
+++ b/app/views/services/_about.html.haml
@@ -39,7 +39,7 @@
               %strong.text-dark= service.project_items.order_required.size
 
       %a.more-details{ href: service_details_path(service), "data-shepherd-tour-target": "service-more-about",
-        "data-probe" => ""}
+        "data-probe" => "" }
         = _("More about")
         = service.name
         %i.fas.fa-long-arrow-alt-right

--- a/app/views/services/_categorization.html.haml
+++ b/app/views/services/_categorization.html.haml
@@ -1,19 +1,20 @@
 %dl.mb-0
   %dt.x-small
     %span
-      = _("Provided by") + ":"
+      = _("Organisation") + ":"
   %dd.x-small
-    %mr-4= safe_join(resource_organisation_and_providers(service), ", ")
+    %mr-4= resource_organisation(service)
+- unless service.providers?
+  %dl.mb-0
+    %dt.x-small
+      %span
+        = _("Provided by") + ":"
+    %dd.x-small
+      %mr-4= safe_join(providers(service), ", ")
 %dl.mb-0.research
   %dt.x-small
     %span
       = _("Scientific domain") + ":"
   %dd.x-small
     %mr-4= safe_join(scientific_domains_text(service), ", ")
-%dl.mb-0.dedicated
-  %dt.x-small
-    %span
-      = _("Dedicated for") + ":"
-  %dd.x-small
-    %mr-4= safe_join(dedicated_for_text(service), ", ")
 %span.clearfix

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -23,7 +23,7 @@
               class: "ml-1 default-color"
           .comparison
             - unless local_assigns[:preview]
-              %span.compare{"data-probe" => ""}
+              %span.compare{ "data-probe" => "" }
                 %label{ options(service.slug, comparison_enabled) }
                   = check_box_tag "comparison", service.slug, checked?(service.slug), id: "comparison-#{service.id}",
                           class: "form-check-input",

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -13,7 +13,7 @@
         - if (not defined? show_recommendations) || show_recommendations
           - if ab_test(:recommendation_panel) == "v1"
             = render partial: "services/recommendation_panel_v1",
-                     locals: { highlights: highlights, category: category }
+                     locals: { highlights: highlights, category: category, recommended_services: recommended_services }
         = render "services/pagination", sort_options: sort_options, services: services, pagy: pagy
 
       %p
@@ -27,7 +27,7 @@
         - if (not defined? show_recommendations) || show_recommendations
           - if ab_test(:recommendation_panel) == "v2"
             = render partial: "services/recommendation_panel_v2",
-                     locals: { highlights: highlights, category: category }
+                     locals: { highlights: highlights, category: category, recommended_services: recommended_services }
         = render partial: "service", collection: services[2..],
                  locals: { highlights: highlights,
                            category: category,

--- a/app/views/services/_paginate_simple.haml
+++ b/app/views/services/_paginate_simple.haml
@@ -10,5 +10,5 @@
         %li.page-item{ class: ("active" if per_page == "30") }
           = link_to "30", params.merge(per_page: 30, page: 1).permit!, class: "page-link"
       %li.page-item.disabled
-        %a.page-link.text-dark{"data-probe" => ""}
+        %a.page-link.text-dark{ "data-probe" => "" }
           = _("Items on page")

--- a/app/views/services/_recommendation_panel_v1.html.haml
+++ b/app/views/services/_recommendation_panel_v1.html.haml
@@ -7,5 +7,5 @@
         = _("RECOMMENDED")
 .container
   .row.mb-4.ml-0.mr-0
-    = render partial: "services/recommendation_v1", collection: @recommended_services,
+    = render partial: "services/recommendation_v1", collection: recommended_services,
              locals: { highlights: highlights, category: category }

--- a/app/views/services/_recommendation_panel_v2.html.haml
+++ b/app/views/services/_recommendation_panel_v2.html.haml
@@ -1,4 +1,4 @@
 .container
   .row.mb-4
-    = render partial: "services/recommendation_v2", collection: @recommended_services,
+    = render partial: "services/recommendation_v2", collection: recommended_services,
              locals: { highlights: highlights, category: category }

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -18,7 +18,7 @@
       %a.search-clear{ href: url_for(params.except(:q, :sort, :service_id)), title: _("Clear search") }
         .fas.fa-times
     %ul.autocomplete-results{ "data-target": "autocomplete.results" }
-  .searchbar__select{"data-probe": ""}
+  .searchbar__select{ "data-probe": "" }
     %span{ "data-target": "search.selected" }
       = _("All resources")
     %select#category-select.container-select{ "data-action": "change->search#refresh",

--- a/app/views/services/_service.html.haml
+++ b/app/views/services/_service.html.haml
@@ -3,7 +3,7 @@
   = link_to highlighted_for(:name, service, highlights[service.id]),
     service_path(service, category.present? ? { fromc: category.slug } : nil)
   - content_for :checkbox do
-    .mt-3.compare{"data-probe" => ""}
+    .mt-3.compare{ "data-probe" => "" }
       %label{ options(service.slug, comparison_enabled) }
         = check_box_tag "comparison", service.slug, checked?(service.slug), id: "comparison-#{service.id}",
                 class: "form-check-input",

--- a/app/views/services/_service_details.html.haml
+++ b/app/views/services/_service_details.html.haml
@@ -1,7 +1,7 @@
 .media.mb-3.service-box.shadow-sm
   .media-body.pt-4
     .pl-4.pr-4.mb-3
-      %h2.mb-3{"data-probe" => "", "data-service-id" => service.id}= yield
+      %h2.mb-3{ "data-probe" => "", "data-service-id" => service.id }= yield
       %p.mb-3= highlighted_for(:tagline, service, highlights)
       = render "services/categorization", service: service
       - if content_for(:checkbox)

--- a/app/views/services/_tabs.haml
+++ b/app/views/services/_tabs.haml
@@ -5,10 +5,10 @@
     %ul#my-tab.nav.nav-tabs.row.pl-3{ role: "tablist" }
       - if local_assigns[:preview]
         %li.nav-item
-          %a.nav-link.active.text-uppercase{"data-probe" => ""}
+          %a.nav-link.active.text-uppercase{ "data-probe" => "" }
             = _("About")
         %li.nav-item
-          %a.nav-link.disabled.text-uppercase{"data-probe" => ""}
+          %a.nav-link.disabled.text-uppercase{ "data-probe" => "" }
             = _("Reviews (%{ssoc})") % { ssoc: service.service_opinion_count }
       - else
         %li.nav-item

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -20,7 +20,8 @@
                              filters: @filters,
                              active_filters: @active_filters,
                              offers: @offers,
-                             comparison_enabled: @comparison_enabled
+                             comparison_enabled: @comparison_enabled,
+                             recommended_services: @recommended_services
   #comparison-bar.comparison-bar.fixed-bottom{ class: (session[:comparison]&.size || 0) > 0 ? "d-block" : "d-none",
   "data-target": "comparison.bar" }
     = render "comparisons/bar", services: @compare_services, category: @category

--- a/app/views/services/nav/_category.html.haml
+++ b/app/views/services/nav/_category.html.haml
@@ -1,5 +1,5 @@
 - active = "font-weight-bolder" if local_assigns[:current] && current == category
-%li{ class: "d-flex justify-content-between align-items-center #{active}"}
+%li{ class: "d-flex justify-content-between align-items-center #{active}" }
   = link_to category.name, category_services_path(category, category_query_params.merge(page: nil).permit!),
   "data-probe": ""
   %span= counter


### PR DESCRIPTION
Resource with RO and RP's
![Zrzut ekranu 2021-03-11 o 09 47 33](https://user-images.githubusercontent.com/6060538/110760400-f6867900-824e-11eb-9e52-80dad87b1dfe.png)
![Zrzut ekranu 2021-03-11 o 09 47 30](https://user-images.githubusercontent.com/6060538/110760429-fe461d80-824e-11eb-8801-845f7704f9e2.png)

Resource only with RO
![Zrzut ekranu 2021-03-11 o 09 46 03](https://user-images.githubusercontent.com/6060538/110760161-b1fadd80-824e-11eb-9de7-27c7aab57a76.png)
![Zrzut ekranu 2021-03-11 o 09 45 54](https://user-images.githubusercontent.com/6060538/110760149-aeffed00-824e-11eb-8905-9e0d50ff8523.png)

Closes #1833 