### PR TITLE
[#1803] Display sync error for errored resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Filtering by providers includes both `resource_organisation` and `providers` associations (@goreck888)
+- Displaying synchronization issues (if any occurs) in resource page for `data_administrators` (@goreck888)
 
 ## [3.8.0] 2021-03-03
 

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -3,12 +3,12 @@
 class ServicePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.where(status: [:published, :unverified])
+      scope.where(status: [:published, :unverified, :errored])
     end
   end
 
   def show?
-    record.published? || record.unverified?
+    record.published? || record.unverified? || record.errored?
   end
 
   def order?

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -10,6 +10,7 @@
       = ("The resource is published but has no published offers. Publish one offer to make possible for a user to " + |
          "Access the service.") |
       -# haml-lint:enable MultilinePipe
+  = render "services/errors", service: @service
 
 .container
   .status-row

--- a/app/views/services/_errors.html.haml
+++ b/app/views/services/_errors.html.haml
@@ -1,0 +1,7 @@
+- if current_user.present?
+  - has_role_for_message = !(current_user.roles.to_a & [:service_portfolio_manager]).empty?
+  - if has_role_for_message || service.administered_by?(current_user)
+    .container
+      - if service&.sources&.first&.errored.present?
+        .alert.alert-danger.mb-0.text-center
+          = ("This resource is not up to date because of invalid import data. Reason: #{service.sources.first.errored}")

--- a/app/views/services/ordering_configurations/show.html.haml
+++ b/app/views/services/ordering_configurations/show.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, @service.name
 - breadcrumb :ordering_configuration, @service
-
+= render "services/errors", service: @service
 .container{ "data-controller": "comparison" }
   .pt-4.pl-3.pr-3.shadow-sm.rounded.service-box.service-detail{ "data-shepherd-tour-target": "service-box" }
     = render "services/ordering_configurations/header", service: @service

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -3,6 +3,7 @@
 :javascript
   _paq.push(['trackEvent', 'Service', 'Visit', '#{id}']);
 - breadcrumb :service, @service
+= render "services/errors", service: @service
 .container{ "data-controller": "comparison" }
   .pt-4.pl-3.pr-3.shadow-sm.rounded.service-box.service-detail{ "data-shepherd-tour-target": "service-box" }
     = render "services/header", service: @service, comparison_enabled: @comparison_enabled, question: @question

--- a/db/migrate/20210316161711_add_errored_to_service_source.rb
+++ b/db/migrate/20210316161711_add_errored_to_service_source.rb
@@ -1,0 +1,5 @@
+class AddErroredToServiceSource < ActiveRecord::Migration[6.0]
+  def change
+    add_column :service_sources, :errored, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_02_061137) do
+ActiveRecord::Schema.define(version: 2021_03_16_161711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -389,6 +389,7 @@ ActiveRecord::Schema.define(version: 2021_03_02_061137) do
     t.bigint "service_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "errored"
     t.index ["eid", "source_type", "service_id"], name: "index_service_sources_on_eid_and_source_type_and_service_id", unique: true
     t.index ["service_id"], name: "index_service_sources_on_service_id"
   end


### PR DESCRIPTION
Change logic, now errored resources
are displayed on resources list
Errors are saved in service_source as errored field.

Fixes #1803