### PR TITLE
[#1841] Fix duplicated providers in import:eic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - Representation of the Resource Organisation and Resource Providers in the Resource views (@kmarszalek, @jarekzet)
+- Removal of duplicated provider entries in the Resource Provider field in the MP (@kmarszalek)
 
 ### Changed
 - `Provided by` field in `Popular resources`, `Suggested compatible resources` and `Recently added resources` to `Organisation` (@kmarszalek, @jarekzet)

--- a/app/services/importers/service.rb
+++ b/app/services/importers/service.rb
@@ -85,7 +85,7 @@ class Importers::Service
       resource_organisation: map_provider(@data["resourceOrganisation"],
                                           @eic_base_url,
                                           token: @token),
-      providers: providers.map { |p| map_provider(p, @eic_base_url,
+      providers: providers.uniq.map { |p| map_provider(p, @eic_base_url,
                                                    token: @token) },
       webpage_url: @data["webpage"] || "",
       # Marketing

--- a/spec/factories/eic_services_response.rb
+++ b/spec/factories/eic_services_response.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
                     "resourceOrganisation" => "bluebridge",
                     "resourceProviders" => [
                         "phenomenal",
+                        "phenomenal",
                         "awesome"
                     ],
                     "version" => "2018.08",

--- a/spec/fixtures/files/eic_import_output.json
+++ b/spec/fixtures/files/eic_import_output.json
@@ -16,6 +16,7 @@
       "resourceOrganisation": "bluebridge",
       "resourceProviders": [
         "phenomenal",
+        "phenomenal",
         "awesome"
       ],
       "version": "2018.08",

--- a/spec/lib/import/eic_spec.rb
+++ b/spec/lib/import/eic_spec.rb
@@ -110,7 +110,7 @@ describe Import::Eic do
       expect(Service.first.as_json(except: [:created_at, :updated_at])).to eq(service.as_json(except: [:created_at, :updated_at]))
     end
 
-    it "should update service which has upstream to external id" do
+    it "should update service which has upstream to external id and repeated providers" do
       service = create(:service)
       create(:offer, service: service)
       source = create(:service_source, eid: "phenomenal.phenomenal", service_id: service.id, source_type: "eic")


### PR DESCRIPTION
- duplicated providers were crashing update of the resource

requires:
bundle exec import:eic

* [x] issue
* [x] import on PR instance
* [x] rspec tests

before import
![Zrzut ekranu 2021-03-12 o 14 58 32](https://user-images.githubusercontent.com/6060538/110952175-31b7a380-8346-11eb-9804-4ce2918e325a.png)

after import
![Zrzut ekranu 2021-03-12 o 15 18 45](https://user-images.githubusercontent.com/6060538/110952363-6af01380-8346-11eb-8a62-0cf884973db6.png)

Closes #1841