### PR TITLE
[#1879] Add OMS to DB

### DIFF
--- a/app/models/oms.rb
+++ b/app/models/oms.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class Oms < ApplicationRecord
+  has_many :oms_administrations, dependent: :destroy
+  has_many :administrators,
+           through: :oms_administrations,
+           source: :user,
+           class_name: "User"
+  has_many :oms_providers, dependent: :destroy
+  has_many :providers, through: :oms_providers
+  has_many :offers, foreign_key: :primary_oms_id, dependent: :nullify
+  belongs_to :service, optional: true
+
+  self.inheritance_column = nil
+  enum type: {
+    global: "global",
+    provider_group: "provider_group",
+    resource_dedicated: "resource_dedicated"
+  }
+
+  validates :name, presence: true, uniqueness: true
+  validates :type, presence: true, inclusion: { in: types }
+
+  validates_associated :service, if: :resource_dedicated?
+  validates :service, presence: true, if: :resource_dedicated?
+  validates :providers, absence: true, if: :resource_dedicated?
+
+  validates_associated :providers, if: :provider_group?
+  validates :service, absence: true, if: :provider_group?
+  validates :providers, presence: true, if: :provider_group?
+
+  validates :service, absence: true, if: :global?
+  validates :providers, absence: true, if: :global?
+
+  validate :single_default_oms?, if: :default?
+
+  validate :validate_custom_params, if: :custom_params?
+
+  def mandatory_defaults
+    custom_params&.filter { |_, v| v["mandatory"] }&.transform_values { |v| v["default"] }
+  end
+
+  private
+    def single_default_oms?
+      if Oms.all.pluck(:default).any?
+        errors.add(:default, "there can't be more than one default OMS")
+      end
+    end
+
+    def validate_custom_params
+      unless custom_params.values.all? { |param| JSON::Validator.validate(CUSTOM_PARAMS_SCHEMA, param) }
+        errors.add(:custom_params, "custom_params values must be either {mandatory: false}, or {mandatory: true, default: 'value'}")
+      end
+    end
+
+    CUSTOM_PARAMS_SCHEMA = {
+      type: "object",
+      oneOf: [
+        {
+          properties: {
+            mandatory: { type: "boolean", enum: [true] },
+            default: { type: "string" }
+          },
+          additionalProperties: false,
+          required: [:mandatory, :default]
+        },
+        {
+          properties: {
+            mandatory: { type: "boolean", enum: [false] }
+          },
+          additionalProperties: false,
+          required: [:mandatory]
+        }
+      ]
+  }
+end

--- a/app/models/oms_administration.rb
+++ b/app/models/oms_administration.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class OmsAdministration < ApplicationRecord
+  belongs_to :oms
+  belongs_to :user
+
+  validates :oms, presence: true
+  validates :user, presence: true
+end

--- a/app/models/oms_provider.rb
+++ b/app/models/oms_provider.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class OmsProvider < ApplicationRecord
+  belongs_to :oms
+  belongs_to :provider
+
+  validates :oms, presence: true
+  validates :provider, presence: true
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -50,6 +50,8 @@ class Provider < ApplicationRecord
            source: :vocabulary, source_type: "Vocabulary::AreaOfActivity"
   has_many :societal_grand_challenges, through: :provider_vocabularies,
            source: :vocabulary, source_type: "Vocabulary::SocietalGrandChallenge"
+  has_many :oms_providers, dependent: :destroy
+  has_many :oms, through: :oms_providers
 
   has_one :main_contact, as: :contactable, dependent: :destroy, autosave: true
   has_many :public_contacts, as: :contactable, dependent: :destroy, autosave: true

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -66,6 +66,7 @@ class Service < ApplicationRecord
            source: :vocabulary, source_type: "Vocabulary::LifeCycleStatus"
   has_many :service_target_users, dependent: :destroy
   has_many :target_users, through: :service_target_users
+  has_many :oms, dependent: :destroy
 
   has_one :main_contact, as: :contactable, dependent: :destroy, autosave: true
   has_many :public_contacts, as: :contactable, dependent: :destroy, autosave: true
@@ -90,6 +91,7 @@ class Service < ApplicationRecord
            foreign_key: "target_id",
            dependent: :destroy,
            inverse_of: :target
+
   has_many :target_relationships,
            class_name: "ServiceRelationship",
            foreign_key: "source_id",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,11 @@ class User < ApplicationRecord
   has_many :categories, through: :user_categories
   has_many :user_scientific_domains, dependent: :destroy
   has_many :scientific_domains, through: :user_scientific_domains
+  has_many :oms_administrations, dependent: :destroy
+  has_many :administrated_oms,
+           through: :oms_administrations,
+           source: :oms,
+           class_name: "Oms"
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,3 +16,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.uncountable "Oms"
+end

--- a/db/migrate/20210324140221_create_oms.rb
+++ b/db/migrate/20210324140221_create_oms.rb
@@ -1,0 +1,14 @@
+class CreateOms < ActiveRecord::Migration[6.0]
+  def change
+    create_table :oms do |t|
+      t.string :name, null: false, unique: true
+      t.string :type, null: false, index: true
+      t.jsonb :custom_params, null: true
+      t.boolean :default, null: false, default: false, index: true
+      t.string :trigger_url, null: true
+      t.references :service, foreign_key: true, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20210324141046_create_oms_administrations.rb
+++ b/db/migrate/20210324141046_create_oms_administrations.rb
@@ -1,0 +1,12 @@
+class CreateOmsAdministrations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :oms_administrations do |t|
+      t.references :oms, null: false, foreign_key: true, index:true
+      t.references :user, null: false, foreign_key: true, index:true
+
+      t.timestamps null: false
+    end
+
+    add_index :oms_administrations, [:oms_id, :user_id], unique: true
+  end
+end

--- a/db/migrate/20210324141438_create_oms_providers.rb
+++ b/db/migrate/20210324141438_create_oms_providers.rb
@@ -1,0 +1,12 @@
+class CreateOmsProviders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :oms_providers do |t|
+      t.references :oms, null: false, foreign_key: true, index: true
+      t.references :provider, null: false, foreign_key: true, index: true
+
+      t.timestamps null: false
+    end
+
+    add_index :oms_providers, [:oms_id, :provider_id], unique: true
+  end
+end

--- a/db/migrate/20210325120212_add_oms_to_offer.rb
+++ b/db/migrate/20210325120212_add_oms_to_offer.rb
@@ -1,0 +1,6 @@
+class AddOmsToOffer < ActiveRecord::Migration[6.0]
+  def change
+    add_column :offers, :oms_params, :jsonb
+    add_reference :offers, :primary_oms,  foreign_key: { to_table: :oms }, index: true, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_23_162816) do
+ActiveRecord::Schema.define(version: 2021_03_25_120212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -174,9 +174,46 @@ ActiveRecord::Schema.define(version: 2021_03_23_162816) do
     t.boolean "internal", default: false
     t.string "order_url"
     t.boolean "default", default: false
+    t.jsonb "oms_params"
+    t.bigint "primary_oms_id"
     t.index ["iid"], name: "index_offers_on_iid"
+    t.index ["primary_oms_id"], name: "index_offers_on_primary_oms_id"
     t.index ["service_id", "iid"], name: "index_offers_on_service_id_and_iid", unique: true
     t.index ["service_id"], name: "index_offers_on_service_id"
+  end
+
+  create_table "oms", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "type", null: false
+    t.jsonb "custom_params"
+    t.boolean "default", default: false, null: false
+    t.string "trigger_url"
+    t.bigint "service_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["default"], name: "index_oms_on_default"
+    t.index ["service_id"], name: "index_oms_on_service_id"
+    t.index ["type"], name: "index_oms_on_type"
+  end
+
+  create_table "oms_administrations", force: :cascade do |t|
+    t.bigint "oms_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["oms_id", "user_id"], name: "index_oms_administrations_on_oms_id_and_user_id", unique: true
+    t.index ["oms_id"], name: "index_oms_administrations_on_oms_id"
+    t.index ["user_id"], name: "index_oms_administrations_on_user_id"
+  end
+
+  create_table "oms_providers", force: :cascade do |t|
+    t.bigint "oms_id", null: false
+    t.bigint "provider_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["oms_id", "provider_id"], name: "index_oms_providers_on_oms_id_and_provider_id", unique: true
+    t.index ["oms_id"], name: "index_oms_providers_on_oms_id"
+    t.index ["provider_id"], name: "index_oms_providers_on_provider_id"
   end
 
   create_table "platforms", force: :cascade do |t|
@@ -600,6 +637,12 @@ ActiveRecord::Schema.define(version: 2021_03_23_162816) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "offers", "oms", column: "primary_oms_id"
+  add_foreign_key "oms", "services"
+  add_foreign_key "oms_administrations", "oms"
+  add_foreign_key "oms_administrations", "users"
+  add_foreign_key "oms_providers", "oms"
+  add_foreign_key "oms_providers", "providers"
   add_foreign_key "project_items", "offers"
   add_foreign_key "project_items", "projects"
   add_foreign_key "project_scientific_domains", "projects"

--- a/lib/ordering_api/add_sombo.rb
+++ b/lib/ordering_api/add_sombo.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module OrderingApi
+  class AddSombo
+    def initialize; end
+
+    def call
+      sombo_admin = User.find_or_create_by(uid: "iamasomboadmin") do |user|
+        user.first_name = "SOMBO admin"
+        user.last_name = "SOMBO admin"
+        user.email = "sombo@sombo.com"
+      end
+
+      sombo = Oms.find_or_create_by(name: "SOMBO") do |oms|
+        oms.type = :global
+        oms.default = true
+        oms.custom_params = { order_target: { mandatory: false } }
+        oms.administrators = [sombo_admin]
+      end
+
+      Offer.all.each do |o|
+        if o.current_oms == sombo && o.service.order_target.present?
+          o.update(oms_params: { order_target: o.service.order_target })
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/ordering_api.rake
+++ b/lib/tasks/ordering_api.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "ordering_api/add_sombo"
+
+namespace :ordering_api do
+  desc "Add global SOMBO OMS"
+  task add_sombo: :environment do
+    OrderingApi::AddSombo.new.call
+  end
+end

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     sequence(:webpage) { |n| "http://webpage#{n}.invalid" }
     sequence(:order_type) { :order_required }
     sequence(:internal) { true }
+
     factory :offer_with_parameters do
       sequence(:parameters) { [build(:input_parameter)] }
     end

--- a/spec/factories/oms.rb
+++ b/spec/factories/oms.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :oms do
+    sequence(:name) { |n| "OMS #{n}" }
+    sequence(:trigger_url) { |n| "http://webhook#{n}.com" }
+    sequence(:administrators) { build_list(:user, 2) }
+    type { "global" }
+
+    factory :provider_group_oms do
+      type { "provider_group" }
+      sequence(:providers) { build_list(:provider, 2) }
+    end
+
+    factory :resource_dedicated_oms do
+      type { "resource_dedicated" }
+      sequence(:service) { build(:service) }
+    end
+  end
+end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -34,6 +34,7 @@ FactoryBot.define do
     sequence(:version) { nil }
     sequence(:trl) { [create(:trl)] }
     sequence(:synchronized_at) { Time.now - 2.days }
+    sequence(:order_target) { "admin@admin.com" }
 
     upstream { nil }
 

--- a/spec/lib/ordering_api/add_sombo_spec.rb
+++ b/spec/lib/ordering_api/add_sombo_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ordering_api/add_sombo"
+
+describe OrderingApi::AddSombo do
+  it "creates SOMBO OMS and adds SOMBO admin to it" do
+    described_class.new.call
+
+    expect(User.count).to eq(1)
+    expect(User.first.first_name).to eq("SOMBO admin")
+    expect(Oms.count).to eq(1)
+    expect(Oms.first.name).to eq("SOMBO")
+    expect(Oms.first.administrators.first.first_name).to eq("SOMBO admin")
+  end
+
+  it "doesnt create SOMBO OMS and SOMBO admin if they exist" do
+    admin = create(:user, first_name: "SOMBO admin", last_name: "SOMBO admin", email: "sombo@sombo.com", uid: "iamasomboadmin")
+    create(:oms, name: "SOMBO", type: :global, default: true, custom_params: { order_target: { mandatory: false } }, administrators: [admin])
+    described_class.new.call
+
+    expect(User.count).to eq(1)
+    expect(User.first.first_name).to eq("SOMBO admin")
+    expect(Oms.count).to eq(1)
+    expect(Oms.first.name).to eq("SOMBO")
+    expect(Oms.first.administrators.first.first_name).to eq("SOMBO admin")
+  end
+
+  it "if updates offers' oms_params properly" do
+    offer1 = create(:offer, primary_oms: nil, service: create(:service, order_target: "admin@admin.pl"))
+    service = create(:service, order_target: "data@data.pl")
+    offer2 = create(:offer, primary_oms: nil, service: service)
+
+    described_class.new.call
+    offer1.reload
+    offer2.reload
+
+    expect(offer1.current_oms).to eql(Oms.find_by(default: true))
+    expect(offer1.current_oms.name).to eql("SOMBO")
+    expect(offer1.oms_params.symbolize_keys).to eql({ order_target: "admin@admin.pl" })
+
+    expect(offer2.current_oms).to eql(Oms.find_by(default: true))
+    expect(offer2.current_oms.name).to eql("SOMBO")
+    expect(offer2.oms_params.symbolize_keys).to eql({ order_target: "data@data.pl" })
+
+    new_oms = build(:oms, custom_params: { a: { mandatory: true, default: "asd" } })
+    offer1.update(primary_oms: new_oms, oms_params: { a: "qwe" })
+    service.update(order_target: "qwe@qwe.pl")
+
+    described_class.new.call
+    offer1.reload
+    offer2.reload
+
+    expect(offer1.current_oms).to eql(new_oms)
+    expect(offer1.oms_params.symbolize_keys).to eql({ a: "qwe" })
+
+    expect(offer2.current_oms).to eql(Oms.find_by(default: true))
+    expect(offer2.current_oms.name).to eql("SOMBO")
+    expect(offer2.oms_params.symbolize_keys).to eql({ order_target: "qwe@qwe.pl" })
+  end
+end

--- a/spec/models/jira/client_spec.rb
+++ b/spec/models/jira/client_spec.rb
@@ -25,7 +25,7 @@ describe Jira::Client do
     project_item = create(:project_item,
           offer: create(:offer, name: "off1", service: create(:service,
                                                               name: "s1",
-                                                        categories: [create(:category, name: "cat1")])),
+                                                              categories: [create(:category, name: "cat1")])),
           project: create(:project, user: user, name: "My Secret Project",
                           user_group_name: "New user group", reason_for_access: "some reason"),
           properties: [
@@ -75,7 +75,7 @@ describe Jira::Client do
                            "Harvesting endpoint" => "aaaaa",
                          }
                        }.to_json,
-                       "SO-ServiceOrderTarget-1" => "",
+                       "SO-ServiceOrderTarget-1" => "admin@admin.com",
                        "SO-OfferType-1" => { "id" => "20005" } }
 
     issue = double(:Issue)
@@ -163,7 +163,7 @@ describe Jira::Client do
                           "offer" => "off1",
                           "attributes" => {}
                         }.to_json,
-                        "SO-ServiceOrderTarget-1" => "",
+                        "SO-ServiceOrderTarget-1" => "admin@admin.com",
                         "SO-OfferType-1" => { "id" => "20006" } }
 
     issue = double(:Issue)
@@ -204,7 +204,7 @@ describe Jira::Client do
                           "offer" => "off1",
                           "attributes" => {}
                         }.to_json,
-                        "SO-ServiceOrderTarget-1" => "",
+                        "SO-ServiceOrderTarget-1" => "admin@admin.com",
                         "SO-OfferType-1" => { "id" => "20006" } }
 
     issue = double(:Issue)

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -3,13 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Offer do
-  it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:description) }
-  it { should validate_presence_of(:service) }
-  it { should validate_presence_of(:order_type) }
-  it { should belong_to(:service) }
+  describe "validations" do
+    subject { build(:offer) }
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:description) }
+    it { should validate_presence_of(:service) }
+    it { should validate_presence_of(:order_type) }
+    it { should belong_to(:service) }
 
-  it { should have_many(:project_items).dependent(:restrict_with_error) }
+    it { should have_many(:project_items).dependent(:restrict_with_error) }
+  end
 
   context "is open access" do
     subject { build(:offer, order_type: :open_access) }
@@ -24,6 +27,34 @@ RSpec.describe Offer do
   context "is orderable" do
     subject { build(:offer, order_type: :order_required) }
     it { should_not validate_presence_of(:webpage) }
+  end
+
+  context "OMS dependencies" do
+    it "validates properly against primary oms" do
+      oms = build(:oms, custom_params: { a: { mandatory: false }, b: { mandatory: true, default: "XD" } })
+
+      expect(build(:offer, oms_params: { a: 1, b: 2 }, primary_oms: oms)).to be_valid
+      expect(build(:offer, oms_params: { b: 1 }, primary_oms: oms)).to be_valid
+
+      expect(build(:offer, oms_params: { a: 1 }, primary_oms: oms)).to_not be_valid
+      expect(build(:offer, oms_params: { a: 1, b: 1, c: 1 }, primary_oms: oms)).to_not be_valid
+      expect(build(:offer, oms_params: nil, primary_oms: oms)).to_not be_valid
+      expect(build(:offer, oms_params: { b: 1, c: 1 }, primary_oms: build(:oms, custom_params: nil))).to_not be_valid
+
+      expect(build(:offer, oms_params: { c: 1 }, primary_oms: nil)).to_not be_valid
+      create(:oms, default: true, custom_params: { c: { mandatory: true, default: "c" } })
+      expect(build(:offer, oms_params: { c: 1 }, primary_oms: nil)).to be_valid
+    end
+
+    it "returns proper current_oms" do
+      oms = create(:oms)
+      expect(build(:offer, primary_oms: oms).current_oms).to eql(oms)
+      expect(build(:offer, primary_oms: nil).current_oms).to be_nil
+
+      default_oms = create(:oms, default: true)
+      expect(build(:offer, primary_oms: oms).current_oms).to eql(oms)
+      expect(build(:offer, primary_oms: nil).current_oms).to eql(default_oms)
+    end
   end
 
   context "#parameters" do

--- a/spec/models/oms_spec.rb
+++ b/spec/models/oms_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Oms, type: :model do
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:type) }
+
+  # Couldn't get shoulda_matchers to work with conditional validations so I'm writing normal tests
+
+  context "validate uniqueness of name" do
+    subject { create(:oms) }
+    it { should validate_uniqueness_of(:name) }
+  end
+
+  it "should validate single_default_oms?" do
+    create(:oms, default: true)
+    expect(build(:oms, default: true)).to_not be_valid
+  end
+
+  it "should validate custom_params" do
+    expect(build(:oms, custom_params: { a: { mandatory: false }, b: { mandatory: true, default: "ASD" } })).to be_valid
+    expect(build(:oms, custom_params: nil)).to be_valid
+    expect(build(:oms, custom_params: {})).to be_valid
+
+    expect(build(:oms, custom_params: { a: { default: "ASD" } })).to_not be_valid
+    expect(build(:oms, custom_params: { a: { mandatory: false, default: "ASD" } })).to_not be_valid
+    expect(build(:oms, custom_params: { a: { mandatory: true } })).to_not be_valid
+    expect(build(:oms, custom_params: { a: { mandatory: false }, b: { mandatory: true } })).to_not be_valid
+    expect(build(:oms, custom_params: { a: 1 })).to_not be_valid
+    expect(build(:oms, custom_params: { a: { b: 1 } })).to_not be_valid
+  end
+
+  context "global OMS" do
+    it "should validate properly" do
+      expect(build(:oms)).to be_valid
+      expect(build(:oms, offers: [])).to be_valid
+      expect(build(:oms, offers: build_list(:offer, 2))).to be_valid
+      expect(build(:oms, providers: build_list(:provider, 2))).to_not be_valid
+      expect(build(:oms, service: build(:service))).to_not be_valid
+    end
+  end
+
+  context "resource dedicated OMS" do
+    it "should validate properly" do
+      expect(build(:resource_dedicated_oms)).to be_valid
+      expect(build(:resource_dedicated_oms, offers: [])).to be_valid
+      expect(build(:resource_dedicated_oms, offers: build_list(:offer, 2))).to be_valid
+      expect(build(:resource_dedicated_oms, providers: build_list(:provider, 2))).to_not be_valid
+      expect(build(:resource_dedicated_oms, service: nil)).to_not be_valid
+    end
+  end
+
+  context "provider group OMS" do
+    it "should validate properly" do
+      expect(build(:provider_group_oms)).to be_valid
+      expect(build(:provider_group_oms, offers: [])).to be_valid
+      expect(build(:provider_group_oms, offers: build_list(:offer, 2))).to be_valid
+      expect(build(:provider_group_oms, service: build(:service))).to_not be_valid
+      expect(build(:provider_group_oms, providers: [])).to_not be_valid
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -16,4 +16,9 @@ RSpec.describe Provider, type: :model do
     subject { create(:provider) }
     it { should validate_uniqueness_of(:name) }
   end
+
+  context "OMS validations" do
+    subject { build(:provider, oms: build_list(:provider_group_oms, 2)) }
+    it { should have_many(:oms) }
+  end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -110,4 +110,9 @@ RSpec.describe Service do
       expect(Service.administered_by(other_data_admin_user)).to match_array([service_3, service_4])
     end
   end
+
+  context "OMS validations" do
+    subject { build(:service, oms: build_list(:resource_dedicated_oms, 2)) }
+    it { should have_many(:oms) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe User do
     end
   end
 
+  context "OMS validations" do
+    subject { build(:user, administrated_oms: build_list(:oms, 2)) }
+    it { should have_many(:administrated_oms) }
+  end
+
   context "authentication_token" do
     it "is present when creating new user" do
       user = create(:user)


### PR DESCRIPTION
Closes #1879 

**What has been changed**: 

- Add OMS, OmsAministration, OmsProviders and OmsOffer models
- Add primary_oms to Offer, add validations
- Add default OMS logic
- Add SOMBO OMS (along with its admin) creation migration
- Add OMS/Offer model specs