### PR TITLE
Add project_item.user_secrets and handle voucherable

### DIFF
--- a/app/helpers/project_items_helper.rb
+++ b/app/helpers/project_items_helper.rb
@@ -13,6 +13,14 @@ module ProjectItemsHelper
     (@project_item.ready? && @project_item.service_opinion.nil?)
   end
 
+  def voucher_id(project_item)
+    if project_item.voucher_id.present?
+      project_item.voucher_id
+    else
+      project_item.user_secrets["voucher_id"]
+    end
+  end
+
   def webpage(project_item)
     if project_item.external
       project_item.order_url

--- a/app/javascript/app/controllers/project_item_controller.js
+++ b/app/javascript/app/controllers/project_item_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["hasVoucher", "iHaveVaucher", "iDontHaveVoucher"];
+  static targets = ["hasVoucher", "iHaveVoucher", "iDontHaveVoucher"];
 
   voucherChanged(event) {
     if(event.currentTarget.value === "false") {

--- a/app/mailers/project_item_mailer.rb
+++ b/app/mailers/project_item_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ProjectItemMailer < ApplicationMailer
+  include ProjectItemsHelper
+
   def created(project_item)
     load_data(project_item)
     if @project_item.created?
@@ -70,7 +72,7 @@ class ProjectItemMailer < ApplicationMailer
 
   def aod_voucher_accepted(project_item)
     @user = project_item.user
-    @voucher_id = project_item.voucher_id
+    @voucher_id = voucher_id(project_item)
 
     mail(to: @user.email,
        subject: "Elastic Cloud Compute Cluster (EC3) service with voucher approved",
@@ -79,7 +81,7 @@ class ProjectItemMailer < ApplicationMailer
 
   def aod_voucher_rejected(project_item)
     @user = project_item.user
-    @voucher_id = project_item.voucher_id
+    @voucher_id = voucher_id(project_item)
 
     mail(to: @user.email,
          subject: "Elastic Cloud Compute Cluster (EC3) service with voucher rejected",

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -3,7 +3,7 @@
 class MessagePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.where(scope: %w[public user_direct])
+      scope.where(scope: %i[public user_direct])
     end
   end
 

--- a/app/views/projects/services/_voucher.html.haml
+++ b/app/views/projects/services/_voucher.html.haml
@@ -1,14 +1,14 @@
-- unless project_item.voucher_id.blank? && !project_item.request_voucher
+- if project_item.voucher_id.present? || project_item.request_voucher
   %h2.mb-3
     = _("Vouchers")
   .blue-row.form-inline.mb-5
     .d-inline.mr-4
       %i.fas.fa-ticket-alt
-    - if project_item.voucher_id.blank?
+    - if voucher_id(project_item).blank?
       .d-inline
         = _("Requested")
     - else
       .d-inline
         = _("Your voucher ID")
         %br
-        %span.voucher-name= project_item.voucher_id
+        %span.voucher-name= voucher_id(project_item)

--- a/app/views/projects/services/show.html.haml
+++ b/app/views/projects/services/show.html.haml
@@ -10,4 +10,4 @@
     .col-7
       = render "rating", project: @project, project_item: @project_item
     .col-5
-      = render "vaucher", project_item: @project_item
+      = render "voucher", project_item: @project_item

--- a/db/migrate/20210331110641_add_user_secrets_to_project_item.rb
+++ b/db/migrate/20210331110641_add_user_secrets_to_project_item.rb
@@ -1,0 +1,5 @@
+class AddUserSecretsToProjectItem < ActiveRecord::Migration[6.0]
+  def change
+    add_column :project_items, :user_secrets, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_29_084503) do
+ActiveRecord::Schema.define(version: 2021_03_31_110641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define(version: 2021_03_29_084503) do
     t.boolean "internal", default: false
     t.string "order_url"
     t.string "status", default: "created", null: false
+    t.jsonb "user_secrets", default: {}, null: false
     t.index ["offer_id"], name: "index_project_items_on_offer_id"
     t.index ["project_id"], name: "index_project_items_on_project_id"
   end

--- a/spec/features/my_services_spec.rb
+++ b/spec/features/my_services_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "My Services" do
     let(:user) { create(:user) }
     let(:service) { create(:service) }
     let(:offer) { create(:offer, service: service) }
+    let(:project) { create(:project, user: user) }
 
     before { checkin_sign_in_as(user) }
 
@@ -25,7 +26,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "I can see my projects services" do
-      project = create(:project, user: user)
       create(:project_item, project: project, offer: offer)
 
       visit project_services_path(project)
@@ -34,7 +34,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "I can see project_item details" do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer)
 
       visit project_service_path(project, project_item)
@@ -65,7 +64,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "I can see project_item change history", js: true do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer)
 
       project_item.new_status(status: "created", status_type: :created)
@@ -81,7 +79,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "I can see voucher id" do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: create(:offer, voucherable: true),
                             voucher_id: "V123V")
 
@@ -90,8 +87,16 @@ RSpec.feature "My Services" do
       expect(page).to have_text(project_item.voucher_id)
     end
 
+    scenario "I can see voucher id if requested and delivered" do
+      project_item = create(:project_item, project: project, offer: create(:offer, voucherable: true),
+                            request_voucher: true, user_secrets: { "voucher_id" => "V123V" })
+
+      visit project_service_path(project, project_item)
+
+      expect(page).to have_text("V123V")
+    end
+
     scenario "I cannot see voucher entry" do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer)
 
       visit project_service_path(project, project_item)
@@ -100,7 +105,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "I can see that voucher has been requested" do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: create(:offer, voucherable: true),
                             request_voucher: true)
 
@@ -110,7 +114,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "I cannot see review section" do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer)
 
       visit project_service_path(project, project_item)
@@ -119,7 +122,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "I can see review section" do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer, status: "ready", status_type: :ready)
       travel 1.day
       visit project_service_path(project, project_item)
@@ -129,7 +131,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "I can ask question about my project_item" do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer)
 
       visit project_service_conversation_path(project, project_item)
@@ -140,7 +141,6 @@ RSpec.feature "My Services" do
     end
 
     scenario "question message is mandatory" do
-      project = create(:project, user: user)
       project_item = create(:project_item, project: project, offer: offer)
 
       visit project_service_conversation_path(project, project_item)

--- a/spec/mailers/project_item_spec.rb
+++ b/spec/mailers/project_item_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 RSpec.describe ProjectItemMailer, type: :mailer do
   let(:user) { create(:user) }
   let(:project) { create(:project, user: user) }
-
+  let(:project_item) { create(:project_item, project: project) }
 
   context "project_item created" do
-    let(:project_item) { build(:project_item, id: 1, project: project) }
     let(:mail) { described_class.created(project_item).deliver_now }
 
     it "sends email to project_item owner" do
@@ -26,7 +25,6 @@ RSpec.describe ProjectItemMailer, type: :mailer do
   end
 
   context "project_item change" do
-    let(:project_item) { create(:project_item, project: project) }
     before(:each) do
       project_item.new_status(status: "custom_created", status_type: :created)
       project_item.new_status(status: "custom_registered", status_type: :registered)
@@ -91,8 +89,6 @@ RSpec.describe ProjectItemMailer, type: :mailer do
 
   context "Rating service" do
     it "notifies about service rating possibility" do
-      project_item = create(:project_item, project: project)
-
       mail = described_class.rate_service(project_item).deliver_now
       encoded_body = mail.body.encoded
 
@@ -104,8 +100,6 @@ RSpec.describe ProjectItemMailer, type: :mailer do
 
   context "aod request" do
     it "notify if accepted" do
-      project_item = create(:project_item, project: project)
-
       mail = described_class.aod_accepted(project_item).deliver_now
       encoded_body = mail.body.encoded
 
@@ -115,7 +109,6 @@ RSpec.describe ProjectItemMailer, type: :mailer do
     end
 
     it "notify if voucher accepted with voucher_id" do
-      project_item = create(:project_item, project: project)
       project_item.voucher_id = "1234"
 
       mail = described_class.aod_voucher_accepted(project_item).deliver_now
@@ -126,8 +119,18 @@ RSpec.describe ProjectItemMailer, type: :mailer do
       expect(encoded_body).to have_content("1234")
     end
 
+    it "notify if voucher accepted with user_secrets voucher_id" do
+      project_item.user_secrets["voucher_id"] = "1234"
+
+      mail = described_class.aod_voucher_accepted(project_item).deliver_now
+      encoded_body = mail.body.encoded
+
+      expect(mail.subject).to match(/Elastic Cloud Compute Cluster \(EC3\) service with voucher approved/)
+      expect(encoded_body).to match(/To redeem an Exoscale voucher:/)
+      expect(encoded_body).to have_content("1234")
+    end
+
     it "notify if voucher accepted without voucher_id" do
-      project_item = create(:project_item, project: project)
       project_item.voucher_id = "1234"
 
       mail = described_class.aod_voucher_accepted(project_item).deliver_now
@@ -139,8 +142,6 @@ RSpec.describe ProjectItemMailer, type: :mailer do
     end
 
     it "notify if voucher rejected with voucher_id" do
-      project_item = create(:project_item, project: project)
-
       mail = described_class.aod_voucher_rejected(project_item).deliver_now
       encoded_body = mail.body.encoded
 
@@ -149,8 +150,6 @@ RSpec.describe ProjectItemMailer, type: :mailer do
     end
 
     it "notify if voucher rejected without voucher_id" do
-      project_item = create(:project_item, project: project)
-
       mail = described_class.aod_voucher_rejected(project_item).deliver_now
       encoded_body = mail.body.encoded
 

--- a/spec/models/project_item_spec.rb
+++ b/spec/models/project_item_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe ProjectItem do
   subject { create(:project_item) }
 
+  it { should be_valid }
   it { should validate_presence_of(:offer) }
   it { should validate_presence_of(:project) }
   it { should validate_presence_of(:status) }
@@ -75,6 +76,26 @@ RSpec.describe ProjectItem do
 
     it "should defaults to []" do
       expect(create(:project_item).reload.properties).to eq([])
+    end
+  end
+
+  context "#user_secrets" do
+    it "should allow empty hash" do
+      expect(create(:project_item, user_secrets: {})).to be_valid
+    end
+
+    it "should default to empty hash" do
+      expect(create(:project_item).reload.user_secrets).to eq({})
+    end
+
+    it "should forbid non-string values" do
+      subject = build(:project_item, user_secrets: { "key" => 123 })
+      subject.valid?
+      expect(subject.errors[:user_secrets].size).to eq(1)
+    end
+
+    it "should allow string values" do
+      expect(build(:project_item, user_secrets: { "key" => "123" })).to be_valid
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,7 +80,7 @@ RSpec.configure do |config|
 
   # Re-run tests on failure to prevent random failures
   config.include RSpec::Repeat
-  config.around :each do |example|
+  config.around :each, :js do |example|
     repeat example, 4.times, verbose: true
   end
 end

--- a/spec/services/jira/issue_updated_spec.rb
+++ b/spec/services/jira/issue_updated_spec.rb
@@ -90,11 +90,24 @@ RSpec.describe Jira::IssueUpdated do
 
       expect(mail.subject).to eq("Elastic Cloud Compute Cluster (EC3) service with voucher rejected")
     end
+
+    it "updates user_secrets if voucher requested and granted" do
+      platform_aod = create(:platform, name: "EGI Applications on Demand")
+      service = create(:service, platforms: [platform_aod])
+      offer = create(:offer, service: service, voucherable: true)
+      project_item = create(:project_item, offer: offer, request_voucher: true)
+
+      described_class.new(project_item, changelog(field: "CP-VoucherID", toString: "123456")).call
+
+      project_item.reload
+
+      expect(project_item.user_secrets).to include("voucher_id" => "123456")
+    end
   end
 
-  def changelog(to:)
+  def changelog(field: "status", to: nil, toString: nil)
     { "items" => [
-      { "field" => "status", "to" => to }
+      { "field" => field, "to" => to, "toString" => toString }
     ] }
   end
 end


### PR DESCRIPTION
Add project_item.user_secrets column, which will store secrets passed
for a user by the resource (service) provider.
It is validated to only be a "simple" hash, i.e. it should only store
strings as values.

When rendering VoucherID, then take project_item.voucher_id if present,
otherwise, project_item.user_secrets["voucher_id"].

When accepting VoucherID updates from a provider, store it in
user_secrets instead of voucher_id, as the latter should only store
user-entered value (the case when user already has a voucher).

Correct typos in voucher spelling (i.e. vaucher).

Make some methods, which needn't be public, in project_item private.

Correct the MessagePolicy::Scope to use symbols.

Make rendering condition in _voucher.html.haml more readable by using
if instead of a convoluted unless.

Only attempt to repeat :js tests, as retrying all tests make development
harder.

Closes: #1940.