### PR TITLE
[#1881] Generalize project_item status

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.6)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -691,4 +693,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.2.7

--- a/app/helpers/project_items_helper.rb
+++ b/app/helpers/project_items_helper.rb
@@ -25,11 +25,11 @@ module ProjectItemsHelper
     if project_item.in_progress?
       content_tag(:i, nil, class: "fas fa-spinner",
                   "data-toggle": "tooltip", "data-placement": "auto left",
-                  "title": "Status: #{t "project_items.status.#{project_item.status}"}")
+                  "title": "Status: #{t "project_items.status.#{project_item.status_type}"}")
     else
-      content_tag(:i, nil, class: "fas fa-circle status-#{project_item.status}",
+      content_tag(:i, nil, class: "fas fa-circle status-#{project_item.status_type}",
                   "data-toggle": "tooltip", "data-placement": "auto left",
-                  "title": "Status: #{t "project_items.status.#{project_item.status}"}")
+                  "title": "Status: #{t "project_items.status.#{project_item.status_type}"}")
     end
   end
 

--- a/app/mailers/project_item_mailer.rb
+++ b/app/mailers/project_item_mailer.rb
@@ -3,7 +3,7 @@
 class ProjectItemMailer < ApplicationMailer
   def created(project_item)
     load_data(project_item)
-    if @project_item.status == "created"
+    if @project_item.created?
       mail(to: @user.email,
            subject: "New request for the service access in the EOSC Marketplace - CREATED",
            template_name: "created")

--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -229,7 +229,7 @@ private
     when "CI-DisplayName"
       "#{project.user.first_name} #{project.user.last_name}"
     when "CP-ScientificDiscipline"
-      project.scientific_domains .names.join(", ")
+      project.scientific_domains.names.join(", ")
     when "CI-EOSC-UniqueID"
       project.user.uid
     when "CP-CustomerTypology"

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -7,7 +7,7 @@ class ProjectItem < ApplicationRecord
   include Iid
   include Offerable
 
-  STATUSES = {
+  STATUS_TYPES = {
     created: "created",
     registered: "registered",
     in_progress: "in_progress",
@@ -25,7 +25,7 @@ class ProjectItem < ApplicationRecord
       jira_errored: 3
   }
 
-  enum status: STATUSES
+  enum status_type: STATUS_TYPES
   enum issue_status: ISSUE_STATUSES
 
   belongs_to :offer
@@ -39,6 +39,7 @@ class ProjectItem < ApplicationRecord
 
   validates :offer, presence: true
   validates :status, presence: true
+  validates :status_type, presence: true
   validate :scientific_domain_is_a_leaf
   validate :properties_not_nil
 
@@ -58,14 +59,9 @@ class ProjectItem < ApplicationRecord
     !(ready? || rejected?)
   end
 
-  def new_status(status: nil, author: nil)
-    # don't create change when there is not status and message given
-    return unless status
-
-    status ||= self.status
-
-    statuses.create(status: status, author: author).tap do
-      update(status: status)
+  def new_status(status:, status_type:, author: nil)
+    statuses.create(status: status, status_type: status_type, author: author).tap do
+      update(status: status, status_type: status_type)
     end
   end
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Status < ApplicationRecord
-  enum status: ProjectItem::STATUSES
+  enum status_type: ProjectItem::STATUS_TYPES
   belongs_to :author,
              class_name: "User",
              optional: true
   belongs_to :status_holder, polymorphic: true
 
   validates :status, presence: true
+  validates :status_type, presence: true
 end

--- a/app/services/jira/issue_updated.rb
+++ b/app/services/jira/issue_updated.rb
@@ -35,7 +35,7 @@ class Jira::IssueUpdated
         end
 
         if status
-          @project_item.new_status(status: status)
+          @project_item.new_status(status: status.to_s, status_type: status)
           if status == :ready && service.order_required? && !service.external
             if service.aod?
               aod_voucherable? ? ProjectItemMailer.aod_voucher_accepted(@project_item).deliver_later :

--- a/app/services/project_item/create.rb
+++ b/app/services/project_item/create.rb
@@ -10,7 +10,7 @@ class ProjectItem::Create
     @project_item.created!
 
     if @project_item.save
-      @project_item.statuses.create(status: :created)
+      @project_item.statuses.create(status: "created", status_type: :created)
 
       unless orderable?
         ProjectItem::ReadyJob.perform_later(@project_item, @message)

--- a/app/services/project_item/ready.rb
+++ b/app/services/project_item/ready.rb
@@ -50,7 +50,7 @@ class ProjectItem::Ready
     end
 
     def update_status!
-      @project_item.new_status(status: :ready)
+      @project_item.new_status(status: "ready", status_type: :ready)
     end
 
     def activate_message

--- a/app/services/project_item/register.rb
+++ b/app/services/project_item/register.rb
@@ -32,7 +32,7 @@ class ProjectItem::Register
     end
 
     def update_status!
-      @project_item.new_status(status: :registered)
+      @project_item.new_status(status: "registered", status_type: :registered)
       true
     end
 

--- a/app/views/projects/services/_layout.html.haml
+++ b/app/views/projects/services/_layout.html.haml
@@ -16,7 +16,7 @@
         - if project_item.orderable?
           %p.text-uppercase.text-right.font-weight-bold.text-secondary.mb-0
             -# TODO: refactor dynamic translation
-            %span{ class: "status-#{project_item.status}" }= t("project_items.status.#{project_item.status}")
+            %span{ class: "status-#{project_item.status_type}" }= t("project_items.status.#{project_item.status_type}")
 
         = render Services::InlineOrderUrlComponent.new(offerable: project_item,
           classes: "btn btn-primary float-right pl-3 pr-3")

--- a/app/views/projects/services/_project_item.html.haml
+++ b/app/views/projects/services/_project_item.html.haml
@@ -3,7 +3,7 @@
   .float-right.status
     - if project_item.closed?
       -# TODO: refactor dynamic translation
-      = t("project_items.status.#{project_item.status}")
+      = t("project_items.status.#{project_item.status_type}")
     - elsif !project_item.orderable?
       = link_to _("Visit website"), webpage(project_item)
     - else

--- a/app/views/statuses/_status.html.haml
+++ b/app/views/statuses/_status.html.haml
@@ -4,6 +4,6 @@
 
   .ml-4
     -# TODO: refactor dynamic translation
-    %p.frame= t("conversations.status.info.#{status.status}")
-    .d-block.message-info Resource request status: #{t "project_items.status.#{status.status}"}
+    %p.frame= t("conversations.status.info.#{status.status_type}")
+    .d-block.message-info Resource request status: #{t "project_items.status.#{status.status_type}"}
 

--- a/db/migrate/20210323162816_generalize_project_item_statuses.rb
+++ b/db/migrate/20210323162816_generalize_project_item_statuses.rb
@@ -1,0 +1,15 @@
+class GeneralizeProjectItemStatuses < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :project_item_changes
+
+    rename_column :project_items, :status, :status_type
+    add_column :project_items, :status, :string, default: "created"
+    exec_update "UPDATE project_items set status = status_type"
+    change_column_null :project_items, :status, false
+
+    rename_column :statuses, :status, :status_type
+    add_column :statuses, :status, :string
+    exec_update "UPDATE statuses set status = status_type"
+    change_column_null :statuses, :status, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_16_161711) do
+ActiveRecord::Schema.define(version: 2021_03_23_162816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -187,20 +187,8 @@ ActiveRecord::Schema.define(version: 2021_03_16_161711) do
     t.index ["name"], name: "index_platforms_on_name", unique: true
   end
 
-  create_table "project_item_changes", force: :cascade do |t|
-    t.string "status"
-    t.text "message"
-    t.bigint "project_item_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "author_id"
-    t.integer "iid"
-    t.index ["author_id"], name: "index_project_item_changes_on_author_id"
-    t.index ["project_item_id"], name: "index_project_item_changes_on_project_item_id"
-  end
-
   create_table "project_items", force: :cascade do |t|
-    t.string "status", null: false
+    t.string "status_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "issue_id"
@@ -218,6 +206,7 @@ ActiveRecord::Schema.define(version: 2021_03_16_161711) do
     t.boolean "voucherable", default: false, null: false
     t.boolean "internal", default: false
     t.string "order_url"
+    t.string "status", default: "created", null: false
     t.index ["offer_id"], name: "index_project_items_on_offer_id"
     t.index ["project_id"], name: "index_project_items_on_project_id"
   end
@@ -482,11 +471,12 @@ ActiveRecord::Schema.define(version: 2021_03_16_161711) do
 
   create_table "statuses", force: :cascade do |t|
     t.bigint "author_id"
-    t.string "status"
+    t.string "status_type"
     t.string "status_holder_type"
     t.bigint "status_holder_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", null: false
     t.index ["author_id"], name: "index_statuses_on_author_id"
     t.index ["status_holder_type", "status_holder_id"], name: "index_statuses_on_status_holder_type_and_status_holder_id"
   end
@@ -610,7 +600,6 @@ ActiveRecord::Schema.define(version: 2021_03_16_161711) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "project_item_changes", "users", column: "author_id"
   add_foreign_key "project_items", "offers"
   add_foreign_key "project_items", "projects"
   add_foreign_key "project_scientific_domains", "projects"

--- a/spec/factories/order_changes.rb
+++ b/spec/factories/order_changes.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :project_item_change do
-    status { :created }
-    sequence(:message) { |n| "project_item change #{n} message" }
-    project_item
-  end
-end

--- a/spec/factories/project_items.rb
+++ b/spec/factories/project_items.rb
@@ -2,7 +2,8 @@
 
 FactoryBot.define do
   factory :project_item do
-    status { :created }
+    status { "created" }
+    status_type { :created }
     voucher_id { "" }
     request_voucher { false }
 

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -2,7 +2,8 @@
 
 FactoryBot.define do
   factory :status do
-    value { :created }
+    status { "created" }
+    status_type { :created }
     association(:status_holder, factory: :project_item)
   end
 end

--- a/spec/features/my_services_spec.rb
+++ b/spec/features/my_services_spec.rb
@@ -68,9 +68,9 @@ RSpec.feature "My Services" do
       project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer)
 
-      project_item.new_status(status: :created)
-      project_item.new_status(status: :registered)
-      project_item.new_status(status: :ready)
+      project_item.new_status(status: "created", status_type: :created)
+      project_item.new_status(status: "registered", status_type: :registered)
+      project_item.new_status(status: "ready", status_type: :ready)
 
       visit project_service_timeline_path(project, project_item)
 
@@ -120,7 +120,7 @@ RSpec.feature "My Services" do
 
     scenario "I can see review section" do
       project = create(:project, user: user)
-      project_item = create(:project_item, project: project, offer: offer, status: :ready)
+      project_item = create(:project_item, project: project, offer: offer, status: "ready", status_type: :ready)
       travel 1.day
       visit project_service_path(project, project_item)
 

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -165,7 +165,7 @@ RSpec.feature "Project" do
         service = create(:open_access_service)
         offer = create(:offer, service: service)
 
-        create(:project_item, offer: offer, project: project, status: :closed)
+        create(:project_item, offer: offer, project: project, status: "closed", status_type: :closed)
 
         visit project_path(project)
 
@@ -187,7 +187,7 @@ RSpec.feature "Project" do
         service = create(:open_access_service)
         offer = create(:offer, service: service)
 
-        create(:project_item, offer: offer, project: project, status: :closed)
+        create(:project_item, offer: offer, project: project, status: "closed", status_type: :closed)
 
         allow(project_archive).to receive(:call).and_return(true)
 

--- a/spec/helpers/project_items_helper_spec.rb
+++ b/spec/helpers/project_items_helper_spec.rb
@@ -5,26 +5,26 @@ require "rails_helper"
 RSpec.describe ProjectItemsHelper, type: :helper do
   describe "#show_rating_button?" do
     it "is false when project_item is not ready" do
-      @project_item = create(:project_item, status: :created)
+      @project_item = create(:project_item, status: "custom_created", status_type: :created)
       expect(ratingable?).to be_falsy
-      @project_item.new_status(status: :registered)
+      @project_item.new_status(status: "custom_registered", status_type: :registered)
       expect(ratingable?).to be_falsy
-      @project_item.new_status(status: :in_progress)
+      @project_item.new_status(status: "custom_in_progress", status_type: :in_progress)
       expect(ratingable?).to be_falsy
-      @project_item.new_status(status: :rejected)
+      @project_item.new_status(status: "custom_rejected", status_type: :rejected)
       expect(ratingable?).to be_falsy
     end
 
     it "is false when project_item is ready but there is service_opinion" do
-      @project_item = create(:project_item, status: :created)
-      @project_item.new_status(status: :ready)
+      @project_item = create(:project_item, status: "custom_created", status_type: :created)
+      @project_item.new_status(status: "custom_ready", status_type: :ready)
       create(:service_opinion, service_rating: "3", order_rating: "3", project_item: @project_item)
       expect(ratingable?).to eq(false)
     end
 
     it "is true when project_item is ready and no service_opinion" do
-      @project_item = create(:project_item, status: :created)
-      @project_item.new_status(status: :ready)
+      @project_item = create(:project_item, status: "custom_created", status_type: :created)
+      @project_item.new_status(status: "custom_ready", status_type: :ready)
       expect(ratingable?).to eq(true)
     end
   end

--- a/spec/mailers/project_item_spec.rb
+++ b/spec/mailers/project_item_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe ProjectItemMailer, type: :mailer do
   context "project_item change" do
     let(:project_item) { create(:project_item, project: project) }
     before(:each) do
-      project_item.new_status(status: :created)
-      project_item.new_status(status: :registered)
+      project_item.new_status(status: "custom_created", status_type: :created)
+      project_item.new_status(status: "custom_registered", status_type: :registered)
     end
 
     it "notifies about project_item status change to waiting_for_response" do
-      project_item.new_status(status: :waiting_for_response)
+      project_item.new_status(status: "custom_waiting_for_response", status_type: :waiting_for_response)
 
       mail = described_class.waiting_for_response(project_item).deliver_now
       encoded_body = mail.body.encoded
@@ -47,7 +47,7 @@ RSpec.describe ProjectItemMailer, type: :mailer do
     end
 
     it "notifies about project_item status change to rejected" do
-      project_item.new_status(status: :rejected)
+      project_item.new_status(status: "custom_rejected", status_type: :rejected)
 
       mail = described_class.rejected(project_item).deliver_now
       encoded_body = mail.body.encoded
@@ -61,7 +61,7 @@ RSpec.describe ProjectItemMailer, type: :mailer do
     end
 
     it "notifies about project_item status change to closed" do
-      project_item.new_status(status: :closed)
+      project_item.new_status(status: "custom_closed", status_type: :closed)
 
       mail = described_class.closed(project_item).deliver_now
       encoded_body = mail.body.encoded
@@ -75,7 +75,7 @@ RSpec.describe ProjectItemMailer, type: :mailer do
     end
 
     it "notifies about project_item status change to approved" do
-      project_item.new_status(status: :approved)
+      project_item.new_status(status: "custom_approved", status_type: :approved)
 
       mail = described_class.approved(project_item).deliver_now
       encoded_body = mail.body.encoded

--- a/spec/models/project_item_spec.rb
+++ b/spec/models/project_item_spec.rb
@@ -8,33 +8,29 @@ RSpec.describe ProjectItem do
   it { should validate_presence_of(:offer) }
   it { should validate_presence_of(:project) }
   it { should validate_presence_of(:status) }
+  it { should validate_presence_of(:status_type) }
 
   it { should belong_to(:project) }
   it { should belong_to(:offer) }
 
-
   describe "#new_status" do
-    it "new status is not created when no message and status is given" do
-      project_item = create(:project_item)
-
-      expect { project_item.new_status }.to_not change { Status.count }
-    end
-
     it "change project_item status" do
-      project_item = create(:project_item, status: :created)
+      project_item = create(:project_item, status: "created", status_type: :created)
 
-      project_item.new_status(status: :registered)
+      project_item.new_status(status: "custom_registered", status_type: :registered)
       new_status = project_item.statuses.last
 
       expect(project_item).to be_registered
+      expect(project_item.status).to eq "custom_registered"
       expect(new_status).to be_registered
+      expect(new_status.status).to eq "custom_registered"
     end
 
     it "set author" do
-      project_item = create(:project_item, status: :created)
+      project_item = create(:project_item, status: "created", status_type: :created)
       author = create(:user)
 
-      project_item.new_status(status: :registered, author: author)
+      project_item.new_status(status: "registered", status_type: :registered, author: author)
       new_status = project_item.statuses.last
 
       expect(new_status.author).to eq(author)
@@ -43,14 +39,14 @@ RSpec.describe ProjectItem do
 
   describe "#active?" do
     it "is true when processing is not done" do
-      expect(build(:project_item, status: :created)).to be_active
-      expect(build(:project_item, status: :registered)).to be_active
-      expect(build(:project_item, status: :in_progress)).to be_active
+      expect(build(:project_item, status_type: :created)).to be_active
+      expect(build(:project_item, status_type: :registered)).to be_active
+      expect(build(:project_item, status_type: :in_progress)).to be_active
     end
 
     it "is false when processing is done" do
-      expect(build(:project_item, status: :ready)).to_not be_active
-      expect(build(:project_item, status: :rejected)).to_not be_active
+      expect(build(:project_item, status_type: :ready)).to_not be_active
+      expect(build(:project_item, status_type: :rejected)).to_not be_active
     end
   end
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -5,4 +5,5 @@ require "rails_helper"
 RSpec.describe Status do
   it { should belong_to(:status_holder) }
   it { should validate_presence_of(:status) }
+  it { should validate_presence_of(:status_type) }
 end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ProjectPolicy do
   end
   let(:project_with_ended_project_item) do
     create(:project) do |project|
-      create(:project_item,  project: project, status: :closed)
+      create(:project_item,  project: project, status: "closed", status_type: :closed)
     end
   end
 

--- a/spec/requests/api/webhooks/jira_spec.rb
+++ b/spec/requests/api/webhooks/jira_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "JIRA Webhook API", type: :request do
       before {
         project_item = create(:project_item, issue_id: issue_id,
                               request_voucher: true,
-                              status: :registered,
+                              status: "registered", status_type: :registered,
                               offer: create(:offer, voucherable: true))
       }
 

--- a/spec/services/jira/comment_activity_spec.rb
+++ b/spec/services/jira/comment_activity_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Jira::CommentActivity do
   let(:project) { create(:project, name: "Project") }
-  let(:project_item) { create(:project_item, status: :registered) }
+  let(:project_item) { create(:project_item, status: "registered", status_type: :registered) }
 
   context "comment update" do
     context "for project" do

--- a/spec/services/project_item/create_spec.rb
+++ b/spec/services/project_item/create_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe ProjectItem::Create do
   it "creates first project_item status" do
     project_item = described_class.new(project_item_template).call
 
+    expect(project_item.status).to eq("created")
+    expect(project_item).to be_created
     expect(project_item.statuses.count).to eq(1)
+    expect(project_item.statuses.first.status).to eq("created")
     expect(project_item.statuses.first).to be_created
   end
 

--- a/spec/services/project_item/ready_spec.rb
+++ b/spec/services/project_item/ready_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ProjectItem::Ready do
       offer = create(:offer, service: service)
       project_item = create(:project_item, offer: offer)
 
-      project_item.new_status(status: :created)
+      project_item.new_status(status: "custom_created", status_type: :created)
 
       expect { described_class.new(project_item).call }.
           to change { ActionMailer::Base.deliveries.count }.by(2)
@@ -72,7 +72,7 @@ RSpec.describe ProjectItem::Ready do
       offer = create(:offer, service: service)
       project_item = create(:project_item, offer: offer)
 
-      project_item.new_status(status: :created)
+      project_item.new_status(status: "custom_created", status_type: :created)
 
       expect { described_class.new(project_item).call }.
           to change { ActionMailer::Base.deliveries.count }.by(1)
@@ -94,7 +94,7 @@ RSpec.describe ProjectItem::Ready do
     context "Normal service project item" do
       it "sents ready and rate service emails to owner" do
         # project_item change email is sent only when there is more than 1 change
-        project_item.new_status(status: :created)
+        project_item.new_status(status: "custom_created", status_type: :created)
 
         expect { described_class.new(project_item).call }.
             to change { ActionMailer::Base.deliveries.count }.by(1)
@@ -119,7 +119,7 @@ RSpec.describe ProjectItem::Ready do
       end
 
       it "sends only rate service email to owner" do
-        project_item.new_status(status: :ready)
+        project_item.new_status(status: "custom_ready", status_type: :ready)
 
         expect { described_class.new(project_item).call }.
             to change { ActionMailer::Base.deliveries.count }.by(1)

--- a/spec/services/project_item/register_spec.rb
+++ b/spec/services/project_item/register_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ProjectItem::Register do
 
     it "sent email to project_item owner" do
       # project_item change email is sent only when there is more than 1 change
-      project_item.new_status(status: :created)
+      project_item.new_status(status: "custom_created", status_type: :created)
 
       expect { described_class.new(project_item).call }.
           to_not change { ActionMailer::Base.deliveries.count }


### PR DESCRIPTION
Make project_item have a status and a status_type.
The current status is renamed to status_type and it is kept as enum,
so that SOMBO-JIRA can relate to it.
Other than that, a status will now be managed by the primary OMS - it
just has to specify the associated status_type as well.

For now, keep the current SOMBO-JIRA integration, mapping
the status_type to status directly, ensuring it continues to work.

Purge forgotten project_item_changes model from the DB and factories.

Closes: #1881.