### PR TITLE
Add author_role and scope to Message

### DIFF
--- a/app/controllers/concerns/project/authorize.rb
+++ b/app/controllers/concerns/project/authorize.rb
@@ -10,7 +10,7 @@ module Project::Authorize
 
   private
     def load_and_authorize_project!
-      @project = Project.find(params[:project_id])
+      @project = Project.find_by_id(params[:project_id])
       authorize(@project, :show?)
     end
 end

--- a/app/controllers/projects/conversations_controller.rb
+++ b/app/controllers/projects/conversations_controller.rb
@@ -15,8 +15,8 @@ class Projects::ConversationsController < ApplicationController
       permitted_attributes(Message)
         .merge(
           author: current_user,
-          author_role: "user",
-          scope: "public",
+          author_role: :user,
+          scope: :public,
           messageable: @project
         )
     )

--- a/app/controllers/projects/conversations_controller.rb
+++ b/app/controllers/projects/conversations_controller.rb
@@ -6,8 +6,8 @@ class Projects::ConversationsController < ApplicationController
   def show
     @message = Message.new(messageable: @project)
 
-    load_messages
-    load_projects
+    load_messages!
+    load_projects!
   end
 
   def create
@@ -25,18 +25,18 @@ class Projects::ConversationsController < ApplicationController
       flash[:notice] = "Message sent successfully"
       redirect_to project_conversation_path(@project)
     else
-      load_messages
-      load_projects
+      load_messages!
+      load_projects!
       render :show, status: :bad_request
     end
   end
 
   private
-    def load_projects
+    def load_projects!
       @projects = policy_scope(Project).order(:name)
     end
 
-    def load_messages
+    def load_messages!
       @messages = Message.where(
         messageable_id: @project.id,
         scope: %w[public user_direct],

--- a/app/controllers/projects/conversations_controller.rb
+++ b/app/controllers/projects/conversations_controller.rb
@@ -37,9 +37,6 @@ class Projects::ConversationsController < ApplicationController
     end
 
     def load_messages!
-      @messages = Message.where(
-        messageable_id: @project.id,
-        scope: %w[public user_direct],
-      ).order(:created_at)
+      @messages = policy_scope(@project.messages).order(:created_at)
     end
 end

--- a/app/controllers/projects/conversations_controller.rb
+++ b/app/controllers/projects/conversations_controller.rb
@@ -4,23 +4,42 @@ class Projects::ConversationsController < ApplicationController
   include Project::Authorize
 
   def show
-    @projects = policy_scope(Project).order(:name)
-    @messages = @project.messages.order("created_at ASC")
     @message = Message.new(messageable: @project)
+
+    load_messages
+    load_projects
   end
 
   def create
-    @message = Message.
-                new(permitted_attributes(Message).
-                    merge(author: current_user, messageable: @project))
+    @message = Message.new(
+      permitted_attributes(Message)
+        .merge(
+          author: current_user,
+          author_role: "user",
+          scope: "public",
+          messageable: @project
+        )
+    )
 
     if Message::Create.new(@message).call
       flash[:notice] = "Message sent successfully"
       redirect_to project_conversation_path(@project)
     else
-      @messages = @project.messages
-      @projects = policy_scope(Project).order(:name)
+      load_messages
+      load_projects
       render :show, status: :bad_request
     end
   end
+
+  private
+    def load_projects
+      @projects = policy_scope(Project).order(:name)
+    end
+
+    def load_messages
+      @messages = Message.where(
+        messageable_id: @project.id,
+        scope: %w[public user_direct],
+      ).order(:created_at)
+    end
 end

--- a/app/controllers/projects/services/conversations_controller.rb
+++ b/app/controllers/projects/services/conversations_controller.rb
@@ -6,8 +6,8 @@ class Projects::Services::ConversationsController < ApplicationController
   def show
     @message = Message.new(messageable: @project_item)
 
-    load_messages
-    load_projects
+    load_messages!
+    load_projects!
   end
 
   def create
@@ -25,18 +25,18 @@ class Projects::Services::ConversationsController < ApplicationController
       flash[:notice] = "Message sent successfully"
       redirect_to project_service_conversation_path(@project, @project_item)
     else
-      load_messages
-      load_projects
+      load_messages!
+      load_projects!
       render "show", status: :bad_request
     end
   end
 
   private
-    def load_projects
+    def load_projects!
       @projects = policy_scope(Project).order(:name)
     end
 
-    def load_messages
+    def load_messages!
       @messages = Message.where(
         messageable_id: @project_item.id,
         scope: %w[public user_direct],

--- a/app/controllers/projects/services/conversations_controller.rb
+++ b/app/controllers/projects/services/conversations_controller.rb
@@ -37,9 +37,6 @@ class Projects::Services::ConversationsController < ApplicationController
     end
 
     def load_messages!
-      @messages = Message.where(
-        messageable_id: @project_item.id,
-        scope: %w[public user_direct],
-      ).order(:created_at)
+      @messages = policy_scope(@project_item.messages).order(:created_at)
     end
 end

--- a/app/controllers/projects/services/conversations_controller.rb
+++ b/app/controllers/projects/services/conversations_controller.rb
@@ -11,9 +11,15 @@ class Projects::Services::ConversationsController < ApplicationController
   end
 
   def create
-    @message = Message.
-                new(permitted_attributes(Message).
-                merge(author: current_user, messageable: @project_item))
+    @message = Message.new(
+      permitted_attributes(Message)
+        .merge(
+          author: current_user,
+          author_role: "user",
+          scope: "public",
+          messageable: @project_item
+        )
+    )
 
     if Message::Create.new(@message).call
       flash[:notice] = "Message sent successfully"
@@ -31,6 +37,9 @@ class Projects::Services::ConversationsController < ApplicationController
     end
 
     def load_messages
-      @messages = @project_item.messages.order(:updated_at)
+      @messages = Message.where(
+        messageable_id: @project_item.id,
+        scope: %w[public user_direct],
+      ).order(:created_at)
     end
 end

--- a/app/controllers/projects/services/conversations_controller.rb
+++ b/app/controllers/projects/services/conversations_controller.rb
@@ -15,8 +15,8 @@ class Projects::Services::ConversationsController < ApplicationController
       permitted_attributes(Message)
         .merge(
           author: current_user,
-          author_role: "user",
-          scope: "public",
+          author_role: :user,
+          scope: :public,
           messageable: @project_item
         )
     )

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,6 +5,23 @@ class Message < ApplicationRecord
              class_name: "User",
              optional: true
 
+  enum author_role: {
+    user: "user",
+    provider: "provider",
+    mediator: "mediator",
+  }, _prefix: :role
+
+  enum scope: {
+    public: "public",
+    internal: "internal",
+    user_direct: "user_direct",
+  }, _suffix: true
+
+  validates :author_role, presence: true
+  validates :author, presence: true, if: :role_user?
+
+  validates :scope, presence: true
+
   validates :message, presence: true
   belongs_to :messageable, polymorphic: true
 

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -78,7 +78,13 @@ class ProjectItem < ApplicationRecord
       "Voucher ID has been updated: #{voucher_id}"
     end
 
-    messages.create(message: message, author: author, iid: iid).tap do
+    messages.create(
+      message: message,
+      author: author,
+      author_role: "provider",
+      scope: "user_direct",
+      iid: iid
+    ).tap do
       update(voucher_id: voucher_id)
     end
   end

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -81,8 +81,8 @@ class ProjectItem < ApplicationRecord
     messages.create(
       message: message,
       author: author,
-      author_role: "provider",
-      scope: "user_direct",
+      author_role: :provider,
+      scope: :user_direct,
       iid: iid
     ).tap do
       update(voucher_id: voucher_id)

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class MessagePolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.where(scope: %w[public user_direct])
+    end
+  end
+
   def permitted_attributes
     [:message]
   end

--- a/app/services/jira/comment_activity.rb
+++ b/app/services/jira/comment_activity.rb
@@ -10,8 +10,8 @@ class Jira::CommentActivity
     return if body.blank? || reject?
     message = Message.find_or_initialize_by(messageable: @messageable, iid: id)
     message.update(
-      author_role: "provider",
-      scope: "public",
+      author_role: :provider,
+      scope: :public,
       message: body,
       edited: message.persisted?,
     )

--- a/app/services/jira/comment_activity.rb
+++ b/app/services/jira/comment_activity.rb
@@ -9,7 +9,12 @@ class Jira::CommentActivity
   def call
     return if body.blank? || reject?
     message = Message.find_or_initialize_by(messageable: @messageable, iid: id)
-    message.update(message: body, edited: message.persisted?)
+    message.update(
+      author_role: "provider",
+      scope: "public",
+      message: body,
+      edited: message.persisted?,
+    )
     if message.edited?
       WebhookJiraMailer.message_edited(message).deliver_later
     else

--- a/app/services/project_item/ready.rb
+++ b/app/services/project_item/ready.rb
@@ -71,8 +71,8 @@ class ProjectItem::Ready
       if @message
         message_temp = Message.new(
           author: @project_item.user,
-          author_role: "user",
-          scope: "public",
+          author_role: :user,
+          scope: :public,
           message: @message,
           messageable: @project_item
         )

--- a/app/services/project_item/ready.rb
+++ b/app/services/project_item/ready.rb
@@ -69,9 +69,13 @@ class ProjectItem::Ready
 
     def create_message
       if @message
-        message_temp = Message.new(author: @project_item.user,
-                                   message: @message,
-                                   messageable: @project_item)
+        message_temp = Message.new(
+          author: @project_item.user,
+          author_role: "user",
+          scope: "public",
+          message: @message,
+          messageable: @project_item
+        )
         Message::Create.new(message_temp).call
       end
       true

--- a/app/services/project_item/register.rb
+++ b/app/services/project_item/register.rb
@@ -42,9 +42,13 @@ class ProjectItem::Register
 
     def create_message
       if @message
-        message_temp = Message.new(author: @project_item.user,
-                                   message: @message,
-                                   messageable: @project_item)
+        message_temp = Message.new(
+          author: @project_item.user,
+          author_role: "user",
+          scope: "public",
+          message: @message,
+          messageable: @project_item
+        )
         Message::Create.new(message_temp).call
       end
       true

--- a/app/services/project_item/register.rb
+++ b/app/services/project_item/register.rb
@@ -44,8 +44,8 @@ class ProjectItem::Register
       if @message
         message_temp = Message.new(
           author: @project_item.user,
-          author_role: "user",
-          scope: "public",
+          author_role: :user,
+          scope: :public,
           message: @message,
           messageable: @project_item
         )

--- a/db/migrate/20210329084503_add_scope_and_role_to_message.rb
+++ b/db/migrate/20210329084503_add_scope_and_role_to_message.rb
@@ -1,0 +1,18 @@
+class AddScopeAndRoleToMessage < ActiveRecord::Migration[6.0]
+  def change
+    add_column :messages, :author_email, :string
+    add_column :messages, :author_name, :string
+    add_column :messages, :author_role, :string
+    add_column :messages, :scope, :string
+
+    exec_update "UPDATE messages SET author_role = 'provider' WHERE author_id IS NULL"
+    exec_update "UPDATE messages SET author_role = 'user' WHERE author_id IS NOT NULL"
+    exec_update "UPDATE messages SET scope = 'public'"
+
+    change_column_null :messages, :author_role, false
+    change_column_null :messages, :scope, false
+
+    add_index :messages, :author_role
+    add_index :messages, :scope
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_120212) do
+ActiveRecord::Schema.define(version: 2021_03_29_084503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -155,8 +155,14 @@ ActiveRecord::Schema.define(version: 2021_03_25_120212) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "edited", default: false
+    t.string "author_email"
+    t.string "author_name"
+    t.string "author_role", null: false
+    t.string "scope", null: false
     t.index ["author_id"], name: "index_messages_on_author_id"
+    t.index ["author_role"], name: "index_messages_on_author_role"
     t.index ["messageable_type", "messageable_id"], name: "index_messages_on_messageable_type_and_messageable_id"
+    t.index ["scope"], name: "index_messages_on_scope"
   end
 
   create_table "offers", force: :cascade do |t|

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
   factory :message do
     sequence(:message) { |n| "text message #{n}" }
     sequence(:author) { |n| create(:user) }
+    author_role { "user" }
+    scope { "public" }
     sequence(:messageable) { association(:project_item) }
     sequence(:edited) { false }
     sequence(:iid) { |n| "n" }

--- a/spec/jobs/message/register_message_job_spec.rb
+++ b/spec/jobs/message/register_message_job_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Message::RegisterMessageJob do
            messageable: project_item,
            message: "message msg",
            author: author,
-           author_role: author.nil? ? "provider" : "user",
-           scope: "public")
+           author_role: author.nil? ? :provider : :user,
+           scope: :public)
   end
 
   it "triggers registration process for project_item owner message" do

--- a/spec/jobs/message/register_message_job_spec.rb
+++ b/spec/jobs/message/register_message_job_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Message::RegisterMessageJob do
     create(:message,
            messageable: project_item,
            message: "message msg",
-           author: author)
+           author: author,
+           author_role: author.nil? ? "provider" : "user",
+           scope: "public")
   end
 
   it "triggers registration process for project_item owner message" do

--- a/spec/mailers/previews/webhook_jira_preview.rb
+++ b/spec/mailers/previews/webhook_jira_preview.rb
@@ -5,11 +5,25 @@
 # !!! We are using last created project_item to show email previews !!!
 class WebhookJiraPreview < ActionMailer::Preview
   def new_message_for_project_item
-    WebhookJiraMailer.new_message(Message.new(messageable: ProjectItem.last, message: "message content"))
+    WebhookJiraMailer.new_message(
+      Message.new(
+        messageable: ProjectItem.last,
+        author_role: "provider",
+        scope: "public",
+        message: "message content"
+      )
+    )
   end
 
 
   def project_new_message
-    WebhookJiraMailer.new_message(Message.new(messageable: Project.last, message: "message content"))
+    WebhookJiraMailer.new_message(
+      Message.new(
+        messageable: Project.last,
+        author_role: "provider",
+        scope: "public",
+        message: "message content"
+      )
+    )
   end
 end

--- a/spec/mailers/previews/webhook_jira_preview.rb
+++ b/spec/mailers/previews/webhook_jira_preview.rb
@@ -8,8 +8,8 @@ class WebhookJiraPreview < ActionMailer::Preview
     WebhookJiraMailer.new_message(
       Message.new(
         messageable: ProjectItem.last,
-        author_role: "provider",
-        scope: "public",
+        author_role: :provider,
+        scope: :public,
         message: "message content"
       )
     )
@@ -20,8 +20,8 @@ class WebhookJiraPreview < ActionMailer::Preview
     WebhookJiraMailer.new_message(
       Message.new(
         messageable: Project.last,
-        author_role: "provider",
-        scope: "public",
+        author_role: :provider,
+        scope: :public,
         message: "message content"
       )
     )

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -5,6 +5,20 @@ require "rails_helper"
 RSpec.describe Message do
   it { should belong_to(:messageable) }
   it { should validate_presence_of(:message) }
+  it { should validate_presence_of(:author_role) }
+  it { should validate_presence_of(:scope) }
+
+  describe "#author" do
+    context "if role_user?" do
+      before { allow(subject).to receive(:role_user?).and_return(true) }
+      it { should validate_presence_of(:author) }
+    end
+
+    context "if !role_user?" do
+      before { allow(subject).to receive(:role_user?).and_return(false) }
+      it { should_not validate_presence_of(:author) }
+    end
+  end
 
   describe "#question?" do
     it "is true when message is created by project_item owner" do
@@ -28,7 +42,7 @@ RSpec.describe Message do
 
 
     it "is false when there is not message author" do
-      message = create(:message, author: nil)
+      message = create(:message, author: nil, author_role: "provider")
 
       expect(message).to_not be_question
     end
@@ -40,6 +54,7 @@ RSpec.describe Message do
       new_message = create(:message,
                                    messageable: project_item,
                                    author: create(:user),
+                                   author_role: "provider",
                                    message: "some question")
 
       expect(new_message).to_not be_question
@@ -51,6 +66,7 @@ RSpec.describe Message do
       new_message = create(:message,
                                    messageable: project,
                                    author: create(:user),
+                                   author_role: "provider",
                                    message: "some question")
 
       expect(new_message).to_not be_question

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Message do
 
 
     it "is false when there is not message author" do
-      message = create(:message, author: nil, author_role: "provider")
+      message = create(:message, author: nil, author_role: :provider)
 
       expect(message).to_not be_question
     end
@@ -54,7 +54,7 @@ RSpec.describe Message do
       new_message = create(:message,
                                    messageable: project_item,
                                    author: create(:user),
-                                   author_role: "provider",
+                                   author_role: :provider,
                                    message: "some question")
 
       expect(new_message).to_not be_question
@@ -66,7 +66,7 @@ RSpec.describe Message do
       new_message = create(:message,
                                    messageable: project,
                                    author: create(:user),
-                                   author_role: "provider",
+                                   author_role: :provider,
                                    message: "some question")
 
       expect(new_message).to_not be_question

--- a/spec/policies/message_policy_spec.rb
+++ b/spec/policies/message_policy_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MessagePolicy, type: :policy do
+  let(:user) { create(:user) }
+
+  subject { described_class }
+
+  def resolve
+    subject::Scope.new(user, Message).resolve
+  end
+
+  permissions ".scope" do
+    it "allows scope=public" do
+      message = create(:message, scope: :public)
+
+      expect(resolve).to contain_exactly(message)
+    end
+
+    it "allows scope=user_direct" do
+      message = create(:message, scope: :user_direct)
+
+      expect(resolve).to contain_exactly(message)
+    end
+
+    it "forbids scope=internal" do
+      create(:message, scope: :internal)
+
+      expect(resolve).to be_empty
+    end
+  end
+
+  context "permitted_attributes" do
+    it "should return message" do
+      policy = described_class.new(user, create(:message))
+      expect(policy.permitted_attributes).to match_array([:message])
+    end
+  end
+end

--- a/spec/requests/api/webhooks/jira_spec.rb
+++ b/spec/requests/api/webhooks/jira_spec.rb
@@ -103,7 +103,9 @@ RSpec.describe "JIRA Webhook API", type: :request do
         expect {
           post(api_webhooks_jira_url + "?secret=secret&issue_id=#{issue_id}", params: data)
         }.to change { project_item.messages.count }.by(1)
-        updated_message = Message.find_by(iid: comment_id)
+        updated_message = Message.find_by_iid(comment_id)
+        expect(updated_message.public_scope?).to be_truthy
+        expect(updated_message.role_provider?).to be_truthy
         expect(updated_message.message).to eq("New message")
       end
     end

--- a/spec/services/jira/comment_activity_spec.rb
+++ b/spec/services/jira/comment_activity_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Jira::CommentActivity do
         project.messages.create(
           message: "First message",
           iid: 123,
-          author_role: "provider",
-          scope: "public",
+          author_role: :provider,
+          scope: :public,
         )
       }
 
@@ -58,8 +58,8 @@ RSpec.describe Jira::CommentActivity do
         project_item.messages.create(
           message: "First message",
           iid: 123,
-          author_role: "provider",
-          scope: "public",
+          author_role: :provider,
+          scope: :public,
         )
       }
 
@@ -123,8 +123,8 @@ RSpec.describe Jira::CommentActivity do
         # Than jira webhood with new comment is triggered.
         project_item.messages.create(
           message: "question",
-          author_role: "user",
-          scope: "public",
+          author_role: :user,
+          scope: :public,
         )
 
         expect do
@@ -185,8 +185,8 @@ RSpec.describe Jira::CommentActivity do
         # Than jira webhood with new comment is triggered.
         project.messages.create(
           message: "question",
-          author_role: "user",
-          scope: "public",
+          author_role: :user,
+          scope: :public,
         )
 
         expect do

--- a/spec/services/message/create_spec.rb
+++ b/spec/services/message/create_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Message::Create do
     let(:message) do
       Message.new(
         author: project_item_owner,
-        author_role: "user",
-        scope: "public",
+        author_role: :user,
+        scope: :public,
         messageable: project_item,
         message: "message text"
       )

--- a/spec/services/message/create_spec.rb
+++ b/spec/services/message/create_spec.rb
@@ -9,8 +9,13 @@ RSpec.describe Message::Create do
 
   context "valid message" do
     let(:message) do
-      Message.new(author: project_item_owner,
-                          messageable: project_item, message: "message text")
+      Message.new(
+        author: project_item_owner,
+        author_role: "user",
+        scope: "public",
+        messageable: project_item,
+        message: "message text"
+      )
     end
 
     it "returns true" do
@@ -50,7 +55,7 @@ RSpec.describe Message::Create do
         to_not change { project_item.messages.count }
     end
 
-    it "does not triggers message registration" do
+    it "does not trigger message registration" do
       described_class.new(message).call
 
       expect(Message::RegisterMessageJob).

--- a/spec/services/project_item/ready_spec.rb
+++ b/spec/services/project_item/ready_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ProjectItem::Ready do
       expect(ActionMailer::Base.deliveries.last.subject).to eq("EOSC Portal - Rate your service")
     end
 
-    it "do not send  email with activate message if not present" do
+    it "do not send email with activate message if not present" do
       service = create(:open_access_service, activate_message: " ")
       offer = create(:offer, service: service)
       project_item = create(:project_item, offer: offer)
@@ -103,11 +103,13 @@ RSpec.describe ProjectItem::Ready do
     end
 
     context "With additional comment" do
-      it "should create first komment message" do
+      it "should create first comment message" do
         expect { described_class.new(project_item, "First message").call }.
           to change { project_item.messages.count }.by(1)
         last_message = project_item.messages.last
 
+        expect(last_message.role_user?).to be_truthy
+        expect(last_message.public_scope?).to be_truthy
         expect(last_message.message).to eq("First message")
       end
     end

--- a/spec/services/project_item/register_spec.rb
+++ b/spec/services/project_item/register_spec.rb
@@ -57,6 +57,8 @@ RSpec.describe ProjectItem::Register do
           to change { project_item.messages.count }.by(1)
         last_message = project_item.messages.last
 
+        expect(last_message.role_user?).to be_truthy
+        expect(last_message.public_scope?).to be_truthy
         expect(last_message.message).to eq("First message")
       end
     end


### PR DESCRIPTION
The author_role extends the Message typology, so that Messages
which come from providers and ops-team can be differentiated
(author_role=user|provider|mediator).
On the other hand, scope allows the providers and ops-team to exchange
Messages private to user between OMSes (scope=internal) and allows
providers to send Messages privately to user (scope=user_direct).

Before, when a Message wasn't sent by an MP user, it only had the
author_id==nil. I take it into account when migrating data.

Yet unused, but I add author_name and author_email columns, so that
OMSes can provide them when creating messages, making it easier for user
and other participating providers and ops-team members to discern the
Message origin.

Update the conversation_controllers, so that only scope_public? and
scope_user_direct? are shown to users. Also, make sure the messages are
always ordered by creation time (for project_items the order was by
updated time, inconsitent with the project level).