### PR TITLE
Fix ordering_api:add_sombo task

### DIFF
--- a/lib/ordering_api/add_sombo.rb
+++ b/lib/ordering_api/add_sombo.rb
@@ -18,9 +18,11 @@ module OrderingApi
         oms.administrators = [sombo_admin]
       end
 
-      Offer.all.each do |o|
-        if o.current_oms == sombo && o.service.order_target.present?
-          o.update(oms_params: { order_target: o.service.order_target })
+      Service.all.each do |s|
+        s.offers.each do |o|
+          if o.current_oms == sombo && s.order_target.present?
+            o.update(oms_params: { order_target: s.order_target })
+          end
         end
       end
     end

--- a/spec/lib/ordering_api/add_sombo_spec.rb
+++ b/spec/lib/ordering_api/add_sombo_spec.rb
@@ -14,7 +14,7 @@ describe OrderingApi::AddSombo do
     expect(Oms.first.administrators.first.first_name).to eq("SOMBO admin")
   end
 
-  it "doesnt create SOMBO OMS and SOMBO admin if they exist" do
+  it "doesn't create SOMBO OMS and SOMBO admin if they exist" do
     admin = create(:user, first_name: "SOMBO admin", last_name: "SOMBO admin", email: "sombo@sombo.com", uid: "iamasomboadmin")
     create(:oms, name: "SOMBO", type: :global, default: true, custom_params: { order_target: { mandatory: false } }, administrators: [admin])
     described_class.new.call
@@ -26,7 +26,7 @@ describe OrderingApi::AddSombo do
     expect(Oms.first.administrators.first.first_name).to eq("SOMBO admin")
   end
 
-  it "if updates offers' oms_params properly" do
+  it "updates offers' oms_params properly" do
     offer1 = create(:offer, primary_oms: nil, service: create(:service, order_target: "admin@admin.pl"))
     service = create(:service, order_target: "data@data.pl")
     offer2 = create(:offer, primary_oms: nil, service: service)


### PR DESCRIPTION
Previous implementation assumed that every offer has a service.
That was was not the case in one of the testing environments, so the
`offer.service.order_target` part failed. Right now we are updating
`oms_params` only in offers which indeed have a service.