### PR TITLE
Bump mimemagic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
Fixes deploy issues caused by
change license of mimemagic gem