### PR TITLE
[#1859] Fix externally ordered resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Functional recommendation enhancements for the sake of better user experience (@wujuu)
 - Removal of duplicated provider entries in the Resource Provider field in the MP (@kmarszalek)
 - Feature highlight opinions panel in the admin section (@goreck888)
+- `Internal ordering` checkbox in offer's form (@goreck888)
 
 ### Changed
 - `Provided by` field in `Popular resources`, `Suggested compatible resources` and `Recently added resources` to `Organisation` (@kmarszalek, @jarekzet)
@@ -26,6 +27,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Fixed
 - Filtering by providers includes both `resource_organisation` and `providers` associations (@goreck888)
 - Displaying synchronization issues (if any occurs) in resource page for `data_administrators` (@goreck888)
+- Conditions to get external ordering of resource (@goreck888)
+- Internal ordering statistics in executive panel (@goreck888)
 
 ## [3.8.0] 2021-03-03
 

--- a/app/components/services/inline_order_url_component.rb
+++ b/app/components/services/inline_order_url_component.rb
@@ -19,7 +19,7 @@ class Services::InlineOrderUrlComponent < ApplicationComponent
 
   def link_name
     if @offerable.external
-      _("Order externally")
+      _("Go to the order website")
     else
       _("Go to the resource")
     end

--- a/app/models/concerns/offerable.rb
+++ b/app/models/concerns/offerable.rb
@@ -16,7 +16,7 @@ module Offerable
     validates :description, presence: true
 
     def external
-      !internal && order_required? && order_url.present?
+      order_required? && !internal
     end
 
     def open_access?

--- a/app/models/usage_report.rb
+++ b/app/models/usage_report.rb
@@ -59,9 +59,10 @@ class UsageReport
                                      status: [:published, :unverified]).uniq.count
       else
         Service.joins(:offers)
-            .where(offers: { order_type: types, order_url: ["", nil], status: :published },
-                   status: [:published, :unverified], order_type: types)
-            .uniq.count
+          .where("offers.order_type = ? AND services.status <> ? AND " +
+                   "offers.status = ? AND offers.internal = ?",
+                 types, "draft", "published", true)
+          .uniq.count
       end
     end
 end

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -44,7 +44,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:id, :name, :description, :webpage, :order_type, :order_url,
+    [:id, :name, :description, :webpage, :order_type, :order_url, :internal,
      parameters_attributes: [:type, :name, :hint, :min, :max,
                              :unit, :value_type, :start_price, :step_price, :currency,
                              :exclusive_min, :exclusive_max, :mode, :values, :value]]

--- a/app/services/service/create.rb
+++ b/app/services/service/create.rb
@@ -11,6 +11,7 @@ class Service::Create
                                 description: "#{@service.name} Offer",
                                 order_type: @service.order_type || "open_access",
                                 order_url: @service.order_url,
+                                internal: @service.order_url.blank?,
                                 webpage: @service.webpage_url, status: "published", service: @service)).call
     @service
   end

--- a/app/services/service/update.rb
+++ b/app/services/service/update.rb
@@ -11,6 +11,7 @@ class Service::Update
       Offer::Update.new(@service.offers.first, { order_type: @params[:order_type] || @service.order_type,
                                    order_url: @params[:order_url] || @service.order_url,
                                    webpage: @params[:webpage_url] || @service.webpage_url,
+                                   internal: @params[:webpage_url].blank? && @service.webpage_url.blank?,
                                    status: "published" }).call
     elsif @service.offers.size == 0
       Offer::Create.new(Offer.new(name: "Offer",
@@ -18,6 +19,7 @@ class Service::Update
                                   order_type: @params[:order_type] || @service.order_type,
                                   order_url: @params[:order_url] || @service.order_url,
                                   webpage: @params[:webpage_url] || @service.webpage_url,
+                                  internal: @params[:webpage_url].blank? && @service.webpage_url.blank?,
                                   status: "published",
                                   service: @service)).call
     end

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -8,6 +8,7 @@
       selected: (offer.order_type || service.order_type),
       input_html: { class: "form-control-lg col-lg-6" }
     = f.input :webpage, label: _("Offer website"), input_html: { class: "form-control-lg" }
+    = f.input :internal, label: _("Internal Marketplace ordering")
     = f.input :order_url, input_html: { class: "form-control-lg" }
 
   %h4.mt-5.mb-0.text-uppercase

--- a/app/views/components/services/information_description_component/_external.html.haml
+++ b/app/views/components/services/information_description_component/_external.html.haml
@@ -1,7 +1,7 @@
 %p
   To use this resource you need to request access at the provider’s website.
   Press
-  %strong Go to the resource
+  %strong Go to the order website
   button to visit it.
   You may also add the resource to a
   %strong Project

--- a/spec/components/services/information_description_component_spec.rb
+++ b/spec/components/services/information_description_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Services::InformationDescriptionComponent, type: :component do
                                                                 offer: offer))
 
     expect(page).to have_text("To use this resource you need to request access at the provider’s website." +
-                              "\nPress\nGo to the resource\nbutton to visit it.\n" +
+                              "\nPress\nGo to the order website\nbutton to visit it.\n" +
                               "You may also add the resource to a\nProject\nin order to:\n\n" +
                               "Gain EOSC experts support\nEasily access the selected resource" +
                               "\nOrganise your resources and orders into logical blocks\n\n\n\n" +

--- a/spec/components/services/inline_order_url_component_spec.rb
+++ b/spec/components/services/inline_order_url_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Services::InlineOrderUrlComponent, type: :component do
     offer = create(:external_offer)
     render_inline(Services::InlineOrderUrlComponent.new(offerable: offer))
 
-    expect(page).to have_link("Order externally")
+    expect(page).to have_link("Go to the order website")
   end
 
   it "hides button with webpage if order_required order_type" do

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     sequence(:status) { :published }
     sequence(:webpage) { |n| "http://webpage#{n}.invalid" }
     sequence(:order_type) { :order_required }
+    sequence(:internal) { true }
     factory :offer_with_parameters do
       sequence(:parameters) { [build(:input_parameter)] }
     end
@@ -29,6 +30,7 @@ FactoryBot.define do
       sequence(:order_type) { :open_access }
     end
     factory :external_offer do
+      sequence(:internal) { false }
       sequence(:order_type) { :order_required }
       sequence(:order_url) { "http://order.com" }
     end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -118,7 +118,8 @@ RSpec.feature "Service ordering" do
     [:open_access_service, :external_service].each do |type|
       scenario "I cannot order #{type} service twice in one project if offer has no parameters" do
         service = create(type)
-        _offer = create(:offer, service: service, order_type: service.order_type, order_url: service.order_url)
+        _offer = create(:offer, service: service, internal: false,
+                        order_type: service.order_type, order_url: service.order_url)
         _default_project = user.projects.find_by(name: "Services")
 
         visit service_path(service)
@@ -155,8 +156,8 @@ RSpec.feature "Service ordering" do
     [:open_access_service, :external_service].each do |type|
       scenario "I can order #{type} service twice in one project if offer has parameters" do
         service = create(type)
-        _offer = create(:offer_with_parameters, service: service, order_type: service.order_type,
-                        order_url: service.order_url)
+        _offer = create(:offer_with_parameters, service: service, internal: false,
+                        order_type: service.order_type, order_url: service.order_url)
         _default_project = user.projects.find_by(name: "Services")
 
         visit service_path(service)
@@ -510,7 +511,7 @@ RSpec.feature "Service ordering" do
 
         click_on "Access the resource"
 
-        expect(page).to have_link("Order externally")
+        expect(page).to have_link("Go to the order website")
       end
     end
   end

--- a/spec/models/usage_report_spec.rb
+++ b/spec/models/usage_report_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe UsageReport do
       create(:offer, service: s1, order_type: :order_required, status: :draft)
       create(:offer, service: s1, order_type: :open_access, status: :published)
       create(:offer, service: s1, order_type: :order_required, order_url: "http://order.com", status: :published)
-      create(:offer, service: s2, order_type: :order_required, status: :published)
-      create(:offer, service: s3, order_type: :order_required, status: :published)
-      create(:offer, service: s4, order_type: :order_required, status: :published)
+      create(:offer, service: s2, order_type: :order_required, internal: true, status: :published)
+      create(:offer, service: s3, order_type: :order_required, internal: true, status: :published)
+      create(:offer, service: s4, order_type: :order_required, internal: true, status: :published)
 
-      expect(subject.orderable_count).to eq(2)
+      expect(subject.orderable_count).to eq(3)
     end
   end
 
@@ -34,7 +34,7 @@ RSpec.describe UsageReport do
       create(:offer, service: s3, order_type: :order_required, order_url: "http://order.com", status: :published)
       create(:offer, service: s4, order_type: :order_required, order_url: "http://order.com", status: :published)
 
-      expect(subject.not_orderable_count).to eq(2)
+      expect(subject.not_orderable_count).to eq(1)
     end
   end
 


### PR DESCRIPTION
Fix conditions for external ordering type
Fix query in executive panel
Add hidden `internal` field to the Offer's form
Fixes #1859