### PR TITLE
[#1966] Expose user_secrets in ordering API

### DIFF
--- a/app/policies/api/v1/oms/project_item_policy.rb
+++ b/app/policies/api/v1/oms/project_item_policy.rb
@@ -17,7 +17,7 @@ class Api::V1::Oms::ProjectItemPolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :user_secrets,
+      user_secrets: {},
       status: [:value, :type]
     ]
   end

--- a/app/serializers/ordering_api/v1/event_serializer.rb
+++ b/app/serializers/ordering_api/v1/event_serializer.rb
@@ -22,7 +22,13 @@ class OrderingApi::V1::EventSerializer < ActiveModel::Serializer
   end
 
   def changes
-    object.updates
+    object.updates&.map do |update|
+      if update["field"] == "user_secrets"
+        update["after"] = "<OBFUSCATED>"
+        update["before"] = "<OBFUSCATED>"
+      end
+      update
+    end
   end
 
   def project_id

--- a/app/serializers/ordering_api/v1/project_item_serializer.rb
+++ b/app/serializers/ordering_api/v1/project_item_serializer.rb
@@ -5,6 +5,7 @@ class OrderingApi::V1::ProjectItemSerializer < ActiveModel::Serializer
   attribute :status
   attribute :attribute_extractor, key: :attributes
   attribute :oms_params, if: -> { object.offer.oms_params.present? }
+  attribute :user_secrets
 
   def status
     {
@@ -27,5 +28,12 @@ class OrderingApi::V1::ProjectItemSerializer < ActiveModel::Serializer
 
   def oms_params
     object.offer.oms_params
+  end
+
+  def user_secrets
+    non_obfuscated = instance_options[:non_obfuscated_user_secrets] || []
+    object.user_secrets&.map { |k, v|
+      non_obfuscated.include?(k) ? [k, v] : [k, "<OBFUSCATED>"]
+    }.to_h
   end
 end

--- a/spec/serializers/ordering_api/v1/event_serializer_spec.rb
+++ b/spec/serializers/ordering_api/v1/event_serializer_spec.rb
@@ -5,7 +5,10 @@ require "rails_helper"
 RSpec.describe OrderingApi::V1::EventSerializer do
   it "it properly serializes a project item event" do
     event = Event.create(action: :update,
-                         updates: [{ field: "name", before: "zxc", after: "qwe" }],
+                         updates: [
+                           { field: "name", before: "zxc", after: "qwe" },
+                           { field: "user_secrets", before: "123", after: "456" },
+                         ],
                          additional_info: { eventable_type: "ProjectItem", project_id: 1, project_item_id: 1 })
 
     serialized = described_class.new(event).as_json
@@ -19,8 +22,13 @@ RSpec.describe OrderingApi::V1::EventSerializer do
         {
           field: "name",
           before: "zxc",
-          after: "qwe"
-        }
+          after: "qwe",
+        },
+        {
+          field: "user_secrets",
+          before: "<OBFUSCATED>",
+          after: "<OBFUSCATED>",
+        },
       ]
     }
 

--- a/spec/serializers/ordering_api/v1/project_item_serializer_spec.rb
+++ b/spec/serializers/ordering_api/v1/project_item_serializer_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe OrderingApi::V1::ProjectItemSerializer do
         request_voucher: project_item.request_voucher,
         order_type: project_item.order_type,
       },
-      oms_params: project_item.offer.oms_params
+      oms_params: project_item.offer.oms_params,
+      user_secrets: {},
     }
 
     expect(serialized).to eq(expected)
@@ -49,8 +50,27 @@ RSpec.describe OrderingApi::V1::ProjectItemSerializer do
         request_voucher: project_item.request_voucher,
         order_type: project_item.order_type,
       },
+      user_secrets: {},
     }
 
     expect(serialized).to eq(expected)
+  end
+
+  context "#user_secrets" do
+    it "obfuscates values" do
+      project_item = create(:project_item, user_secrets: { "key-1" => "value", "key-2" => "value" })
+
+      serialized = described_class.new(project_item).as_json
+
+      expect(serialized[:user_secrets]).to eq({ "key-1" => "<OBFUSCATED>", "key-2" => "<OBFUSCATED>" })
+    end
+
+    it "obfuscates non-excluded values" do
+      project_item = create(:project_item, user_secrets: { "key-1" => "value", "key-2" => "value" })
+
+      serialized = described_class.new(project_item, non_obfuscated_user_secrets: %w[key-1 other]).as_json
+
+      expect(serialized[:user_secrets]).to eq({ "key-1" => "value", "key-2" => "<OBFUSCATED>" })
+    end
   end
 end

--- a/swagger/v1/ordering/project/project_item/project_item_update.json
+++ b/swagger/v1/ordering/project/project_item/project_item_update.json
@@ -14,7 +14,7 @@
     },
     "user_secrets": {"type": "object"}
   },
-  "oneOf": [
+  "anyOf": [
     {
       "required": [
         "status"

--- a/swagger/v1/ordering/swagger.json
+++ b/swagger/v1/ordering/swagger.json
@@ -35,7 +35,7 @@
             "name": "from_timestamp",
             "in": "query",
             "required": true,
-            "description": "List events after",
+            "description": "List events after, ISO8601 format",
             "schema": {
               "type": "string"
             }
@@ -57,6 +57,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "event/event_index.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
                 }
               }
             }
@@ -445,7 +455,7 @@
             }
           },
           "400": {
-            "description": "project item update validation failed",
+            "description": "project item update validation failed wrong user secrets",
             "content": {
               "application/json": {
                 "schema": {
@@ -459,7 +469,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "project/project_item/project_item_write.json"
+                "$ref": "project/project_item/project_item_update.json"
               }
             }
           }


### PR DESCRIPTION
The user_secrets hash values are obfuscated, excluding the ones which
were updated by the call (i.e. in method update).

Setting `user_secrets: {}` in policy's permitted_attributes allows any
key.

The obfuscation is done in controller on purpose, to allow
non-obfuscation of some keys in case of update.

Closes: #1966.