### PR TITLE
[#1827] Extend finding resource in main searchbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- Extend finding resource in main searchbar including providers (@danielkryska, goreck888)
 
 ### Changed
 

--- a/app/controllers/concerns/service/autocomplete.rb
+++ b/app/controllers/concerns/service/autocomplete.rb
@@ -5,15 +5,15 @@ module Service::Autocomplete
 
   def autocomplete
     query = Searchkick.search(params[:q],
-                           fields: ["name", "offer_name"],
-                           operator: "or",
-                           match: :word_middle,
-                           limit: 5,
-                           load: false,
-                           where: { service_id: scope.ids },
-                           highlight: { multiple: true, tag: "<b>" },
-                           models: [Service, Offer],
-                           model_includes: { Service => [:offers], Offer => [:service] })
+                              fields: ["name", "offer_name", "provider_names"],
+                              operator: "or",
+                              match: :word_middle,
+                              limit: 5,
+                              load: false,
+                              where: { service_id: scope.ids },
+                              highlight: { multiple: true, tag: "<b>" },
+                              models: [Service, Offer, Provider],
+                              model_includes: { Service => [:offers], Offer => [:service], Provider => [:services] })
 
     service_titles = Service.where(id: scope.ids).pluck(:id, :name).to_h
 

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -73,7 +73,8 @@ module Service::Searchable
 
     def common_params
       {
-          fields: [ "name^7", "tagline^3", "description", "offer_names"],
+          fields: [ "name^7", "tagline^3", "description", "offer_names", "provider_names",
+                    "resource_organisation_name"],
           operator: "or",
           match: :word_middle
       }

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -49,9 +49,9 @@ module ServiceHelper
     service.scientific_domains.map { |target| target.name }
   end
 
-  def resource_organisation(service)
+  def resource_organisation(service, highlights = nil)
     target = service.resource_organisation
-    link_to(target.name, provider_path(target))
+    link_to(highlighted_for(:resource_organisation_name, service, highlights), provider_path(target))
   end
 
   def resource_organisation_text(service)
@@ -66,11 +66,17 @@ module ServiceHelper
     service.resource_organisation_and_providers.map { |target| target.name }
   end
 
-  def providers(service)
+  def providers(service, highlights = nil)
+    highlighted = highlights.present? ? sanitize(highlights[:provider_names])&.to_str : ""
     service.providers
            .reject(&:blank?)
-           .reject { |p| p == service.resource_organisation }
-           .uniq.map { |target| link_to(target.name, provider_path(target)) }
+           .reject { |p| p == service.resource_organisation }.uniq.map do |target|
+      if highlighted.present? && highlighted.strip == target.name.strip
+        link_to highlights[:provider_names].html_safe, provider_path(target)
+      else
+        link_to target.name, provider_path(target)
+      end
+    end
   end
 
   def providers_text(service)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -7,6 +7,15 @@ class Provider < ApplicationRecord
 
   acts_as_taggable
 
+  searchkick word_middle: [:provider_name]
+
+  def search_data
+    {
+      provider_name: name,
+      service_ids: service_ids
+    }
+  end
+
   has_one_attached :logo
 
   serialize :participating_countries, Country::Array

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -214,6 +214,10 @@ class Service < ApplicationRecord
     ([resource_organisation] + Array(providers)).reject(&:blank?).uniq
   end
 
+  def resource_organisation_name
+    resource_organisation.name
+  end
+
   def external
     order_type == "order_required" && order_url.present?
   end

--- a/app/models/service/search.rb
+++ b/app/models/service/search.rb
@@ -7,8 +7,9 @@ module Service::Search
     # ELASTICSEARCH
     # scope :search_import working with should_indexe?
     # and define which services are indexed in elasticsearch
-    searchkick word_middle: [:name, :tagline, :description, :offer_names],
-      highlight: [:name, :tagline]
+    searchkick word_middle: [:name, :tagline, :description, :offer_names,
+                             :resource_organisation_name, :provider_names],
+      highlight: [:name, :tagline, :resource_organisation_name, :provider_names]
   end
 
   # search_data are definition whitch
@@ -23,6 +24,7 @@ module Service::Search
       rating: rating,
       categories: categories.map(&:id),
       scientific_domains: search_scientific_domains_ids,
+      resource_organisation_name: resource_organisation.name,
       providers: resource_organisation_and_providers.map(&:id),
       platforms: platforms.map(&:id),
       geographical_availabilities: geographical_availabilities.map(&:alpha2),
@@ -31,7 +33,8 @@ module Service::Search
       tags: tag_list,
       source: upstream&.source_type,
       offers: offers.ids,
-      offer_names:  offers.map(&:name)
+      offer_names: offers.map(&:name),
+      provider_names: [resource_organisation.name] << providers.map(&:name)
     }
   end
 

--- a/app/views/backoffice/services/_header.html.haml
+++ b/app/views/backoffice/services/_header.html.haml
@@ -9,7 +9,7 @@
     .col-12.col-sm-9.service-details-header
       %h2.font-weight-bolder= service.name
       %p.mb-1= service.tagline
-      = render "services/categorization", service: service
+      = render "services/categorization", service: service, highlights: nil
       .row.mt-2
         .col
           .stars

--- a/app/views/services/_categorization.html.haml
+++ b/app/views/services/_categorization.html.haml
@@ -3,14 +3,14 @@
     %span
       = _("Organisation") + ":"
   %dd.x-small
-    %mr-4= resource_organisation(service)
+    %mr-4= resource_organisation(service, highlights)
 - unless service.providers?
   %dl.mb-0
     %dt.x-small
       %span
         = _("Provided by") + ":"
     %dd.x-small
-      %mr-4= safe_join(providers(service), ", ")
+      %mr-4= safe_join(providers(service, highlights), ", ")
 %dl.mb-0.research
   %dt.x-small
     %span

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -9,7 +9,7 @@
     .col-12.col-sm-9.service-details-header
       %h2.font-weight-bolder= service.name
       %p.mb-1= service.tagline
-      = render "services/categorization", service: service
+      = render "services/categorization", service: service, highlights: nil
 
       .row.mt-2
         .col

--- a/app/views/services/_service_details.html.haml
+++ b/app/views/services/_service_details.html.haml
@@ -3,7 +3,7 @@
     .pl-4.pr-4.mb-3
       %h2.mb-3{ "data-probe" => "", "data-service-id" => service.id }= yield
       %p.mb-3= highlighted_for(:tagline, service, highlights)
-      = render "services/categorization", service: service
+      = render "services/categorization", service: service, highlights: highlights
       - if content_for(:checkbox)
         = yield_content!(:checkbox)
     - if service_offers && service_offers.any?

--- a/app/views/services/autocomplete/_provider_item.html.haml
+++ b/app/views/services/autocomplete/_provider_item.html.haml
@@ -1,0 +1,5 @@
+%li.dropdown-item{ "role": "option",
+  "data-autocomplete-value": "#{service.id}" }
+  = highlights[:provider_names].html_safe
+  >
+  = service.name

--- a/app/views/services/autocomplete/list.html.haml
+++ b/app/views/services/autocomplete/list.html.haml
@@ -10,3 +10,10 @@
     = render "services/autocomplete/offer_item", offer: elem,
       highlights: highlights,
       service_titles: service_titles
+%li.label
+  = _("Providers")
+- results.each do |elem, highlights|
+  - if highlights[:provider_names]
+    = render "services/autocomplete/provider_item", service: elem,
+     highlights: highlights
+

--- a/app/views/services/ordering_configurations/_header.html.haml
+++ b/app/views/services/ordering_configurations/_header.html.haml
@@ -9,7 +9,7 @@
     .col-12.col-sm-9.service-details-header
       %h2.font-weight-bolder= service.name
       %p.mb-1= service.tagline
-      = render "services/categorization", service: service
+      = render "services/categorization", service: service, highlights: nil
 
       .row.mt-2
         .col

--- a/docs/upgrade/3.9.0.md
+++ b/docs/upgrade/3.9.0.md
@@ -1,4 +1,4 @@
-# Upgrade to 3.7.0
+# Upgrade to 3.9.0
 
 # Standard procedure
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -115,4 +115,32 @@ RSpec.feature "Service searching in top bar", js: true do
     visit :services
     expect(page).to have_selector("#category-select > option:last-child", text: "Other")
   end
+
+  scenario "After starting searching autocomplete are shown with resource organisation", js: true, search: true do
+    provider = create(:provider, name: "Cyfronet")
+    create(:service, name: "DDDD Something 1", resource_organisation: provider)
+    create(:service, name: "DDDD Something 2")
+    create(:service, name: "DDDD Something 3")
+
+    visit services_path
+    fill_in "q", with: "Cyfr"
+
+    expect(page).to have_text ("Cyfronet > DDDD Something 1")
+    expect(page).to_not have_text ("Cyfronet > DDDD Something 2")
+    expect(page).to_not have_text ("Cyfronet > DDDD Something 3")
+  end
+
+  scenario "After starting searching autocomplete are shown with providers", js: true, search: true do
+    provider = create(:provider, name: "Cyfronet")
+    create(:service, name: "DDDD Something 1", providers: [provider])
+    create(:service, name: "DDDD Something 2")
+    create(:service, name: "DDDD Something 3")
+
+    visit services_path
+    fill_in "q", with: "Cyfr"
+
+    expect(page).to have_text ("Cyfronet > DDDD Something 1")
+    expect(page).to_not have_text ("Cyfronet > DDDD Something 2")
+    expect(page).to_not have_text ("Cyfronet > DDDD Something 3")
+  end
 end


### PR DESCRIPTION
- Services can be found by provider or resource organisation

On search `cyfronet` in top searchbar, all resources of `Test-Cyfronet #10` should appear (3 of them).

Closes #1827