### PR TITLE
[HOTFIX] Fix category slug

### DIFF
--- a/db/vocabulary.yml
+++ b/db/vocabulary.yml
@@ -1794,6 +1794,7 @@ category:
     eid: subcategory-security_and_operations-operations_and_infrastructure_management_services-configuration
     name: Configuration
     parentId: category-security_and_operations-operations_and_infrastructure_management_services
+    slug: operations-infrastructure-management-services-configuration
     type: SUBCATEGORY
   access_physical_and_eInfrastructures-instrument_and_equipment-spectrometer:
     eid: subcategory-access_physical_and_eInfrastructures-instrument_and_equipment-spectrometer

--- a/lib/tasks/rdt.rake
+++ b/lib/tasks/rdt.rake
@@ -122,19 +122,22 @@ namespace :rdt do
       existing_category = Category.find_by(name: hash["name"], eid: [hash["eid"], nil])
       parent = hash["parentId"].blank? ? nil : Category.find_by(eid: hash["parentId"])
       if existing_category.blank?
-        Category.find_or_initialize_by(eid: hash["eid"]) do |category|
+        c = Category.find_or_initialize_by(eid: hash["eid"]) do |category|
           category.update!(name: hash["name"],
                            eid: hash["eid"],
                            description: hash["description"],
+                           slug: hash["slug"],
                            parent: parent)
         end
-        puts "Created category: #{hash["name"]}, eid: #{hash["eid"]}"
+        puts "Created category: #{c.name}, eid: #{c.eid}, slug: #{c.slug}"
       else
         existing_category.update!(name: hash["name"],
-                                   eid: hash["eid"],
-                                   description: hash["description"],
-                                   parent: parent)
-        puts "Updated existing category: #{hash["name"]} with eid: #{hash["eid"]}"
+                                  eid: hash["eid"],
+                                  description: hash["description"],
+                                  slug: hash["slug"],
+                                  parent: parent)
+        puts "Updated existing category: #{existing_category.name}, eid: #{existing_category.eid}, " +
+        "slug: #{existing_category.slug}"
       end
     end
     puts "Remove categories with no eid"


### PR DESCRIPTION
Fix error with bad routing in categories
Error caused by a category slug `configuration`
because it is similar to service configuration path
`{root_path}/services/c/configuration` is a path to category
but rails recognize it like resource with slug `c`
and redirects to order configuration path of resource
instead of category_path