### PR TITLE
[#1883] OMS ordering API authorization 

### DIFF
--- a/app/controllers/api/v1/oms/api_controller.rb
+++ b/app/controllers/api/v1/oms/api_controller.rb
@@ -3,7 +3,6 @@
 class Api::V1::Oms::ApiController < ActionController::API
   include Pundit
   acts_as_token_authentication_handler_for User, fallback: :exception
-  before_action :find_and_authorize_oms
 
   rescue_from Pundit::NotAuthorizedError do
     render json: not_authorized, status: 403
@@ -21,15 +20,16 @@ class Api::V1::Oms::ApiController < ActionController::API
     super([:api, :v1, :oms, record], action)
   end
 
+  protected
+    def find_and_authorize_oms
+      @oms = Oms.find(params[:oms_id])
+      authorize @oms, :show?
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "OMS not found" }, status: 404
+    end
+
   private
     def not_authorized
       { error: "You are not authorized to perform this action." }
-    end
-
-    def find_and_authorize_oms
-      @oms = Oms.find(params[:oms_id])
-      authorize @oms, :this_oms_admin?
-    rescue ActiveRecord::RecordNotFound
-      render json: { error: "Oms not found" }, status: 404
     end
 end

--- a/app/controllers/api/v1/oms/events_controller.rb
+++ b/app/controllers/api/v1/oms/events_controller.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 class Api::V1::Oms::EventsController < Api::V1::Oms::ApiController
-  before_action :handle_timestamp
-  before_action :handle_limit
+  before_action :find_and_authorize_oms
+  before_action :handle_timestamp,  only: [:index]
+  before_action :handle_limit, only: [:index]
+  before_action :load_events, only: [:index]
 
   def index
-    load_events
     render json: { events: @events.map { |e| OrderingApi::V1::EventSerializer.new(e) } }
   end
 
-
   private
     def load_events
-      @events = policy_scope(@oms.associated_events).limit(@limit).where("created_at > ?", @from_timestamp).order(:created_at)
+      @events = policy_scope(@oms.events).limit(@limit).where("events.created_at > ?", @from_timestamp).order("events.created_at")
     end
 
     def handle_timestamp

--- a/app/controllers/api/v1/oms/projects_controller.rb
+++ b/app/controllers/api/v1/oms/projects_controller.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class Api::V1::Oms::ProjectsController < Api::V1::Oms::ApiController
+  before_action :find_and_authorize_oms
   before_action :find_and_authorize, only: :show
 
   def index
     @from_id = params[:from_id].present? ? params[:from_id] : 0
     @limit = params[:limit].present? ? params[:limit] : 20
-    load_projects!
+    load_projects
     render json: { projects: @projects.map { |p| OrderingApi::V1::ProjectSerializer.new(p) } }
   end
 
@@ -16,13 +17,13 @@ class Api::V1::Oms::ProjectsController < Api::V1::Oms::ApiController
 
   private
     def find_and_authorize
-      @project = @oms.associated_projects.find(params[:id])
+      @project = @oms.projects.find(params[:id])
       authorize @project
     rescue ActiveRecord::RecordNotFound
       render json: { error: "Project not found" }, status: 404
     end
 
-    def load_projects!
-      @projects = policy_scope(@oms.associated_projects).where("id > ?", @from_id).order(:id).limit(@limit)
+    def load_projects
+      @projects = policy_scope(@oms.projects).where("projects.id > ?", @from_id).order("projects.id").limit(@limit)
     end
 end

--- a/app/controllers/api/v1/oms_controller.rb
+++ b/app/controllers/api/v1/oms_controller.rb
@@ -1,13 +1,31 @@
 # frozen_string_literal: true
 
 class Api::V1::OmsController < Api::V1::Oms::ApiController
+  before_action :find_and_authorize, only: [:show, :update]
+  before_action :load_omses, only: [:index]
+
+  def index
+    render json: { "OMSes": @omses.map { |oms| OrderingApi::V1::OmsSerializer.new(oms).as_json } }
+  end
+
   def show
-    # TODO: implement endpoint functionality
-    render json: { "message": "Api::V1::OmsController#show" }
+    render json: OrderingApi::V1::OmsSerializer.new(@oms).as_json
   end
 
   def update
     # TODO: implement endpoint functionality
-    render json: { "message": "Api::V1::OmsController#update" }
+    render json: { "message": "Not yet implemented" }
   end
+
+  private
+    def load_omses
+      @omses = policy_scope(Oms).order(:id)
+    end
+
+    def find_and_authorize
+      @oms = Oms.find(params[:id])
+      authorize @oms
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "OMS not found" }, status: 404
+    end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,12 @@
 
 class Event < ApplicationRecord
   belongs_to :eventable, polymorphic: true
+  belongs_to :project, -> { where(events: { eventable_type: "Project" }).includes(:events) },
+             foreign_key: "eventable_id", optional: true
+  belongs_to :project_item, -> { where(events: { eventable_type: "ProjectItem" }).includes(:events) },
+             foreign_key: "eventable_id", optional: true
+  belongs_to :message, -> { where(events: { eventable_type: "Message" }).includes(:events) },
+             foreign_key: "eventable_id", optional: true
 
   enum action: {
     create: "create",

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -19,6 +19,10 @@ class Message < ApplicationRecord
              class_name: "User",
              optional: true
   belongs_to :messageable, polymorphic: true
+  belongs_to :project_item, -> { where(messages: { messageable_type: "ProjectItem" }).includes(:messages) },
+             foreign_key: "messageable_id", optional: true
+  belongs_to :project, -> { where(messages: { messageable_type: "Project" }).includes(:messages) },
+             foreign_key: "messageable_id", optional: true
 
   validates :author_role, presence: true
   validates :author, presence: true, if: :role_user?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,10 @@ class User < ApplicationRecord
     DataAdministrator.where(email: email).count.positive?
   end
 
+  def default_oms_administrator?
+    administrated_oms.where(default: true).present?
+  end
+
   def managed_services
     Service.administered_by(self)
   end

--- a/app/policies/api/v1/oms/api_policy.rb
+++ b/app/policies/api/v1/oms/api_policy.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class Api::V1::Oms::ApiPolicy < Struct.new(:user, :api)
-  def show?
-    # user.administrated_oms.present? TODO: implement - in authorization task #1883
-    # TODO: or it may not be necessary, then we can delete this class
-    true
-  end
-end

--- a/app/policies/api/v1/oms/event_policy.rb
+++ b/app/policies/api/v1/oms/event_policy.rb
@@ -3,7 +3,21 @@
 class Api::V1::Oms::EventPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.all # TODO: implement index scope logic - in authorization task #1883
+      if user.default_oms_administrator?
+        scope.all
+      else
+        # Outer join chosen events with ProjectItem OR Project OR Message eventables
+        # and look if user is administrating an oms inside their respective offers.primary_oms
+        scope.where("offers.primary_oms_id IN (?)", user.administrated_oms_ids)
+             .or(scope.where("offers_project_items.primary_oms_id IN (?)", user.administrated_oms_ids))
+             .or(scope.where("offers_project_items_2.primary_oms_id IN (?)", user.administrated_oms_ids))
+             .or(scope.where("offers_project_items_3.primary_oms_id IN (?)", user.administrated_oms_ids))
+             .left_outer_joins({ project_item: :offer },
+                               { project: { project_items: :offer } },
+                               { message: { project_item: :offer } },
+                               { message: { project: { project_items: :offer } } })
+             .distinct
+      end
     end
   end
 end

--- a/app/policies/api/v1/oms/message_policy.rb
+++ b/app/policies/api/v1/oms/message_policy.rb
@@ -3,16 +3,29 @@
 class Api::V1::Oms::MessagePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.all # TODO: implement index scope logic - in authorization task #1883
+      if user.default_oms_administrator?
+        scope.all
+      else
+        # Outer join chosen messages with ProjectItem OR Project messageables
+        # and look if user is administrating an oms inside their respective offers.primary_oms
+        scope.where("offers.primary_oms_id IN (?)", user.administrated_oms_ids)
+             .or(scope.where("offers_project_items.primary_oms_id IN (?)", user.administrated_oms_ids))
+             .left_outer_joins(project_item: :offer, project:  { project_items: :offer })
+             .distinct
+      end
     end
   end
 
+  def show?
+    message_managed_by_user? || user.default_oms_administrator?
+  end
+
   def create?
-    true # TODO: show policy logic - in authorization task #1883
+    write_permissions
   end
 
   def update?
-    true # TODO: update policy logic - in authorization task #1883
+    write_permissions
   end
 
   def permitted_attributes_for_create
@@ -28,4 +41,50 @@ class Api::V1::Oms::MessagePolicy < ApplicationPolicy
   def permitted_attributes_for_update
     [:content]
   end
+
+  private
+    def write_permissions
+      if record.messageable_type == "Project"
+        project_message_write_permissions
+      elsif record.messageable_type == "ProjectItem"
+        project_item_message_write_permissions
+      end
+    end
+
+    def project_message_write_permissions
+      if record.public_scope? || record.internal_scope?
+        if record.role_provider?
+          message_managed_by_user?
+        elsif record.role_mediator?
+          user.default_oms_administrator?
+        elsif record.role_user?
+          false
+        end
+      elsif record.user_direct_scope?
+        record.role_mediator? ? user.default_oms_administrator? : false
+      end
+    end
+
+    def project_item_message_write_permissions
+      if record.public_scope? || record.internal_scope?
+        if record.role_provider?
+          message_managed_by_user?
+        elsif record.role_mediator?
+          user.default_oms_administrator?
+        elsif record.role_user?
+          false
+        end
+      elsif record.user_direct_scope?
+        record.role_provider? ? message_managed_by_user? : false
+      end
+    end
+
+    def message_managed_by_user?
+      if record.messageable_type == "ProjectItem"
+        user.administrated_oms.include? record.messageable.offer.current_oms
+      elsif record.messageable_type == "Project"
+        # Using .map instead of .joins, because we need .current_oms method and not .primary_oms relation
+        Set.new(user.administrated_oms).intersect?(Set.new(record.messageable.project_items.map(&:offer).map(&:current_oms)))
+      end
+    end
 end

--- a/app/policies/api/v1/oms/oms_policy.rb
+++ b/app/policies/api/v1/oms/oms_policy.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class Api::V1::Oms::OmsPolicy < ApplicationPolicy
-  def this_oms_admin?
+  class Scope < Scope
+    def resolve
+      user.administrated_oms
+    end
+  end
+
+  def show?
     user.administrated_oms.include? record
   end
 end

--- a/app/policies/api/v1/oms/project_policy.rb
+++ b/app/policies/api/v1/oms/project_policy.rb
@@ -3,11 +3,22 @@
 class Api::V1::Oms::ProjectPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.all # TODO: index policy logic - in authorization task #1883
+      if user.default_oms_administrator?
+        scope.all
+      else
+        scope.joins(project_items: :offer)
+             .where({ project_items: { offers: { primary_oms_id: user.administrated_oms_ids } } }).distinct
+      end
     end
   end
 
   def show?
-    true # TODO: show policy logic - in authorization task #1883
+    project_managed_by_user? || user.default_oms_administrator?
   end
+
+  private
+    def project_managed_by_user?
+      # Using .map instead of .joins, because we need .current_oms method and not .primary_oms relation
+      Set.new(user.administrated_oms).intersect?(Set.new(record.project_items.map(&:offer).map(&:current_oms)))
+    end
 end

--- a/app/serializers/ordering_api/v1/message_serializer.rb
+++ b/app/serializers/ordering_api/v1/message_serializer.rb
@@ -4,7 +4,7 @@ class OrderingApi::V1::MessageSerializer < ActiveModel::Serializer
   attribute :id
   attribute :author
   attribute :message, key: :content
-  attribute :scope
+  attribute :message_scope, key: :scope
   attributes :created_at, :updated_at
 
   def author
@@ -15,9 +15,8 @@ class OrderingApi::V1::MessageSerializer < ActiveModel::Serializer
     }
   end
 
-  def scope
-    # TODO: absolutely no idea why it doesn't work like attribute :id, :created_at or any other attribute...
-    # TODO: and you have to specify this in this method
+  def message_scope
+    # scope is a reserved keyword in ActiveModel::Serializer
     object.scope
   end
 

--- a/app/serializers/ordering_api/v1/oms_serializer.rb
+++ b/app/serializers/ordering_api/v1/oms_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class OrderingApi::V1::OmsSerializer < ActiveModel::Serializer
+  attributes :id, :name, :type, :default
+  attribute :trigger_url, if: -> { object.trigger_url.present? }
+  attribute :custom_params, if: -> { object.custom_params.present? }
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -18,7 +18,5 @@
 # end
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.uncountable "Oms"
-  inflect.uncountable "OMS"
-  inflect.uncountable "oms"
+  inflect.irregular "oms", "oms"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ Rails.application.routes.draw do
           resources :offers, only: [:index, :create, :show, :destroy, :update]
         end
       end
-      resources :oms, only: [:show, :update] do
+      resources :oms, only: [:index, :show, :update] do
         scope module: :oms do
           resources :events, only: :index
           resources :projects, only: [:index, :show, :update] do
@@ -125,7 +125,7 @@ Rails.application.routes.draw do
               resources :project_items, only: [:index, :show, :update]
             end
           end
-          resources :messages, only: [:index, :create, :update]
+          resources :messages, only: [:index, :show, :create, :update]
         end
       end
     end

--- a/lib/ordering_api/authorization_test_setup.rb
+++ b/lib/ordering_api/authorization_test_setup.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module OrderingApi
+  class AuthorizationTestSetup
+    def initialize; end
+
+    def call
+      oms_admin1 = User.create!(uid: "oms2_admin", first_name: "oms2_admin", last_name: "oms2_admin", email: "email1@email.com")
+      oms_admin2 = User.create!(uid: "oms3_admin", first_name: "oms3_admin", last_name: "oms3_admin", email: "email2@email.com")
+
+      oms2 = Oms.create!(name: "OMS2", type: "global", administrators: [oms_admin1])
+      oms3 = Oms.create!(name: "OMS3", type: "global", administrators: [oms_admin2])
+
+      provider = Provider.create!(name: "provider")
+      service1 = Service.create!(name: "s1", description: "asd", tagline: "asd", status: "published", providers: [provider],
+                               resource_organisation: provider, scientific_domains: [ScientificDomain.first], geographical_availabilities: ["PL"])
+      service2 = Service.create!(name: "s2", description: "asd", tagline: "asd", status: "published", providers: [provider],
+                                resource_organisation: provider, scientific_domains: [ScientificDomain.first], geographical_availabilities: ["PL"])
+      offer1 = Offer.create!(order_type: "open_access", name: "o1", description: "asd", service: service1,
+                            status: "published", primary_oms: oms2)
+      offer2 = Offer.create!(order_type: "open_access", name: "o2", description: "asd", service: service2,
+                            status: "published", primary_oms: oms3)
+
+      project_owner = User.create!(uid: "user", first_name: "user", last_name: "user", email: "email3@email.com")
+      project1 = Project.create!(user: project_owner, name: "p1", email: "email4@email.com",
+                                 country_of_origin: "PL", webpage: "https://www.cyfronet.krakow.pl/", organization: "asd",
+                                reason_for_access: "asd", customer_typology: "single_user", status: "active")
+      project2 = Project.create!(user: project_owner, name: "p2", email: "email4@email.com",
+                                 country_of_origin: "PL", webpage: "https://www.cyfronet.krakow.pl/", organization: "asd",
+                                 reason_for_access: "asd", customer_typology: "single_user", status: "active")
+      project3 = Project.create!(user: project_owner, name: "p3", email: "email4@email.com",
+                                 country_of_origin: "PL", webpage: "https://www.cyfronet.krakow.pl/", organization: "asd",
+                                 reason_for_access: "asd", customer_typology: "single_user", status: "active")
+
+      ProjectItem.create!(offer: offer1, project: project2, status: "ready", status_type: "ready")
+      ProjectItem.create!(offer: offer1, project: project3, status: "ready", status_type: "ready")
+      ProjectItem.create!(offer: offer2, project: project3, status: "ready", status_type: "ready")
+
+      Message.create!(messageable: project1, author_role: "user", author: project_owner, scope: "public", message: "Public user message in project 1")
+      Message.create!(messageable: project1, author_role: "mediator", scope: "public", message: "Public mediator  message in project 1")
+
+      Message.create!(messageable: project3, author_role: "provider", scope: "public", message: "Public provider message in project3")
+      Message.create!(messageable: project3, author_role: "provider", scope: "user_direct", message: "User direct provider message in project3")
+    end
+  end
+end

--- a/lib/tasks/ordering_api.rake
+++ b/lib/tasks/ordering_api.rake
@@ -3,8 +3,11 @@
 require "ordering_api/add_sombo"
 
 namespace :ordering_api do
-  desc "Add global SOMBO OMS"
   task add_sombo: :environment do
     OrderingApi::AddSombo.new.call
+  end
+
+  task authorization_test_setup: :environment do
+    OrderingApi::AuthorizationTestSetup.new.call
   end
 end

--- a/spec/models/oms_spec.rb
+++ b/spec/models/oms_spec.rb
@@ -60,4 +60,114 @@ RSpec.describe Oms, type: :model do
       expect(build(:provider_group_oms, providers: [])).to_not be_valid
     end
   end
+
+  context "#projects" do
+    let(:project1) { create(:project) }
+    let(:project2) { create(:project) }
+    let(:default_oms) { create(:oms, offers: [create(:offer),
+                                 create(:offer, project_items: [create(:project_item, project: project1)]),
+                                 create(:offer, project_items: [create(:project_item, project: project1),
+                                                                create(:project_item, project: project2)])]) }
+
+    let(:oms) { create(:oms, default: true, offers: [create(:offer, project_items: [create(:project_item, project: project1)]),
+                                                     create(:offer, project_items: [create(:project_item, project: project1)])]) }
+    let(:other_oms) { create(:oms, offers: create_list(:offer, 2)) }
+
+    it "should return all project when oms is default" do
+      expect(default_oms.projects).to contain_exactly(project1, project2)
+    end
+
+    it "should return only associated projects when oms is not default" do
+      expect(oms.projects).to contain_exactly(project1)
+      expect(other_oms.projects).to eq([])
+    end
+  end
+
+  context "#project_items_for" do
+    let(:oms1) { create(:oms) }
+    let(:oms2) { create(:oms) }
+    let(:default_oms) { create(:oms, default: true) }
+    let(:project_items1) { [
+      build(:project_item, offer: build(:offer, primary_oms: oms1)),
+      build(:project_item, offer: build(:offer, primary_oms: oms1)),
+      build(:project_item, offer: build(:offer, primary_oms: oms2)),
+      build(:project_item, offer: build(:offer, primary_oms: oms1)),
+      build(:project_item, offer: build(:offer, primary_oms: oms2))
+    ] }
+    let(:project_items2) { [
+      build(:project_item, offer: build(:offer, primary_oms: oms1)),
+      build(:project_item, offer: build(:offer, primary_oms: oms1))
+    ] }
+    let(:project) { create(:project, project_items: project_items1) }
+    let(:other_project) { create(:project, project_items: project_items2) }
+
+    it "returns only associated project_items for a single project" do
+      expect(oms1.project_items_for(project)).to contain_exactly(project_items1[0], project_items1[1], project_items1[3])
+      expect(oms2.project_items_for(project)).to contain_exactly(project_items1[2], project_items1[4])
+
+      expect(oms1.project_items_for(other_project)).to eq(project_items2)
+      expect(oms2.project_items_for(other_project)).to eq([])
+    end
+
+    it "returns all project_items for a single project for a default oms" do
+      expect(default_oms.project_items_for(project)).to eq(project_items1)
+      expect(default_oms.project_items_for(other_project)).to eq(project_items2)
+    end
+  end
+
+  context "#events" do
+    let(:default_oms) { create(:oms, default: true) }
+    let(:oms) { create(:oms) }
+
+    let!(:project1) { create(:project) }
+    let!(:project2) { create(:project) }
+
+    let!(:project_item1) { create(:project_item, project: project1, offer: build(:offer, primary_oms: default_oms)) }
+    let!(:project_item2) { create(:project_item, project: project2, offer: build(:offer, primary_oms: oms)) }
+
+    let!(:message1) { create(:message, messageable: project1) }
+    let!(:message2) { create(:message, messageable: project_item1) }
+    let!(:message3) { create(:message, messageable: project2) }
+    let!(:message4) { create(:message, messageable: project_item2) }
+
+    it "returns all events when oms is default" do
+      expect(default_oms.events.count).to eq(8)
+      expect(default_oms.events[0].eventable).to eq(project1)
+      expect(default_oms.events[1].eventable).to eq(project2)
+      expect(default_oms.events[2].eventable).to eq(project_item1)
+      expect(default_oms.events[3].eventable).to eq(project_item2)
+      expect(default_oms.events[4].eventable).to eq(message1)
+      expect(default_oms.events[5].eventable).to eq(message2)
+      expect(default_oms.events[6].eventable).to eq(message3)
+      expect(default_oms.events[7].eventable).to eq(message4)
+    end
+
+    it "returns proper events when oms is not default" do
+      expect(oms.events.count).to eq(4)
+      expect(oms.events[0].eventable).to eq(project2)
+      expect(oms.events[1].eventable).to eq(project_item2)
+      expect(oms.events[2].eventable).to eq(message3)
+      expect(oms.events[3].eventable).to eq(message4)
+    end
+  end
+
+  context "#messages" do
+    let(:oms1) { create(:oms) }
+    let(:oms2) { create(:oms) }
+    let(:default_oms) { create(:oms, default: true) }
+
+    let(:project_item1) { create(:project_item, offer: create(:offer, primary_oms: oms1)) }
+    let(:project_item2) { create(:project_item, offer: create(:offer, primary_oms: oms2)) }
+    let(:project) { create(:project, project_items: [project_item1, project_item2]) }
+
+    let!(:message1) { create(:message, messageable: project_item1) }
+    let!(:message2) { create(:message, messageable: project_item2) }
+    let!(:message3) { create(:message, messageable: project) }
+
+    it "returns associated messages" do
+      expect(oms1.messages).to contain_exactly(message1, message3)
+      expect(oms2.messages).to contain_exactly(message2, message3)
+      expect(default_oms.messages).to contain_exactly(message1, message2, message3)
+    end
+  end
 end

--- a/spec/policies/api/v1/oms/event_policy_spec.rb
+++ b/spec/policies/api/v1/oms/event_policy_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Oms::EventPolicy, type: :policy do
+  subject { described_class }
+
+  permissions ".scope" do
+    let(:default_oms_admin) { create(:user) }
+    let(:other_oms_admin) { (create(:user)) }
+
+    let(:default_oms) { (create(:oms, default: true, administrators:  [default_oms_admin])) }
+    let(:other_oms) { (create(:oms, administrators: [other_oms_admin])) }
+
+    let(:project_item1) { build(:project_item, offer: build(:offer, primary_oms: default_oms), iid: 1) }
+    let(:project_item2) { build(:project_item, offer: build(:offer, primary_oms: other_oms), iid: 2) }
+    let(:project_item3) { build(:project_item, offer: build(:offer, primary_oms: nil), iid: 1) }
+
+    let!(:project1) { create(:project, project_items: [project_item1, project_item2]) }
+    let!(:project2) { create(:project, project_items: [project_item3]) }
+
+    let!(:message1) { create(:message, messageable: project1) }
+    let!(:message2) { create(:message, messageable: project2) }
+    let!(:message3) { create(:message, messageable: project2) }
+
+    let!(:message4) { create(:message, messageable: project_item1) }
+    let!(:message5) { create(:message, messageable: project_item2) }
+    let!(:message6) { create(:message, messageable: project_item3) }
+    let!(:message7) { create(:message, messageable: project_item1) }
+
+    it "shows all events for a default oms" do
+      expect(subject::Scope.new(default_oms_admin, default_oms.events).resolve.count).to eq(12)
+      expect(subject::Scope.new(default_oms_admin, default_oms.events).resolve.map(&:eventable)).
+        to contain_exactly(project_item1, project_item2, project_item3,
+                           project1, project2,
+                           message1, message2, message3, message4, message5, message6, message7)
+
+      # Shouldn't happen because we are authorizing if a user is administrating a particular OMS beforehand
+      expect(subject::Scope.new(default_oms_admin, other_oms.events).resolve.count).to eq(4)
+      expect(subject::Scope.new(default_oms_admin, other_oms.events).resolve.map(&:eventable)).
+        to contain_exactly(project_item2, project1, message1, message5)
+    end
+
+    it "shows events which offers' primary_oms is administrated by user" do
+      expect(subject::Scope.new(other_oms_admin, other_oms.events).resolve.count).to eq(4)
+      expect(subject::Scope.new(other_oms_admin, other_oms.events).resolve.map(&:eventable)).
+        to contain_exactly(project_item2, project1, message1, message5)
+
+      # Shouldn't happen because we are authorizing if a user is administrating a particular OMS beforehand
+      expect(subject::Scope.new(other_oms_admin, default_oms.events).resolve.count).to eq(4)
+      expect(subject::Scope.new(other_oms_admin, default_oms.events).resolve.map(&:eventable)).
+        to contain_exactly(project_item2, project1, message1, message5)
+    end
+  end
+end

--- a/spec/policies/api/v1/oms/message_policy_spec.rb
+++ b/spec/policies/api/v1/oms/message_policy_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Oms::MessagePolicy, type: :policy do
+  subject { described_class }
+
+  let(:oms_admin) { create(:user) }
+  let(:default_oms_admin) { create(:user) }
+
+  let(:oms) { create(:oms, administrators: [oms_admin]) }
+  let(:default_oms) { create(:oms, default: true, administrators: [default_oms_admin]) }
+
+  let(:project_item1) { build(:project_item, offer: build(:offer, primary_oms: oms)) }
+  let(:project_item2) { build(:project_item, offer: build(:offer, primary_oms: default_oms)) }
+  let(:project_item3) { build(:project_item, offer: build(:offer, primary_oms: nil)) }
+
+  let(:project1) { create(:project, project_items: [project_item1, project_item2]) }
+  let(:project2) { create(:project, project_items: [project_item3]) }
+  let(:project3) { create(:project, project_items: [build(:project_item, offer: build(:offer, primary_oms: oms))]) }
+
+  let!(:message1) { create(:message, messageable: project1, scope: "public", author_role: "provider") }
+  let!(:message2) { create(:message, messageable: project1, scope: "public", author_role: "mediator") }
+  let!(:message3) { create(:message, messageable: project2, scope: "internal", author_role: "provider") }
+  let!(:message4) { create(:message, messageable: project2, scope: "internal", author_role: "mediator") }
+  let!(:message5) { create(:message, messageable: project3, scope: "user_direct", author_role: "provider") }
+  let!(:message6) { create(:message, messageable: project3, scope: "user_direct", author_role: "mediator") }
+  let!(:message7) { create(:message, messageable: project3, author_role: "user") }
+
+  let!(:message8) { create(:message, messageable: project_item1, scope: "public", author_role: "provider") }
+  let!(:message9) { create(:message, messageable: project_item1, scope: "public", author_role: "mediator") }
+  let!(:message10) { create(:message, messageable: project_item2, scope: "internal", author_role: "provider") }
+  let!(:message11) { create(:message, messageable: project_item2, scope: "internal", author_role: "mediator") }
+  let!(:message12) { create(:message, messageable: project_item3, scope: "user_direct", author_role: "provider") }
+  let!(:message13) { create(:message, messageable: project_item3, scope: "user_direct", author_role: "mediator") }
+  let!(:message14) { create(:message, messageable: project_item3, author_role: "user") }
+
+  permissions ".scope" do
+    it "shows all project's and project_items' messages when user is a default oms admin" do
+      expect(subject::Scope.new(default_oms_admin, project1.messages).resolve).to contain_exactly(message1, message2)
+      expect(subject::Scope.new(default_oms_admin, project2.messages).resolve).to contain_exactly(message3, message4)
+      expect(subject::Scope.new(default_oms_admin, project3.messages).resolve).to contain_exactly(message5, message6, message7)
+
+      expect(subject::Scope.new(default_oms_admin, project_item1.messages).resolve).to contain_exactly(message8, message9)
+      expect(subject::Scope.new(default_oms_admin, project_item2.messages).resolve).to contain_exactly(message10, message11)
+      expect(subject::Scope.new(default_oms_admin, project_item3.messages).resolve).to contain_exactly(message12, message13, message14)
+    end
+
+    it "shows messages which offers' primary_oms is administrated by user" do
+      expect(subject::Scope.new(oms_admin, project1.messages).resolve).to contain_exactly(message1, message2)
+      expect(subject::Scope.new(oms_admin, project2.messages).resolve).to eq([])
+      expect(subject::Scope.new(oms_admin, project3.messages).resolve).to contain_exactly(message5, message6, message7)
+
+      expect(subject::Scope.new(oms_admin, project_item1.messages).resolve).to contain_exactly(message8, message9)
+      expect(subject::Scope.new(oms_admin, project_item2.messages).resolve).to eq([])
+      expect(subject::Scope.new(oms_admin, project_item3.messages).resolve).to eq([])
+    end
+  end
+
+  permissions :show? do
+    it "grants permission to all of the project's and project_items' messages when user is a default oms admin" do
+      expect(subject).to permit(default_oms_admin, message1)
+      expect(subject).to permit(default_oms_admin, message2)
+      expect(subject).to permit(default_oms_admin, message3)
+      expect(subject).to permit(default_oms_admin, message4)
+      expect(subject).to permit(default_oms_admin, message5)
+      expect(subject).to permit(default_oms_admin, message6)
+      expect(subject).to permit(default_oms_admin, message7)
+      expect(subject).to permit(default_oms_admin, message8)
+      expect(subject).to permit(default_oms_admin, message9)
+      expect(subject).to permit(default_oms_admin, message10)
+      expect(subject).to permit(default_oms_admin, message11)
+      expect(subject).to permit(default_oms_admin, message12)
+      expect(subject).to permit(default_oms_admin, message13)
+      expect(subject).to permit(default_oms_admin, message14)
+    end
+
+    it "grants permission to project's and project_items' messages when user is a provider oms admin" do
+      expect(subject).to permit(oms_admin, message1)
+      expect(subject).to permit(oms_admin, message2)
+      expect(subject).to_not permit(oms_admin, message3)
+      expect(subject).to_not permit(oms_admin, message4)
+      expect(subject).to permit(oms_admin, message5)
+      expect(subject).to permit(oms_admin, message6)
+      expect(subject).to permit(oms_admin, message7)
+      expect(subject).to permit(oms_admin, message8)
+      expect(subject).to permit(oms_admin, message9)
+      expect(subject).to_not permit(oms_admin, message10)
+      expect(subject).to_not permit(oms_admin, message11)
+      expect(subject).to_not permit(oms_admin, message12)
+      expect(subject).to_not permit(oms_admin, message13)
+      expect(subject).to_not permit(oms_admin, message14)
+    end
+  end
+
+  permissions :create? do
+    it "grants permission to project's messages" do
+      expect(subject).to permit(default_oms_admin, message1)
+      expect(subject).to permit(oms_admin, message1)
+
+      expect(subject).to permit(default_oms_admin, message2)
+      expect(subject).to_not permit(oms_admin, message2)
+
+      expect(subject).to permit(default_oms_admin, message3)
+      expect(subject).to_not permit(oms_admin, message3)
+
+      expect(subject).to permit(default_oms_admin, message4)
+      expect(subject).to_not permit(oms_admin, message4)
+
+      expect(subject).to_not permit(default_oms_admin, message5)
+      expect(subject).to_not permit(oms_admin, message5)
+
+      expect(subject).to permit(default_oms_admin, message6)
+      expect(subject).to_not permit(oms_admin, message6)
+
+      expect(subject).to_not permit(oms_admin, message7)
+      expect(subject).to_not permit(oms_admin, message7)
+    end
+
+    it "grants permission to project item's messages" do
+      expect(subject).to_not permit(default_oms_admin, message8)
+      expect(subject).to permit(oms_admin, message8)
+
+      expect(subject).to permit(default_oms_admin, message9)
+      expect(subject).to_not permit(oms_admin, message9)
+
+      expect(subject).to permit(default_oms_admin, message10)
+      expect(subject).to_not permit(oms_admin, message10)
+
+      expect(subject).to permit(default_oms_admin, message11)
+      expect(subject).to_not permit(oms_admin, message11)
+
+      expect(subject).to permit(default_oms_admin, message12)
+      expect(subject).to_not permit(oms_admin, message12)
+
+      expect(subject).to_not permit(default_oms_admin, message13)
+      expect(subject).to_not permit(oms_admin, message13)
+
+      expect(subject).to_not permit(default_oms_admin, message14)
+      expect(subject).to_not permit(oms_admin, message14)
+    end
+  end
+
+  permissions :update? do
+    it "grants permission to project's messages" do
+      expect(subject).to permit(default_oms_admin, message1)
+      expect(subject).to permit(oms_admin, message1)
+
+      expect(subject).to permit(default_oms_admin, message2)
+      expect(subject).to_not permit(oms_admin, message2)
+
+      expect(subject).to permit(default_oms_admin, message3)
+      expect(subject).to_not permit(oms_admin, message3)
+
+      expect(subject).to permit(default_oms_admin, message4)
+      expect(subject).to_not permit(oms_admin, message4)
+
+      expect(subject).to_not permit(default_oms_admin, message5)
+      expect(subject).to_not permit(oms_admin, message5)
+
+      expect(subject).to permit(default_oms_admin, message6)
+      expect(subject).to_not permit(oms_admin, message6)
+
+      expect(subject).to_not permit(oms_admin, message7)
+      expect(subject).to_not permit(oms_admin, message7)
+    end
+
+    it "grants permission to project item's messages" do
+      expect(subject).to_not permit(default_oms_admin, message8)
+      expect(subject).to permit(oms_admin, message8)
+
+      expect(subject).to permit(default_oms_admin, message9)
+      expect(subject).to_not permit(oms_admin, message9)
+
+      expect(subject).to permit(default_oms_admin, message10)
+      expect(subject).to_not permit(oms_admin, message10)
+
+      expect(subject).to permit(default_oms_admin, message11)
+      expect(subject).to_not permit(oms_admin, message11)
+
+      expect(subject).to permit(default_oms_admin, message12)
+      expect(subject).to_not permit(oms_admin, message12)
+
+      expect(subject).to_not permit(default_oms_admin, message13)
+      expect(subject).to_not permit(oms_admin, message13)
+
+      expect(subject).to_not permit(default_oms_admin, message14)
+      expect(subject).to_not permit(oms_admin, message14)
+    end  end
+end

--- a/spec/policies/api/v1/oms/oms_policy_spec.rb
+++ b/spec/policies/api/v1/oms/oms_policy_spec.rb
@@ -2,12 +2,35 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Oms::OmsPolicy do
+RSpec.describe Api::V1::Oms::OmsPolicy, type: :policy do
   subject { described_class }
 
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
+  let(:user3) { create(:user) }
+
+  let(:oms1) { create(:oms, administrators: [user1]) }
+  let(:oms2) { create(:oms, administrators: [user2]) }
+  let(:oms3) { create(:oms, administrators: [user1, user2]) }
+
+  permissions ".scope" do
+    it "shows only administrated oms" do
+      expect(subject::Scope.new(user1, Oms).resolve).to contain_exactly(oms1, oms3)
+      expect(subject::Scope.new(user2, Oms).resolve).to contain_exactly(oms2, oms3)
+      expect(subject::Scope.new(user3, Oms).resolve).to eq([])
+    end
+  end
+
   permissions :show? do
-    it "permits OMS admin", skip: "not yet implemented" do
-      # TODO: Implement when doing authorization task
+    it "grants permission to an oms admin only" do
+      expect(subject).to permit(user1, oms1)
+      expect(subject).to_not permit(user1, oms2)
+
+      expect(subject).to permit(user2, oms2)
+      expect(subject).to_not permit(user1, oms2)
+
+      expect(subject).to_not permit(user3, oms1)
+      expect(subject).to_not permit(user3, oms2)
     end
   end
 end

--- a/spec/policies/api/v1/oms/project_item_policy_spec.rb
+++ b/spec/policies/api/v1/oms/project_item_policy_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Oms::ProjectItemPolicy, type: :policy do
+  subject { described_class }
+
+  let(:default_oms_admin) { create(:user) }
+  let(:oms_admin) { create(:user) }
+
+  let(:default_oms)  { create(:oms, default: true, administrators: [default_oms_admin]) }
+  let(:oms)  { create(:oms, administrators: [oms_admin]) }
+
+  let(:project1) { build(:project) }
+  let(:project2) { build(:project) }
+
+  let!(:project_item1) { create(:project_item, project: project1, offer: build(:offer, primary_oms: default_oms)) }
+  let!(:project_item2) { create(:project_item, project: project1, offer: build(:offer, primary_oms: oms)) }
+  let!(:project_item3) { create(:project_item, project: project2, offer: build(:offer, primary_oms: default_oms)) }
+  let!(:project_item4) { create(:project_item, project: project2, offer: build(:offer, primary_oms: nil)) }
+
+  permissions ".scope" do
+    it "shows all project items when user is a default oms admin" do
+      expect(subject::Scope.new(default_oms_admin, project1.project_items).resolve).to contain_exactly(project_item1, project_item2)
+    end
+
+    it "shows project_items which offers' primary_oms is administered by user" do
+      expect(subject::Scope.new(default_oms_admin, project2.project_items).resolve).to contain_exactly(project_item3, project_item4)
+      expect(subject::Scope.new(oms_admin, project1.project_items).resolve).to contain_exactly(project_item2)
+      expect(subject::Scope.new(oms_admin, project2.project_items).resolve).to eq([])
+    end
+  end
+
+  permissions :show? do
+    it "grants permission to project_item administrated by user and default_oms admin" do
+      expect(subject).to permit(default_oms_admin, project_item1)
+      expect(subject).to permit(default_oms_admin, project_item2)
+      expect(subject).to permit(default_oms_admin, project_item3)
+      expect(subject).to permit(default_oms_admin, project_item4)
+
+      expect(subject).to_not permit(oms_admin, project_item1)
+      expect(subject).to permit(oms_admin, project_item2)
+      expect(subject).to_not permit(oms_admin, project_item3)
+      expect(subject).to_not permit(oms_admin, project_item4)
+    end
+  end
+
+  permissions :update? do
+    it "grants permission to project_item administrated by user" do
+      expect(subject).to permit(default_oms_admin, project_item1)
+      expect(subject).to_not permit(default_oms_admin, project_item2)
+      expect(subject).to permit(default_oms_admin, project_item3)
+      expect(subject).to permit(default_oms_admin, project_item4)
+
+      expect(subject).to_not permit(oms_admin, project_item1)
+      expect(subject).to permit(oms_admin, project_item2)
+      expect(subject).to_not permit(oms_admin, project_item4)
+      expect(subject).to_not permit(oms_admin, project_item4)
+    end
+  end
+end

--- a/spec/policies/api/v1/oms/project_policy_spec.rb
+++ b/spec/policies/api/v1/oms/project_policy_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Oms::ProjectPolicy, type: :policy do
+  subject { described_class }
+
+  let(:default_oms_admin) { create(:user) }
+  let(:oms_admin) { create(:user) }
+
+  let(:default_oms) { create(:oms, default: true, administrators: [default_oms_admin]) }
+  let(:oms) { create(:oms, administrators: [oms_admin]) }
+
+  let!(:project1) { create(:project, project_items: [
+    build(:project_item, offer: build(:offer, primary_oms: oms)),
+    build(:project_item, offer: build(:offer, primary_oms: default_oms))
+  ]) }
+  let!(:project2) { create(:project, project_items: [build(:project_item, offer: build(:offer, primary_oms: nil))]) }
+  let!(:project3) { create(:project, project_items: [build(:project_item, offer: build(:offer, primary_oms: oms))]) }
+
+  permissions ".scope" do
+    it "shows all projects when user is a default oms admin" do
+      expect(subject::Scope.new(default_oms_admin, default_oms.projects).resolve)
+        .to contain_exactly(project1, project2, project3)
+
+      # Shouldn't happen because we are authorizing if a user is administrating a particular OMS beforehand
+      expect(subject::Scope.new(default_oms_admin, oms.projects).resolve).to contain_exactly(project1, project3)
+    end
+
+    it "shows projects which offers' primary_oms is administrated by user" do
+      expect(subject::Scope.new(oms_admin, oms.projects).resolve).to contain_exactly(project1, project3)
+
+      # Shouldn't happen because we are authorizing if a user is administrating a particular OMS beforehand
+      expect(subject::Scope.new(oms_admin, default_oms.projects).resolve).to contain_exactly(project1, project3)
+    end
+  end
+
+  permissions :show? do
+    it "grants permission to project administrated by user or a default oms admin" do
+      expect(subject).to permit(default_oms_admin, project1)
+      expect(subject).to permit(default_oms_admin, project2)
+      expect(subject).to permit(default_oms_admin, project3)
+
+      expect(subject).to permit(oms_admin, project1)
+      expect(subject).to_not permit(oms_admin, project2)
+      expect(subject).to permit(oms_admin, project3)
+    end
+  end
+end

--- a/spec/requests/api/v1/oms/project/project_items_controller_spec.rb
+++ b/spec/requests/api/v1/oms/project/project_items_controller_spec.rb
@@ -30,13 +30,15 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
         schema "$ref" => "project/project_item/project_item_index.json"
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
+        let(:other_oms) { create(:oms, administrators: [oms_admin]) }
         let(:project) { create(:project) }
         let!(:project_items) {
           [
-            create(:project_item, iid: 1, project: project),
-            create(:project_item, iid: 2, project: project, user_secrets: { "key": "value" }),
-            create(:project_item, iid: 3, project: project),
-            create(:project_item, iid: 4, project: project),
+            create(:project_item, offer: build(:offer, primary_oms: oms), project: project, iid: 1),
+            create(:project_item, offer: build(:offer, primary_oms: oms), project: project, iid: 2, user_secrets: { "key": "value" }),
+            create(:project_item, offer: build(:offer, primary_oms: other_oms), project: project, iid: 3),
+            create(:project_item, offer: build(:offer, primary_oms: oms), project: project, iid: 4),
+            create(:project_item, offer: build(:offer, primary_oms: oms), project: project, iid: 5)
           ]
         }
 
@@ -49,7 +51,7 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
         run_test! do |response|
           data = JSON.parse(response.body)
           expect(data).to eq({
-                               project_items: project_items[1..2].map { |pi|
+                               project_items: project_items.values_at(1, 3).map { |pi|
                                  serialized = OrderingApi::V1::ProjectItemSerializer.new(pi).as_json
                                  serialized[:user_secrets] = serialized[:user_secrets].transform_values { |_| "<OBFUSCATED>" }
                                  serialized
@@ -61,8 +63,8 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
       response 200, "project items found but were empty", document: false do
         schema "$ref" => "project/project_item/project_item_index.json"
         let(:oms_admin) { create(:user) }
-        let(:oms) { create(:oms, administrators: [oms_admin]) }
-        let(:project) { create(:project, project_items: []) }
+        let(:oms) { create(:oms, default: true, administrators: [oms_admin]) }
+        let(:project) { create(:project) }
 
         let(:oms_id) { oms.id }
         let(:p_id) { project.id }
@@ -74,18 +76,60 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
         end
       end
 
-      response 404, "project not found" do
+      response 401, "user not recognized" do
+        schema "$ref" => "error.json"
+        let(:oms_id) { 1 }
+        let(:p_id) { 1 }
+        let(:"X-User-Token") { "asdasdasd" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "You need to sign in or sign up before continuing." }.deep_stringify_keys)
+        end
+      end
+
+      response 403, "OMS not authorized" do
         schema "$ref" => "error.json"
         let(:oms_admin) { create(:user) }
-        let(:oms) { create(:oms, administrators: [oms_admin]) }
+        let(:user) { create(:user) }
+        let(:oms) { create(:oms, default: true, administrators: [oms_admin]) }
 
         let(:oms_id) { oms.id }
         let(:p_id) { 1 }
+        let(:"X-User-Token") { user.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "You are not authorized to perform this action." }.deep_stringify_keys)
+        end
+      end
+
+      response 404, "project not found" do
+        schema "$ref" => "error.json"
+        let(:oms_admin) { create(:user) }
+        let(:oms) { create(:oms, default: true, administrators: [oms_admin]) }
+
+        let(:oms_id) { oms.id }
+        let(:p_id) { 9999 }
         let(:"X-User-Token") { oms_admin.authentication_token }
 
         run_test! do |response|
           data = JSON.parse(response.body)
           expect(data).to eq({ error: "Project not found" }.deep_stringify_keys)
+        end
+      end
+
+      response 404, "OMS not found" do
+        schema "$ref" => "error.json"
+        let(:user) { create(:user) }
+
+        let(:oms_id) { 9999 }
+        let(:p_id) { 9999 }
+        let(:"X-User-Token") { user.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "OMS not found" }.deep_stringify_keys)
         end
       end
     end
@@ -106,7 +150,7 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
         let(:project) { create(:project) }
-        let(:project_item) { create(:project_item, project: project, user_secrets: { "key": "value" }) }
+        let(:project_item) { create(:project_item, project: project, user_secrets: { "key": "value" }, offer: create(:offer, primary_oms: oms)) }
 
         let(:oms_id) { oms.id }
         let(:p_id) { project.id }
@@ -123,20 +167,105 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
         end
       end
 
+      response 401, "user not recognized" do
+        schema "$ref" => "error.json"
+        let(:oms_id) { 1 }
+        let(:p_id) { 1 }
+        let(:pi_id) { 1 }
+        let(:"X-User-Token") { "asdasdasd" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "You need to sign in or sign up before continuing." }.deep_stringify_keys)
+        end
+      end
+
+      response 403, "user not authorized" do
+        schema "$ref" => "error.json"
+        let(:oms_admin) { create(:user) }
+        let(:other_oms_admin) { create(:user) }
+        let(:oms) { create(:oms, administrators: [oms_admin]) }
+        let(:other_oms) { create(:oms, administrators: [other_oms_admin]) }
+        let(:project_item1) { create(:project_item, offer: create(:offer, primary_oms: oms), iid: 1) }
+        let(:project_item2) { create(:project_item, offer: create(:offer, primary_oms: other_oms), iid: 2) }
+        let(:project) { create(:project, project_items: [project_item1, project_item2]) }
+
+        let(:oms_id) { oms.id }
+        let(:p_id) { project.id }
+        let(:pi_id) { project_item1.iid }
+        let(:"X-User-Token") { other_oms_admin.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "You are not authorized to perform this action." }.deep_stringify_keys)
+        end
+      end
+
+      response 403, "OMS not authorized" do
+        schema "$ref" => "error.json"
+        let(:oms_admin) { create(:user) }
+        let(:user) { create(:user) }
+        let(:oms) { create(:oms, default: true, administrators: [oms_admin]) }
+
+        let(:oms_id) { oms.id }
+        let(:p_id) { 1 }
+        let(:pi_id) { 1 }
+        let(:"X-User-Token") { user.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "You are not authorized to perform this action." }.deep_stringify_keys)
+        end
+      end
+
       response 404, "project item not found" do
         schema "$ref" => "error.json"
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
-        let(:project) { create(:project, project_items: []) }
+        let(:other_oms) { create(:oms, administrators: [oms_admin]) }
+        let(:project_item1) { create(:project_item, offer: create(:offer, primary_oms: oms), iid: 1) }
+        let(:project_item2) { create(:project_item, offer: create(:offer, primary_oms: other_oms), iid: 2) }
+        let(:project) { create(:project, project_items: [project_item1, project_item2]) }
 
         let(:oms_id) { oms.id }
         let(:p_id) { project.id }
-        let(:pi_id) { 1 }
+        let(:pi_id) { project_item2.iid }
         let(:"X-User-Token") { oms_admin.authentication_token }
 
         run_test! do |response|
           data = JSON.parse(response.body)
           expect(data).to eq({ error: "Project item not found" }.deep_stringify_keys)
+        end
+      end
+
+      response 404, "project not found" do
+        schema "$ref" => "error.json"
+        let(:oms_admin) { create(:user) }
+        let(:oms) { create(:oms, default: true, administrators: [oms_admin]) }
+
+        let(:oms_id) { oms.id }
+        let(:p_id) { 9999 }
+        let(:pi_id) { 9999 }
+        let(:"X-User-Token") { oms_admin.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "Project not found" }.deep_stringify_keys)
+        end
+      end
+
+      response 404, "OMS not found" do
+        schema "$ref" => "error.json"
+        let(:user) { create(:user) }
+
+        let(:oms_id) { 9999 }
+        let(:p_id) { 9999 }
+        let(:pi_id) { 9999 }
+        let(:"X-User-Token") { user.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "OMS not found" }.deep_stringify_keys)
         end
       end
     end
@@ -156,11 +285,11 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
         let(:project) { create(:project) }
         let(:project_item) { create(
           :project_item,
-          project: project,
           status_type: :created,
+          project: project,
           status: "old value",
-          user_secrets: { "other": "something" }
-        ) }
+          user_secrets: { "other": "something" },
+          offer: build(:offer, primary_oms: oms)) }
 
         let(:oms_id) { oms.id }
         let(:p_id) { project.id }
@@ -194,7 +323,7 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
 
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
-        let(:project_item) { create(:project_item, status_type: "created", status: "old value") }
+        let(:project_item) { create(:project_item, status_type: "created", status: "old value", offer: create(:offer, primary_oms: oms)) }
         let(:project) { create(:project, project_items: [project_item]) }
 
         let(:oms_id) { oms.id }
@@ -211,11 +340,11 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
         }
         run_test! do |response|
           data = JSON.parse(response.body)
-          expect(data).to eq({ error: "The property '#/status/type' value \"LOL\" did not match one of the following values: rejected, waiting_for_response, registered, in_progress, ready, closed, approved" }.deep_stringify_keys)
+          expect(data).to eq({ error: %{The property '#/status/type' value "LOL" did not match one of the following values: rejected, waiting_for_response, registered, in_progress, ready, closed, approved} }.deep_stringify_keys)
 
           project_item.reload
-          expect(project_item.status).to eq(project_item.status)
-          expect(project_item.status_type).to eq(project_item.status_type)
+          expect(project_item.status).to eq("old value")
+          expect(project_item.status_type).to eq("created")
         end
       end
 
@@ -224,7 +353,7 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
 
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
-        let(:project_item) { create(:project_item) }
+        let(:project_item) { create(:project_item, offer: build(:offer, primary_oms: oms)) }
         let(:project) { create(:project, project_items: [project_item]) }
 
         let(:oms_id) { oms.id }
@@ -250,6 +379,100 @@ RSpec.describe "OMS Project items API", swagger_doc: "v1/ordering/swagger.json" 
 
           project_item.reload
           expect(project_item.user_secrets).to eq({})
+        end
+      end
+
+      response 403, "user not authorized" do
+        schema "$ref" => "error.json"
+        let(:default_oms_admin) { create(:user) }
+        let(:default_oms) { create(:oms, default: true, administrators: [default_oms_admin]) }
+        let(:other_oms) { create(:oms) }
+        let(:project_item) { create(:project_item, status: "ready", status_type: "ready",
+                                    offer: create(:offer, primary_oms: other_oms), iid: 1) }
+        let(:project) { create(:project, project_items: [project_item]) }
+
+        let(:oms_id) { default_oms.id }
+        let(:p_id) { project.id }
+        let(:pi_id) { project_item.iid }
+        let(:"X-User-Token") { default_oms_admin.authentication_token }
+        let(:project_item_payload) { {} }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "You are not authorized to perform this action." }.deep_stringify_keys)
+
+          project_item.reload
+          expect(project_item.status).to eq("ready")
+          expect(project_item.status_type).to eq("ready")
+        end
+      end
+
+      response 403, "OMS not authorized" do
+        schema "$ref" => "error.json"
+        let(:oms_admin) { create(:user) }
+        let(:user) { create(:user) }
+        let(:oms) { create(:oms, default: true, administrators: [oms_admin]) }
+
+        let(:oms_id) { oms.id }
+        let(:p_id) { 1 }
+        let(:pi_id) { 1 }
+        let(:"X-User-Token") { user.authentication_token }
+        let(:project_item_payload) { {} }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "You are not authorized to perform this action." }.deep_stringify_keys)
+        end
+      end
+
+      response 404, "project item not found" do
+        schema "$ref" => "error.json"
+        let(:oms_admin) { create(:user) }
+        let(:oms) { create(:oms, default: true, administrators: [oms_admin]) }
+        let(:project) { create(:project, project_items: []) }
+
+        let(:oms_id) { oms.id }
+        let(:p_id) { project.id }
+        let(:pi_id) { 9999 }
+        let(:project_item_payload) { {} }
+        let(:"X-User-Token") { oms_admin.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "Project item not found" }.deep_stringify_keys)
+        end
+      end
+
+      response 404, "project not found" do
+        schema "$ref" => "error.json"
+        let(:oms_admin) { create(:user) }
+        let(:oms) { create(:oms, default: true, administrators: [oms_admin]) }
+
+        let(:oms_id) { oms.id }
+        let(:p_id) { 9999 }
+        let(:pi_id) { 9999 }
+        let(:project_item_payload) { {} }
+        let(:"X-User-Token") { oms_admin.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "Project not found" }.deep_stringify_keys)
+        end
+      end
+
+      response 404, "OMS not found" do
+        schema "$ref" => "error.json"
+        let(:user) { create(:user) }
+
+        let(:oms_id) { 9999 }
+        let(:p_id) { 9999 }
+        let(:pi_id) { 9999 }
+        let(:project_item_payload) { {} }
+        let(:"X-User-Token") { user.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "OMS not found" }.deep_stringify_keys)
         end
       end
     end

--- a/spec/requests/api/v1/oms_controller_spec.rb
+++ b/spec/requests/api/v1/oms_controller_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+require "rails_helper"
+
+
+RSpec.describe "OMS Projects API", swagger_doc: "v1/ordering/swagger.json" do
+  before(:all) do
+    Dir.chdir Rails.root.join("swagger", "v1", "ordering") # Workaround for rswag bug: https://github.com/rswag/rswag/issues/393
+  end
+
+  after(:all) do
+    Dir.chdir Rails.root # Workaround for rswag bug: https://github.com/rswag/rswag/issues/393
+  end
+
+  path "/api/v1/oms" do
+    get "lists projects" do
+      tags "OMS"
+      produces "application/json"
+      security [ authentication_token: [] ]
+
+      response 200, "OMSes found" do
+        schema "$ref" => "oms/oms_index.json"
+        let(:oms_admin) { create(:user) }
+        let!(:omses) { create_list(:oms, 2, administrators: [oms_admin]) }
+
+        let(:"X-User-Token") { oms_admin.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ OMSes: omses.map { |p| OrderingApi::V1::OmsSerializer.new(p).as_json } }.deep_stringify_keys)
+        end
+      end
+
+      response 200, "user doesn't administrate any OMSes", document: false do
+        schema "$ref" => "oms/oms_index.json"
+        let(:regular_user) { create(:user) }
+        let(:oms_admin) { create(:user) }
+        let(:oms) { create(:oms, administrators: [oms_admin]) }
+
+        let(:"X-User-Token") { regular_user.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ OMSes: [] }.deep_stringify_keys)
+        end
+      end
+
+      response 401, "user not recognized" do
+        schema "$ref" => "error.json"
+        let(:"X-User-Token") { "asdasdasd" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "You need to sign in or sign up before continuing." }.deep_stringify_keys)
+        end
+      end
+    end
+  end
+
+  path "/api/v1/oms/{oms_id}" do
+    parameter name: :oms_id, in: :path, type: :string, description: "OMS id"
+
+    get "retrieves an OMS" do
+      tags "OMS"
+      produces "application/json"
+      security [ authentication_token: [] ]
+
+      response 200, "OMS found" do
+        schema "$ref" => "oms/oms_read.json"
+        let(:oms_admin) { create(:user) }
+        let(:oms) { create(:oms, administrators: [oms_admin]) }
+
+        let(:oms_id) { oms.id }
+        let(:"X-User-Token") { oms_admin.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq(OrderingApi::V1::OmsSerializer.new(oms).as_json.deep_stringify_keys)
+        end
+      end
+
+      response 404, "OMS not found" do
+        schema "$ref" => "error.json"
+        let(:user) { create(:user) }
+
+        let(:oms_id) { 9999 }
+        let(:"X-User-Token") { user.authentication_token }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({ error: "OMS not found" }.deep_stringify_keys)
+        end
+      end
+    end
+  end
+end

--- a/swagger/v1/ordering/oms/oms_index.json
+++ b/swagger/v1/ordering/oms/oms_index.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "OMSes": {
+      "type": "array",
+      "items": {
+        "$ref": "oms_read.json"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["OMSes"]
+}

--- a/swagger/v1/ordering/oms/oms_read.json
+++ b/swagger/v1/ordering/oms/oms_read.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {"type": "integer"},
+    "name": {"type": "string"},
+    "type": {"type": "string",
+      "enum": ["global", "providers_group", "resource_dedicated"]
+    },
+    "default": {"type": "boolean"},
+    "trigger_url": {"type": "string"},
+    "custom_params": {"type": "object"}
+  },
+  "additionalProperties": false,
+  "required": ["id", "name", "type", "default"]
+}

--- a/swagger/v1/ordering/swagger.json
+++ b/swagger/v1/ordering/swagger.json
@@ -61,8 +61,38 @@
               }
             }
           },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
           "400": {
             "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "OMS not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OMS not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -147,6 +177,26 @@
               }
             }
           },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "OMS not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
           "404": {
             "description": "project item not found",
             "content": {
@@ -187,6 +237,26 @@
           },
           "400": {
             "description": "message created validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not authorized",
             "content": {
               "application/json": {
                 "schema": {
@@ -238,6 +308,54 @@
           }
         }
       ],
+      "get": {
+        "summary": "retrieves a message",
+        "tags": [
+          "Messages"
+        ],
+        "security": [
+          {
+            "authentication_token": [
+
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "message found"
+          },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "message not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          }
+        }
+      },
       "patch": {
         "summary": "updates a message",
         "tags": [
@@ -266,6 +384,36 @@
           },
           "400": {
             "description": "message update validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "message not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -350,8 +498,28 @@
               }
             }
           },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "OMS not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "project not found",
+            "description": "OMS not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -416,8 +584,28 @@
               }
             }
           },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "OMS not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "project item not found",
+            "description": "OMS not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -456,6 +644,26 @@
           },
           "400": {
             "description": "project item update validation failed wrong user secrets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "OMS not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OMS not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -532,17 +740,7 @@
             }
           },
           "401": {
-            "description": "user unrecognized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "error.json"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "oms not found",
+            "description": "user not recognized",
             "content": {
               "application/json": {
                 "schema": {
@@ -552,7 +750,17 @@
             }
           },
           "403": {
-            "description": "user not authorized",
+            "description": "OMS not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OMS not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -608,8 +816,113 @@
               }
             }
           },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "project not found",
+            "description": "OMS not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "user not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/oms": {
+      "get": {
+        "summary": "lists projects",
+        "tags": [
+          "OMS"
+        ],
+        "security": [
+          {
+            "authentication_token": [
+
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OMSes found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "oms/oms_index.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "user not recognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "error.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/oms/{oms_id}": {
+      "parameters": [
+        {
+          "name": "oms_id",
+          "in": "path",
+          "description": "OMS id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "retrieves an OMS",
+        "tags": [
+          "OMS"
+        ],
+        "security": [
+          {
+            "authentication_token": [
+
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OMS found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "oms/oms_read.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OMS not found",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Closes #1883 

- Implement Project, ProjectItem, Message and Event ordering API policies
- Add GET /api/v1/oms endpoint
- Add GET /api/v1/oms/{oms_id} endpoint
- Add GET /api/v1/oms/{oms_id}/messages/{m_id} endpoint
- Finish implementation of ordering API endpoint rswag specs
- Generate new swagger docs


How to test

Permissions should be as stated in https://docs.cyfronet.pl/pages/viewpage.action?spaceKey=FID&title=API+for+resource+orders (Access model section)

We will artificially create a following situation:
- SOMBO (default), OMS2 and OMS3 omses and their admins
- Project1 (p1) which doesn't have any project_items, but has 2 messages (message1_1 (author: user, scope: public), message1_2 (author: mediator, scope: public))
- Project2 (p2) which has 1 project_item (project_item2_1 (assigned to OMS2)) and no messages
- Project3 (p3) which has 2 project_items (project_item3_1 (assigned to OMS2), project_item3_2 (assigned to OMS3)) and 2 messages (message3_1 (author: provider, scope: public), message3_2 (author: provider, scope: user_direct))

Clear any project/project_items/messages and OMSes added previously if present.

To create this scenario run:
```
rails db:drop db:create db:migrate
rails dev:prime # includes add_sombo task
rails ordering_api:authorization_test_setup
```

Then run this to get admin tokens:
```
rails c
> User.find_by(uid: "iamasomboadmin").authentication_token
> User.find_by(uid: "oms2_admin").authentication_token
> User.find_by(uid: "oms3_admin").authentication_token
```
Copy tokens and use them as 'X-User-Token' in /api_docs/swagger (select Ordering API from the top right drop down menu)

Endpoints:
1. GET /api/v1/oms:
- as SOMBO admin I should see "SOMBO" (write down `id` from the returned json and use as `oms_id` in all of the next queries)
- as OMS2 admin I should see "OMS2" (write down `id` from the returned json and use as `oms_id` in all of the next queries)
- as OMS3 admin I should see "OMS3" (write down `id` from the returned json and use as `oms_id` in all of the next queries)

2. GET /api/v1/oms/{oms_id}
- `oms_id` = SOMBO id
  - as SOMBO admin I should see "SOMBO" and 200 status
  - as OMS2 admin I should see "You are not authorized" and 403 status
  - as OMS3 admin I should see "You are not authorized" and 403 status
- `oms_id` = OMS2 id
  - as SOMBO admin I should see "You are not authorized" and 403 status
  - as OMS2 admin I should see "OMS2" and 200 status
  - as OMS3 admin I should see "You are not authorized" and 403 status
- `oms_id` = OMS3 id
  - as SOMBO admin I should see "You are not authorized" and 403 status
  - as OMS2 admin I should see "You are not authorized" and 403 status
  - as OMS3 admin I should see "OMS3" and 200 status
  
The "unauthorized" behaviour should be present in all of the next queries when user doesn't administrate a particular OMS - please test this. I will not write down situations where "`oms_id` = SOME_OMS id" and then "as OTHER_OMS admin" as they should always result in 403 unauthorized.

3. GET  /api/v1/oms/{oms_id}/projects
- `oms_id` = SOMBO id
  - as SOMBO admin I should see ["p1, "p2", "p3"] projects (write down "id" as `p_id` for next queries)
- `oms_id` = OMS2 id
  - as OMS2 admin I should see ["p2", "p3"] projects (write down "id" as `p_id` for next queries)
-  `oms_id` = OMS3 id
  - as OMS3 admin I should see ["p3"] projects (write down "id" as `p_id` for next queries)

4. GET  /api/v1/oms/{oms_id}/projects/{p_id}
- `oms_id` = SOMBO id
  - `p_id` = p1 id
    - as SOMBO admin I should see "p1" and 200 status
  - `p_id` = p2 id
    - as SOMBO admin I should see "p2" and 200 status
  - `p_id` = p3 id
    - as SOMBO admin I should see "p3" and 200 status
- `oms_id` = OMS2 id
  - `p_id` = p1 id
    - as OMS2 admin I should see  "Project not found" and 404 status
  - `p_id` = p2 id
    - as OMS2 admin I should see "p2" and 200 status
  - `p_id` = p3 id
    - as OMS2 admin I should see "p3" and 200 status
- `oms_id` = OMS3 id
  - `p_id` = p1 id
    - as OMS3 admin I should see "Project not found" and 404 status
  - `p_id` = p2 id
    - as OMS3 admin I should see "Project not found" and 404 status
  - `p_id` = p3 id
    - as OMS3 admin I should see "p3" and 200 status
    
5. GET /api/v1/oms/{oms_id}/projects/{p_id}/project_items
- `oms_id` = SOMBO id
  - `p_id` = p1 id
    - as SOMBO admin I should see [] and 200 status
  - `p_id` = p2 id
    - as SOMBO admin I should see ["project_item2_1"] and 200 status
  - `p_id` = p3 id
    - as SOMBO admin I should see ["project_item3_1", "project_item3_2"] and 200 status
- `oms_id` = OMS2 id
  - `p_id` = p1 id
    - as OMS2 admin I should see 400 Project not found
  - `p_id` = p2 id
    - as OMS2 admin I should see ["project_item2_1"] and 200 status
  - `p_id` = p3 id
    - as OMS2 admin I should see ["project_item3_1", "project_item3_2"] and 200 status
- `oms_id` = OMS3 id
  - `p_id` = p1 id
    - as OMS3 admin I should see 400 Project not found
  - `p_id` = p2 id
    - as OMS3 admin I should see 400 Project not found
  - `p_id` = p3 id
    - as OMS3 admin I should see ["project_item3_1", "project_item3_2"] and 200 status

6. GET /api/v1/oms/{oms_id}/projects/{p_id}/project_items/{pi_id}
- `oms_id` = OMS2 id
  - `p_id` = p1 id
      - as OMS2 admin I should see 400 Project not found
  - `p_id` = p2 id
    - `pi_id` = project_item2_1
      - as OMS2 admin I should see "project_item2_1" and status 200
  - `p_id` = p3 id
    - `pi_id` = project_item3_1
      - as OMS2 admin I should see "project_item3_1" and status 200
    - `pi_id` = project_item3_2
      - as OMS2 admin I should see "project_item3_2" and status 200
- `oms_id` = OMS3 id
  - `p_id` = p1 id
      - as OMS3 admin I should see 400 Project not found
  - `p_id` = p2 id
    - `pi_id` = project_item2_1
      - as OMS3 admin I should see 400 Project not found
  - `p_id` = p3 id
    - `pi_id` = project_item3_1
      - as OMS3 admin I should see "project_item3_1" and status 200
    - `pi_id` = project_item3_2
      - as OMS3 admin I should see "project_item3_2" and status 200

7. PATCH /api/v1/oms/{oms_id}/projects/{p_id}/project_items/{pi_id}
- `oms_id` = SOMBO id
  - `p_id` = p1 id
      - there aren't any project items in p1
  - `p_id` = p2 id
    - `pi_id` = project_item2_1
      - as SOMBO admin I should NOT be able to edit "project_item2_1" and it should 403 unauthorized
  - `p_id` = p3 id
    - `pi_id` = project_item3_1
      - as SOMBO admin I should NOT be able to edit "project_item3_1" and it should 403 unauthorized
     - `pi_id` = project_item3_2
       - as SOMBO admin I should NOT be able to edit "project_item3_2" and it should 403 unauthorized
- `oms_id` = OMS2 id
  - `p_id` = p1 id
      - as OMS2 admin I should see 400 Project not found
  - `p_id` = p2 id
    - `pi_id` = project_item2_1
      - as OMS2 admin I should be able to edit "project_item2_1" and it should return updated "project_item2_1" and status 200
  - `p_id` = p3 id
    - `pi_id` = project_item3_1
      - as OMS2 admin I should be able to edit "project_item3_1" and it should return updated "project_item2_1" and status 200
     - `pi_id` = project_item3_2
       - as OMS2 admin I should not be able to edit "project_item3_2" and it should return updated "unauthoried" and status 403
- `oms_id` = OMS3 id
  - `p_id` = p1 id
      - as OMS3 admin I should see 400 Project not found
  - `p_id` = p2 id
    - `pi_id` = project_item2_1
      - as OMS3 admin I should see 400 Project not found
  - `p_id` = p3 id
    - `pi_id` = project_item3_1
       - as OMS3 admin I should not be able to edit "project_item3_1" and it should return updated "unauthoried" and status 403
    - `pi_id` = project_item3_2
      - as OMS3 admin I should be able to edit "project_item3_2" and it should return updated "project_item2_1" and status 200

8. GET /api/v1/oms/{oms_id}/messages
- `oms_id` = SOMBO id
  - `p_id` = p1 id (query param)
    - as SOMBO admin I should see ['message1_1', 'message1_2'] and status 200
  - `p_id` = p2 id (query param)
    - as SOMBO admin I should see [] and status 200
  - `p_id` = p3 id (query param)
    - as SOMBO admin I should see ['message3_1', 'message3_2'] and status 200
- `oms_id` = OMS2 id
  - `p_id` = p1 id (query param)
    - as OMS2 admin I should see [] and status 200
  - `p_id` = p2 id (query param)
    - as OMS2 admin I should see [] and status 200
  - `p_id` = p3 id (query param)
    - as OMS2 admin I should see ['message3_1', 'message3_2'] and status 200
- `oms_id` = OMS3 id
  - `p_id` = p1 id (query param)
    - as OMS3 admin I should see [] and status 200
  - `p_id` = p2 id (query param)
    - as OMS3 admin I should see [] and status 200
  - `p_id` = p3 id (query param)
    - as OMS3 admin I should see ['message3_1', 'message3_2'] and status 200
    
 9. POST /api/v1/oms/{oms_id}/messages
- `oms_id` = SOMBO id
  - `p_id` = p1 id (payload param)
    - as SOMBO admin I should be able to create message with an author_role: 'mediator'
    - as SOMBO admin I should not be able to create message with a scope: 'provider' or 'user'
  - `p_id` = p2 id  (payload param)
    - as SOMBO admin I should be able to create message with an author_role: 'mediator'
    - as SOMBO admin I should not be able to create message with a scope: 'provider' or 'user'
  - `p_id` = p3 id  (payload param)
    - as SOMBO admin I should be able to create message with an author_role: 'mediator'
    - as SOMBO admin I should not be able to create message with a scope: 'provider' or 'user'
- `oms_id` = OMS2 id
  - `p_id` = p1 id  (payload param)
    - as OMS2 admin I should not be able to create any kind of message
  - `p_id` = p2 id  (payload param)
    - as OMS2 admin I should be able to create message with author_role: 'provider' and scope in ['public', 'internal'] 
    - as OMS2 admin I should not be able to create any other kind of message
  - `p_id` = p3 id  (payload param)
    - as OMS2 admin I should be able to create message with author_role: 'provider' and scope in ['public', 'internal'] 
    - as OMS2 admin I should not be able to create any other kind of message
- `oms_id` = OMS3 id
  - `p_id` = p1 id (payload param)
    - as OMS3 admin I should not be able to create any kind of message
  - `p_id` = p2 id  (payload param)
    - as OMS3 admin I should not be able to create any kind of message
  - `p_id` = p3 id  (payload param)
    - as OMS3 admin I should be able to create message with author_role: 'provider' and scope in ['public', 'internal'] 
    - as OMS3 admin I should not be able to create any other kind of message
 
10. GET /api/v1/oms/{oms_id}/messages/{m_id}
   Every OMS should be able to see messages specified in "GET /api/v1/oms/{oms_id}/messages" - any other combination of oms_id and m_id should result in either 403 unauthorized or 404 project/messsage not found
   
11. PATCH /api/v1/oms/{oms_id}/messages/{m_id}
- `oms_id` = SOMBO id
  - `m_id` = message1_1
    - as a SOMBO admin I should not be able not edit message, and get 403 unauthorized
  - `m_id` = message1_2
    - as a SOMBO admin I should be able to edit message and it should return updated message along with 200 status
  - `m_id` = message3_1
    - as a SOMBO admin I should not able to edit message and get 403 unauthorized
  - `m_id` = message3_2
    - as a SOMBO admin I should not able to edit message and get 403 unauthorized
- `oms_id` = OMS2 id
  - `m_id` = message1_1
    - as a OMS2 admin I should get 404 message not found
  - `m_id` = message1_2
    - as a OMS2 admin I I should get 404 message not found
  - `m_id` = message3_1
    - as a OMS2 admin I should should be able to edit message and it should return updated message along with 200 status 
  - `m_id` = message3_2
    - as a OMS2 admin I should not able to edit message and get 403 unauthorized
- `oms_id` = OMS3 id
  - `m_id` = message1_1
    - as a OMS3 admin I should get 404 message not found
  - `m_id` = message1_2
    - as a OMS3 admin I I should get 404 message not found
  - `m_id` = message3_1
    - as a OMS3 admin I should should be able to edit message and it should return updated message along with 200 status 
  - `m_id` = message3_2
    - as a OMS3 admin I should not able to edit message and get 403 unauthorized

12. GET /api/v1/oms/{oms_id}/events
- `oms_id` = SOMBO id
  - as a SOMBO admin I should see events connected to: p1, p2, p3, project_item2_1, project_item3_1, project_item3_2, message1_1, message1_2, message3_1, message3_2
- `oms_id` = OMS2 id
  - as a OMS2 admin I should see events connected to: p2, p3, project_item2_1, project_item3_1, project_item3_2, message3_1, message3_2
- `oms_id` = OMS3 id
  - as a OMS3 admin I should see events connected to: p3, project_item3_1, project_item3_2, message3_1, message3_2