### PR TITLE
Fixes from 3.9.x to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- Extend finding resource in main searchbar including providers (@danielkryska, goreck888)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Displaying synchronization issues (if any occurs) in resource page for `data_administrators` (@goreck888)
 - Conditions to get external ordering of resource (@goreck888)
 - Internal ordering statistics in executive panel (@goreck888)
+- Fix showing _Other_ category in search bar select box on HOME page (@michal-szostak)
+- Fix ordering of search bar select box (Other always at the bottom) (@michal-szostak)
+- Redirect non existent categories url to `/services` (@michal-szostak)
 
 ## [3.8.0] 2021-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
-- Extend finding resource in main searchbar including providers (@danielkryska, goreck888)
 
 ### Changed
 
@@ -27,6 +26,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Removal of duplicated provider entries in the Resource Provider field in the MP (@kmarszalek)
 - Feature highlight opinions panel in the admin section (@goreck888)
 - `Internal ordering` checkbox in offer's form (@goreck888)
+- Extend finding resource in main searchbar including providers (@danielkryska, goreck888)
 
 ### Changed
 - `Provided by` field in `Popular resources`, `Suggested compatible resources` and `Recently added resources` to `Organisation` (@kmarszalek, @jarekzet)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)

--- a/app/controllers/concerns/service/autocomplete.rb
+++ b/app/controllers/concerns/service/autocomplete.rb
@@ -5,15 +5,15 @@ module Service::Autocomplete
 
   def autocomplete
     query = Searchkick.search(params[:q],
-                           fields: ["name", "offer_name"],
-                           operator: "or",
-                           match: :word_middle,
-                           limit: 5,
-                           load: false,
-                           where: { service_id: scope.ids },
-                           highlight: { multiple: true, tag: "<b>" },
-                           models: [Service, Offer],
-                           model_includes: { Service => [:offers], Offer => [:service] })
+                              fields: ["name", "offer_name", "provider_names"],
+                              operator: "or",
+                              match: :word_middle,
+                              limit: 5,
+                              load: false,
+                              where: { service_id: scope.ids },
+                              highlight: { multiple: true, tag: "<b>" },
+                              models: [Service, Offer, Provider],
+                              model_includes: { Service => [:offers], Offer => [:service], Provider => [:services] })
 
     service_titles = Service.where(id: scope.ids).pluck(:id, :name).to_h
 

--- a/app/controllers/concerns/service/categorable.rb
+++ b/app/controllers/concerns/service/categorable.rb
@@ -5,6 +5,7 @@ module Service::Categorable
 
   included do
     before_action :init_categories_tree, only: :index
+    rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_services
   end
 
   def category_counters(scope, filters)
@@ -23,6 +24,10 @@ module Service::Categorable
       @subcategories_with_counters = subcategories_with_counters&.
         partition { |cid, c|  c[:category][:name] != "Other" }&.flatten(1)
       @services_total ||= counters[nil]
+    end
+
+    def redirect_to_services
+      redirect_to :services
     end
 
     def category

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -73,7 +73,8 @@ module Service::Searchable
 
     def common_params
       {
-          fields: [ "name^7", "tagline^3", "description", "offer_names"],
+          fields: [ "name^7", "tagline^3", "description", "offer_names", "provider_names",
+                    "resource_organisation_name"],
           operator: "or",
           match: :word_middle
       }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
   def index
     @learn_more_section = LeadSection.includes(:leads).find_by(slug: "learn-more")
     @use_cases_section = LeadSection.includes(:leads).find_by(slug: "use-cases")
-    @root_categories = @root_categories.with_attached_logo.reject { |c| c.name == "Other" }
+    @root_categories_with_logos = @root_categories.with_attached_logo.reject { |c| c.name == "Other" }
     @main_scientific_domains =
       ScientificDomain.with_attached_logo.roots.partition { |sd|  sd.name != "Other" }.flatten(1)
   end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -49,9 +49,9 @@ module ServiceHelper
     service.scientific_domains.map { |target| target.name }
   end
 
-  def resource_organisation(service)
+  def resource_organisation(service, highlights = nil)
     target = service.resource_organisation
-    link_to(target.name, provider_path(target))
+    link_to(highlighted_for(:resource_organisation_name, service, highlights), provider_path(target))
   end
 
   def resource_organisation_text(service)
@@ -66,11 +66,17 @@ module ServiceHelper
     service.resource_organisation_and_providers.map { |target| target.name }
   end
 
-  def providers(service)
+  def providers(service, highlights = nil)
+    highlighted = highlights.present? ? sanitize(highlights[:provider_names])&.to_str : ""
     service.providers
            .reject(&:blank?)
-           .reject { |p| p == service.resource_organisation }
-           .uniq.map { |target| link_to(target.name, provider_path(target)) }
+           .reject { |p| p == service.resource_organisation }.uniq.map do |target|
+      if highlighted.present? && highlighted.strip == target.name.strip
+        link_to highlights[:provider_names].html_safe, provider_path(target)
+      else
+        link_to target.name, provider_path(target)
+      end
+    end
   end
 
   def providers_text(service)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,7 +2,8 @@
 
 class Category < ApplicationRecord
   extend FriendlyId
-  friendly_id :name, use: :slugged
+  friendly_id :slug_candidates, use: :slugged
+
 
   include Parentable
 
@@ -26,6 +27,22 @@ class Category < ApplicationRecord
 
   def to_s
     self.name
+  end
+
+  def slug_candidates
+    [
+      :name,
+      [:parent_name, :name],
+      [:parent_slug, :name]
+    ]
+  end
+
+  def parent_name
+    parent&.name || nil
+  end
+
+  def parent_slug
+    parent&.slug || nil
   end
 
   private

--- a/app/models/concerns/offerable.rb
+++ b/app/models/concerns/offerable.rb
@@ -16,7 +16,7 @@ module Offerable
     validates :description, presence: true
 
     def external
-      order_required? && !internal
+      order_required? && !internal && order_url.present?
     end
 
     def open_access?
@@ -28,7 +28,7 @@ module Offerable
     end
 
     def orderable?
-      internal || (order_required? && !external)
+      order_required? && (internal || !external)
     end
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -7,6 +7,15 @@ class Provider < ApplicationRecord
 
   acts_as_taggable
 
+  searchkick word_middle: [:provider_name]
+
+  def search_data
+    {
+      provider_name: name,
+      service_ids: service_ids
+    }
+  end
+
   has_one_attached :logo
 
   serialize :participating_countries, Country::Array

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -214,6 +214,10 @@ class Service < ApplicationRecord
     ([resource_organisation] + Array(providers)).reject(&:blank?).uniq
   end
 
+  def resource_organisation_name
+    resource_organisation.name
+  end
+
   def external
     order_type == "order_required" && order_url.present?
   end

--- a/app/models/service/search.rb
+++ b/app/models/service/search.rb
@@ -7,8 +7,9 @@ module Service::Search
     # ELASTICSEARCH
     # scope :search_import working with should_indexe?
     # and define which services are indexed in elasticsearch
-    searchkick word_middle: [:name, :tagline, :description, :offer_names],
-      highlight: [:name, :tagline]
+    searchkick word_middle: [:name, :tagline, :description, :offer_names,
+                             :resource_organisation_name, :provider_names],
+      highlight: [:name, :tagline, :resource_organisation_name, :provider_names]
   end
 
   # search_data are definition whitch
@@ -23,6 +24,7 @@ module Service::Search
       rating: rating,
       categories: categories.map(&:id),
       scientific_domains: search_scientific_domains_ids,
+      resource_organisation_name: resource_organisation.name,
       providers: resource_organisation_and_providers.map(&:id),
       platforms: platforms.map(&:id),
       geographical_availabilities: geographical_availabilities.map(&:alpha2),
@@ -31,7 +33,8 @@ module Service::Search
       tags: tag_list,
       source: upstream&.source_type,
       offers: offers.ids,
-      offer_names:  offers.map(&:name)
+      offer_names: offers.map(&:name),
+      provider_names: [resource_organisation.name] << providers.map(&:name)
     }
   end
 

--- a/app/models/usage_report.rb
+++ b/app/models/usage_report.rb
@@ -56,13 +56,13 @@ class UsageReport
     def service_count_by_order_type(*types, internal: false)
       unless internal
         Service.joins(:offers).where(offers: { order_type: types, status: :published },
-                                     status: [:published, :unverified]).uniq.count
+                                     status: [:published, :unverified, :errored]).uniq.count
       else
-        Service.joins(:offers)
-          .where("offers.order_type = ? AND services.status <> ? AND " +
-                   "offers.status = ? AND offers.internal = ?",
-                 types, "draft", "published", true)
-          .uniq.count
+        statuses = %w[published unverified errored]
+        empty = [nil, ""]
+        Service.joins(:offers).where("offers.order_type = ? AND services.status IN (?) AND offers.status IN (?) AND " +
+                                     "(offers.internal = ? OR (offers.internal = ? AND offers.order_url IN (?)))",
+                                     types, statuses, "published", true, false, empty).uniq.count
       end
     end
 end

--- a/app/models/usage_report.rb
+++ b/app/models/usage_report.rb
@@ -26,7 +26,7 @@ class UsageReport
   end
 
   def all_services_count
-    Service.where(status: [:published, :unverified]).count
+    Service.where(status: [:published, :unverified, :errored]).count
   end
 
   def providers

--- a/app/services/service/update.rb
+++ b/app/services/service/update.rb
@@ -11,7 +11,6 @@ class Service::Update
       Offer::Update.new(@service.offers.first, { order_type: @params[:order_type] || @service.order_type,
                                    order_url: @params[:order_url] || @service.order_url,
                                    webpage: @params[:webpage_url] || @service.webpage_url,
-                                   internal: @params[:webpage_url].blank? && @service.webpage_url.blank?,
                                    status: "published" }).call
     elsif @service.offers.size == 0
       Offer::Create.new(Offer.new(name: "Offer",
@@ -19,7 +18,6 @@ class Service::Update
                                   order_type: @params[:order_type] || @service.order_type,
                                   order_url: @params[:order_url] || @service.order_url,
                                   webpage: @params[:webpage_url] || @service.webpage_url,
-                                  internal: @params[:webpage_url].blank? && @service.webpage_url.blank?,
                                   status: "published",
                                   service: @service)).call
     end

--- a/app/views/backoffice/services/_header.html.haml
+++ b/app/views/backoffice/services/_header.html.haml
@@ -9,7 +9,7 @@
     .col-12.col-sm-9.service-details-header
       %h2.font-weight-bolder= service.name
       %p.mb-1= service.tagline
-      = render "services/categorization", service: service
+      = render "services/categorization", service: service, highlights: nil
       .row.mt-2
         .col
           .stars

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -3,7 +3,7 @@
 
   = render "products",
     scientific_domains: @main_scientific_domains,
-    categories: @root_categories
+    categories: @root_categories_with_logos
 
   = render "communities",
     platforms: @home_platforms, more_platforms_count: @home_platforms_counter,

--- a/app/views/services/_categorization.html.haml
+++ b/app/views/services/_categorization.html.haml
@@ -3,14 +3,14 @@
     %span
       = _("Organisation") + ":"
   %dd.x-small
-    %mr-4= resource_organisation(service)
+    %mr-4= resource_organisation(service, highlights)
 - unless service.providers?
   %dl.mb-0
     %dt.x-small
       %span
         = _("Provided by") + ":"
     %dd.x-small
-      %mr-4= safe_join(providers(service), ", ")
+      %mr-4= safe_join(providers(service, highlights), ", ")
 %dl.mb-0.research
   %dt.x-small
     %span

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -9,7 +9,7 @@
     .col-12.col-sm-9.service-details-header
       %h2.font-weight-bolder= service.name
       %p.mb-1= service.tagline
-      = render "services/categorization", service: service
+      = render "services/categorization", service: service, highlights: nil
 
       .row.mt-2
         .col

--- a/app/views/services/_search.html.haml
+++ b/app/views/services/_search.html.haml
@@ -23,11 +23,11 @@
     %span{ "data-target": "search.selected" }
       = _("All resources")
     %select#category-select.container-select{ "data-action": "change->search#refresh",
-                                                    "data-target": "search.categorySelect" }
+                                              "data-target": "search.categorySelect" }
       %option{ value: "", selected: "selected" }
         = _("All resources")
-      = options_for_select categories.map { |category| [category.name, category.slug] }, params[:category]
+      = options_for_select categories.partition { |cat|  cat.name != "Other" }.flatten(1).map { |cat| [cat.name,
+        cat.slug] }, params[:category]
   .input-group-append
     %button#query-submit.input-group-text.bg-white
       %i.fas.fa-search
-

--- a/app/views/services/_service_details.html.haml
+++ b/app/views/services/_service_details.html.haml
@@ -3,7 +3,7 @@
     .pl-4.pr-4.mb-3
       %h2.mb-3{ "data-probe" => "", "data-service-id" => service.id }= yield
       %p.mb-3= highlighted_for(:tagline, service, highlights)
-      = render "services/categorization", service: service
+      = render "services/categorization", service: service, highlights: highlights
       - if content_for(:checkbox)
         = yield_content!(:checkbox)
     - if service_offers && service_offers.any?

--- a/app/views/services/autocomplete/_provider_item.html.haml
+++ b/app/views/services/autocomplete/_provider_item.html.haml
@@ -1,0 +1,5 @@
+%li.dropdown-item{ "role": "option",
+  "data-autocomplete-value": "#{service.id}" }
+  = highlights[:provider_names].html_safe
+  >
+  = service.name

--- a/app/views/services/autocomplete/list.html.haml
+++ b/app/views/services/autocomplete/list.html.haml
@@ -10,3 +10,10 @@
     = render "services/autocomplete/offer_item", offer: elem,
       highlights: highlights,
       service_titles: service_titles
+%li.label
+  = _("Providers")
+- results.each do |elem, highlights|
+  - if highlights[:provider_names]
+    = render "services/autocomplete/provider_item", service: elem,
+     highlights: highlights
+

--- a/app/views/services/ordering_configurations/_header.html.haml
+++ b/app/views/services/ordering_configurations/_header.html.haml
@@ -9,7 +9,7 @@
     .col-12.col-sm-9.service-details-header
       %h2.font-weight-bolder= service.name
       %p.mb-1= service.tagline
-      = render "services/categorization", service: service
+      = render "services/categorization", service: service, highlights: nil
 
       .row.mt-2
         .col

--- a/docs/upgrade/3.9.0.md
+++ b/docs/upgrade/3.9.0.md
@@ -1,4 +1,4 @@
-# Upgrade to 3.7.0
+# Upgrade to 3.9.0
 
 # Standard procedure
 

--- a/lib/tasks/rdt.rake
+++ b/lib/tasks/rdt.rake
@@ -141,6 +141,13 @@ namespace :rdt do
     to_remove = Category.where(eid: [nil, ""])
     puts "Removing categories #{to_remove.map(&:name)}"
     to_remove.destroy_all
+    puts "Check and repair categories slugs"
+    Category.where("slug ~* ?", "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$").each  do |category|
+      puts "Found category #{category.name} with slug #{category.slug}"
+      category.slug = nil
+      category.save!
+      puts "Category #{category.name} updated with new slug: #{category.slug}"
+    end
 
     puts "Creating scientific_domains from yaml"
     yaml_hash["scientific_domain"].each do |_, hash|

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -78,4 +78,10 @@ RSpec.feature "Service categories" do
 
     expect(page).to have_selector(".media", count: 1)
   end
+
+  scenario "navigating to nonexistent category should redirect to :services" do
+    category = build(:category, slug: "noncategory", name: "noncategory")
+    visit category_services_path(category, per_page: "1")
+    expect(page).to have_current_path(services_path)
+  end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -104,4 +104,15 @@ RSpec.feature "Service searching in top bar", js: true do
     expect(page).to have_text("DDDD Something offer 1")
     expect(page).to have_text("DDDD Something offer 2")
   end
+
+  scenario "'Other' category should be at the bottom of the category selection box", js: false do
+    create(:category, name: "Other")
+    create(:category, name: "Research")
+
+    # check services and HOME as there was a bug where home had different list then any other page
+    visit root_path
+    expect(page).to have_selector("#category-select > option:last-child", text: "Other")
+    visit :services
+    expect(page).to have_selector("#category-select > option:last-child", text: "Other")
+  end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -115,4 +115,32 @@ RSpec.feature "Service searching in top bar", js: true do
     visit :services
     expect(page).to have_selector("#category-select > option:last-child", text: "Other")
   end
+
+  scenario "After starting searching autocomplete are shown with resource organisation", js: true, search: true do
+    provider = create(:provider, name: "Cyfronet")
+    create(:service, name: "DDDD Something 1", resource_organisation: provider)
+    create(:service, name: "DDDD Something 2")
+    create(:service, name: "DDDD Something 3")
+
+    visit services_path
+    fill_in "q", with: "Cyfr"
+
+    expect(page).to have_text ("Cyfronet > DDDD Something 1")
+    expect(page).to_not have_text ("Cyfronet > DDDD Something 2")
+    expect(page).to_not have_text ("Cyfronet > DDDD Something 3")
+  end
+
+  scenario "After starting searching autocomplete are shown with providers", js: true, search: true do
+    provider = create(:provider, name: "Cyfronet")
+    create(:service, name: "DDDD Something 1", providers: [provider])
+    create(:service, name: "DDDD Something 2")
+    create(:service, name: "DDDD Something 3")
+
+    visit services_path
+    fill_in "q", with: "Cyfr"
+
+    expect(page).to have_text ("Cyfronet > DDDD Something 1")
+    expect(page).to_not have_text ("Cyfronet > DDDD Something 2")
+    expect(page).to_not have_text ("Cyfronet > DDDD Something 3")
+  end
 end

--- a/spec/services/service/pc_create_or_update_spec.rb
+++ b/spec/services/service/pc_create_or_update_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe Service::PcCreateOrUpdate do
       expect(offer.order_type).to eq("other")
       expect(offer.status).to eq("published")
       expect(offer.service.id).to eq(service.id)
+      expect(service.upstream_id).to eq(service.sources.first.id)
     end
   end
 


### PR DESCRIPTION
Include all fixes from 3.9.x branch:
- [HOTFIX] Fix number of resources in executive statistics
- [#1872, #1886] Handle old categories
- [#1904] Fix categories slugs
- [HOTFIX] Fix logic of resource order wizards
- [#1902] Fix upstream set for resources from jms
- [#1827] Extend finding resource in main searchbar
- [HOTFIX] Bump mimemagic to 0.3.6
