### PR TITLE
[#1872, #1886] Handle old categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Displaying synchronization issues (if any occurs) in resource page for `data_administrators` (@goreck888)
 - Conditions to get external ordering of resource (@goreck888)
 - Internal ordering statistics in executive panel (@goreck888)
+- Fix showing _Other_ category in search bar select box on HOME page (@michal-szostak)
+- Fix ordering of search bar select box (Other always at the bottom) (@michal-szostak)
+- Redirect non existent categories url to `/services` (@michal-szostak)
 
 ## [3.8.0] 2021-03-03
 

--- a/app/controllers/concerns/service/categorable.rb
+++ b/app/controllers/concerns/service/categorable.rb
@@ -5,6 +5,7 @@ module Service::Categorable
 
   included do
     before_action :init_categories_tree, only: :index
+    rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_services
   end
 
   def category_counters(scope, filters)
@@ -23,6 +24,10 @@ module Service::Categorable
       @subcategories_with_counters = subcategories_with_counters&.
         partition { |cid, c|  c[:category][:name] != "Other" }&.flatten(1)
       @services_total ||= counters[nil]
+    end
+
+    def redirect_to_services
+      redirect_to :services
     end
 
     def category

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
   def index
     @learn_more_section = LeadSection.includes(:leads).find_by(slug: "learn-more")
     @use_cases_section = LeadSection.includes(:leads).find_by(slug: "use-cases")
-    @root_categories = @root_categories.with_attached_logo.reject { |c| c.name == "Other" }
+    @root_categories_with_logos = @root_categories.with_attached_logo.reject { |c| c.name == "Other" }
     @main_scientific_domains =
       ScientificDomain.with_attached_logo.roots.partition { |sd|  sd.name != "Other" }.flatten(1)
   end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -3,7 +3,7 @@
 
   = render "products",
     scientific_domains: @main_scientific_domains,
-    categories: @root_categories
+    categories: @root_categories_with_logos
 
   = render "communities",
     platforms: @home_platforms, more_platforms_count: @home_platforms_counter,

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -23,11 +23,11 @@
     %span{ "data-target": "search.selected" }
       = _("All resources")
     %select#category-select.container-select{ "data-action": "change->search#refresh",
-                                                    "data-target": "search.categorySelect" }
+                                              "data-target": "search.categorySelect" }
       %option{ value: "", selected: "selected" }
         = _("All resources")
-      = options_for_select categories.map { |category| [category.name, category.slug] }, params[:category]
+      = options_for_select categories.partition { |cat|  cat.name != "Other" }.flatten(1).map { |cat| [cat.name,
+        cat.slug] }, params[:category]
   .input-group-append
     %button#query-submit.input-group-text.bg-white
       %i.fas.fa-search
-

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -78,4 +78,10 @@ RSpec.feature "Service categories" do
 
     expect(page).to have_selector(".media", count: 1)
   end
+
+  scenario "navigating to nonexistent category should redirect to :services" do
+    category = build(:category, slug: "noncategory", name: "noncategory")
+    visit category_services_path(category, per_page: "1")
+    expect(page).to have_current_path(services_path)
+  end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -104,4 +104,15 @@ RSpec.feature "Service searching in top bar", js: true do
     expect(page).to have_text("DDDD Something offer 1")
     expect(page).to have_text("DDDD Something offer 2")
   end
+
+  scenario "'Other' category should be at the bottom of the category selection box", js: false do
+    create(:category, name: "Other")
+    create(:category, name: "Research")
+
+    # check services and HOME as there was a bug where home had different list then any other page
+    visit root_path
+    expect(page).to have_selector("#category-select > option:last-child", text: "Other")
+    visit :services
+    expect(page).to have_selector("#category-select > option:last-child", text: "Other")
+  end
 end


### PR DESCRIPTION
## What is in this PR?

* If non existent category link would result in 404 it's
  redirected to :services
* In navbar search "Other" is always at the end

Fixes #1872, fixes #1886