### PR TITLE
Create serialize_db_to_file task

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,4 +347,10 @@ It needs the MP data to learn. Run:
 ```
 ./bin/rails recommender:serialize_db
 ```
-...to send the database dump to the recommender system 
+...to send the database dump to the recommender system.
+
+If you want to save database dump to a json file, use:
+
+```
+./bin/rails recommender:serialize_db_to_file
+```

--- a/lib/tasks/recommender.rake
+++ b/lib/tasks/recommender.rake
@@ -6,7 +6,9 @@ require "pp"
 namespace :recommender do
   desc "serialize database for recommender system"
   task serialize_db: :environment do
+    puts "Generating database dump..."
     serialized_db = Recommender::SerializeDb.new.call.to_json
+    puts "Database dump generated successfully!"
 
     begin
       url = Mp::Application.config.recommender_host + "/database_dumps"
@@ -16,7 +18,7 @@ namespace :recommender do
                               serialized_db
 
       if response.code == 204
-        puts "Database dump sent successfully..."
+        puts "Database dump sent successfully!"
       elsif response.code == 400
         puts "Recommender system validation error, details:"
         pp response.body["errors"]
@@ -27,6 +29,21 @@ namespace :recommender do
       File.open(path, "w") do |f|
         f.write(serialized_db)
       end
+      puts "Database dump saved to file successfully!"
     end
+  end
+
+  task serialize_db_to_file: :environment do
+    puts "Generating database dump..."
+    serialized_db = Recommender::SerializeDb.new.call.to_json
+    puts "Database dump generated successfully!"
+
+    path = Rails.root.join("data.json")
+
+    puts "Saving database dump (to #{path})..."
+    File.open(path, "w") do |f|
+      f.write(serialized_db)
+    end
+    puts "Database dump saved successfully!"
   end
 end


### PR DESCRIPTION
Created recommender:serialize_db_to_file task. It allows to save DB dump into json file. Closes #1993 