### PR TITLE
[#1873] Fix providers and scientific domain params

### DIFF
--- a/app/controllers/concerns/service/recommendable.rb
+++ b/app/controllers/concerns/service/recommendable.rb
@@ -7,11 +7,12 @@ module Service::Recommendable
 
   @@filter_param_transformers = {
     geographical_availabilities: -> name { Country.convert_to_regions_add_country(name) },
-    scientific_domains: -> ids { ids.map(&:to_i) + ids.map { |id| ScientificDomain.find(id).descendant_ids }.flatten },
+    scientific_domains: -> ids { ids.instance_of?(Array) ?
+                ids.map(&:to_i) + ids.map { |id| ScientificDomain.find(id).descendant_ids }.flatten: ids.first.to_i },
     category_id: -> slug { [Category.find_by(slug: slug).id] + Category.find_by(slug: slug).descendant_ids },
-    providers: -> ids { ids.map(&:to_i) },
-    related_platforms: -> ids { ids.map(&:to_i) },
-    target_users: -> ids { ids.map(&:to_i) }
+    providers: -> ids { ids.instance_of?(Array) ? ids.map(&:to_i) : ids.first.to_i },
+    related_platforms: -> ids { ids.instance_of?(Array) ? ids.map(&:to_i) : ids.first.to_i },
+    target_users: -> ids { ids.instance_of?(Array) ? ids.map(&:to_i) : ids.first.to_i },
   }
 
   included do


### PR DESCRIPTION
Access from Provider
http://localhost:5000/services?providers=851
![Zrzut ekranu 2021-03-31 o 15 08 15](https://user-images.githubusercontent.com/6060538/113149087-ec92dd00-9232-11eb-93bc-863c7b47b1ef.png)

Access from homepage - Scientific
http://localhost:5000/services?scientific_domains=589
![Zrzut ekranu 2021-03-31 o 15 08 04](https://user-images.githubusercontent.com/6060538/113149063-e6046580-9232-11eb-9844-a3ecc6db8a7d.png)

Filters
http://localhost:5000/services?scientific_domains-filter=&scientific_domains-all=&scientific_domains%5B%5D=589&scientific_domains%5B%5D=590&providers-filter=&providers-all=&providers%5B%5D=736&providers%5B%5D=737&target_users-all=&related_platforms-filter=&related_platforms-all=&rating=&order_type=&geographical_availabilities=
![Zrzut ekranu 2021-03-31 o 15 08 29](https://user-images.githubusercontent.com/6060538/113149115-f4528180-9232-11eb-8249-8d3881426e93.png)



Closes #1930