### PR TITLE
Fix html tags in recommendation boxes

### DIFF
--- a/app/javascript/stylesheets/_ref_designsystem.scss
+++ b/app/javascript/stylesheets/_ref_designsystem.scss
@@ -472,8 +472,8 @@ li {
 
     img {
       float: none !important;
-      margin: 0 0 0 5%;
-      width: 90%;
+      margin: auto !important;
+      max-width: 90%;
       height: auto;
       vertical-align: middle;
     }

--- a/app/views/services/_recommendation_v1.html.haml
+++ b/app/views/services/_recommendation_v1.html.haml
@@ -1,11 +1,11 @@
 .service-info-box.recommendation.ver-1
   %header
-    = link_to highlighted_for(:name, recommendation_v1, highlights[recommendation_v1.id]).truncate(30),
+    = link_to truncate(recommendation_v1.send(:name), length: 40, escape: false),
               service_path(recommendation_v1, category.present? ? { fromc: category.slug } : nil,
               from_recommendation_panel: true), "data-probe": "recommendation-panel"
   %article
     %p
-      = truncate(highlighted_for(:tagline, recommendation_v1, highlights[recommendation_v1.id]), length: 110)
+      = truncate(recommendation_v1.send(:tagline), length: 110, escape: false)
   %footer
     .column-left
       %p

--- a/app/views/services/_recommendation_v2.html.haml
+++ b/app/views/services/_recommendation_v2.html.haml
@@ -2,7 +2,7 @@
   .recommend-box
     Recommended
   %header
-    = link_to highlighted_for(:name, recommendation_v2, highlights[recommendation_v2.id]).truncate(40),
+    = link_to truncate(recommendation_v2.send(:name), length: 40, escape: false),
               service_path(recommendation_v2, category.present? ? { fromc: category.slug } : nil,
               from_recommendation_panel: true), "data-probe": "recommendation-panel"
   %article
@@ -10,7 +10,7 @@
       .image-frame
         %span.helper
         = service_logo(recommendation_v2)
-      = truncate(highlighted_for(:tagline, recommendation_v2, highlights[recommendation_v2.id]), length: 110)
+      = truncate(recommendation_v2.send(:tagline), length: 110, escape: false)
   %footer
     .column-left
       %p


### PR DESCRIPTION
Bug:
when searching with multiple words that will be highlighted the end result isn't pretty :) 

Final solution:
remove highlights from the recommended section.
no changelog.
Closes #1908

-------------------------------

![image](https://user-images.githubusercontent.com/6060538/111633745-1d682080-87f6-11eb-8445-fb6df3b97e4d.png)

Search two worded highlights:
v1:
![Zrzut ekranu 2021-03-18 o 14 24 48](https://user-images.githubusercontent.com/6060538/111633553-ed208200-87f5-11eb-959b-1f3fa849f9bb.png)

v2:
![Zrzut ekranu 2021-03-18 o 14 24 27](https://user-images.githubusercontent.com/6060538/111633570-f0b40900-87f5-11eb-9bed-9026e334267f.png)

