### PR TITLE
[HOTFIX] Fix logic of resource order wizards

### DIFF
--- a/app/models/usage_report.rb
+++ b/app/models/usage_report.rb
@@ -56,13 +56,13 @@ class UsageReport
     def service_count_by_order_type(*types, internal: false)
       unless internal
         Service.joins(:offers).where(offers: { order_type: types, status: :published },
-                                     status: [:published, :unverified]).uniq.count
+                                     status: [:published, :unverified, :errored]).uniq.count
       else
-        Service.joins(:offers)
-          .where("offers.order_type = ? AND services.status <> ? AND " +
-                   "offers.status = ? AND offers.internal = ?",
-                 types, "draft", "published", true)
-          .uniq.count
+        statuses = %w[published unverified errored]
+        empty = [nil, ""]
+        Service.joins(:offers).where("offers.order_type = ? AND services.status IN (?) AND offers.status IN (?) AND " +
+                                     "(offers.internal = ? OR (offers.internal = ? AND offers.order_url IN (?)))",
+                                     types, statuses, "published", true, false, empty).uniq.count
       end
     end
 end


### PR DESCRIPTION
Change logic:
external if offer is `order_required && !internal && order_url.present?`
internal in any other case of `order_required` offer
(it means `!internal && order_url.blank?` or just `internal`)
Executive statistics have unified query

In PRODUCTION data there should be only 3 services with external flag:
["InAcademia", "GÉANT Clouds Service ", "GÉANT Testbeds Service"]