### PR TITLE
[#1983] Execute OMS triggers on Event creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ group :development do
   gem "listen", ">= 3.0.5", "< 3.2"
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
+  gem "spring-commands-rspec"
   gem "rubocop-rails_config"
   gem "overcommit", require: false
   gem "haml_lint", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -554,6 +554,8 @@ GEM
       simple-random (>= 0.9.3)
       sinatra (>= 1.2.6)
     spring (2.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -709,6 +711,7 @@ DEPENDENCIES
   simple_token_authentication
   split
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   stomp
   turbolinks (~> 5)

--- a/app/jobs/oms/call_trigger_job.rb
+++ b/app/jobs/oms/call_trigger_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Oms::CallTriggerJob < ApplicationJob
+  queue_as :orders
+
+  def perform(oms)
+    Oms::CallTrigger.new(oms).call
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -48,6 +48,10 @@ class Message < ApplicationRecord
     Set.new(%i[message])
   end
 
+  def eventable_omses
+    messageable.eventable_omses
+  end
+
   private
     def set_edited!
       self.edited = true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -94,6 +94,14 @@ class Project < ApplicationRecord
     Set.new()
   end
 
+  def eventable_omses
+    project_items
+      .map(&:eventable_omses)
+      .map { |omses| omses.index_by(&:id) } # map each to { <id>: oms }
+      .reduce({}) { |memo, oms_h| memo.merge(oms_h) } # merge, removing duplicates
+      .values
+  end
+
   private
     def require_jira_issue?
       jira_active? || jira_deleted?

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -83,6 +83,10 @@ class ProjectItem < ApplicationRecord
     Set.new(%i[status status_type user_secrets])
   end
 
+  def eventable_omses
+    offer.primary_oms.present? ? [offer.primary_oms] : []
+  end
+
   def to_s
     "\"#{project.name}##{id}\""
   end

--- a/app/services/event/call_triggers.rb
+++ b/app/services/event/call_triggers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Event::CallTriggers
+  def initialize(event)
+    @event = event
+  end
+
+  def call
+    @event.omses.each do |oms|
+      Oms::CallTriggerJob.perform_later(oms)
+    end
+  end
+end

--- a/app/services/oms/call_trigger.rb
+++ b/app/services/oms/call_trigger.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Oms::CallTrigger
+  def initialize(oms)
+    @oms = oms
+  end
+
+  def call
+    Unirest.post @oms.trigger_url if @oms.trigger_url.present?
+  end
+end

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/lib/ordering_api/triggers_test_setup.rb
+++ b/lib/ordering_api/triggers_test_setup.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class OrderingApi::TriggersTestSetup
+  def initialize; end
+
+  def call
+    oms_admin = User.find_by!(uid: "iamasomboadmin")
+
+    oms1 = Oms.find_by!(default: true)
+    oms1.update!(trigger_url: "http://localhost:1080/oms1")
+    oms2 = Oms.create!(name: "OMS2", type: "global", administrators: [oms_admin], trigger_url: "http://localhost:1080/oms2")
+    oms3 = Oms.create!(name: "OMS3", type: "global", administrators: [oms_admin], trigger_url: "http://localhost:1080/oms3")
+
+    provider = Provider.create!(name: "provider")
+    service1 = Service.create!(name: "s1", description: "asd", tagline: "asd", status: "published", providers: [provider],
+                         resource_organisation: provider, scientific_domains: [ScientificDomain.first], geographical_availabilities: ["PL"])
+    service2 = Service.create!(name: "s2", description: "asd", tagline: "asd", status: "published", providers: [provider],
+                         resource_organisation: provider, scientific_domains: [ScientificDomain.first], geographical_availabilities: ["PL"])
+    Offer.create!(name: "s1_o", order_type: "open_access", description: "asd", service: service1,
+                  status: "published", primary_oms: oms2)
+    Offer.create!(name: "s2_o", order_type: "open_access", description: "asd", service: service2,
+                  status: "published", primary_oms: oms3)
+
+    # The test scenario:
+    # Create project p1 (triggers: OMS1)
+    # Write a message in p1 (triggers: OMS1)
+    # Create project_item pi1_1 from s1_o (triggers: OMS1, OMS2)
+    # Write a message in pi1_1 (triggers: OMS1, OMS2)
+    # Write a message in p1 (triggers: OMS1, OMS2)
+    # Create project_item pi1_2 from s2_o (triggers: OMS1, OMS3)
+    # Write a message in pi1_2 (triggers: OMS1, OMS3)
+    # Write a message in p1 (triggers: OMS1, OMS2, OMS3)
+  end
+end

--- a/lib/tasks/ordering_api.rake
+++ b/lib/tasks/ordering_api.rake
@@ -10,4 +10,8 @@ namespace :ordering_api do
   task authorization_test_setup: :environment do
     OrderingApi::AuthorizationTestSetup.new.call
   end
+
+  task triggers_test_setup: :environment do
+    OrderingApi::TriggersTestSetup.new.call
+  end
 end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :event do
+    action { "create" }
+    eventable { build(:project_item) }
+  end
+end

--- a/spec/jobs/oms/call_trigger_job_spec.rb
+++ b/spec/jobs/oms/call_trigger_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Oms::CallTriggerJob, type: :job do
+  let(:call_trigger) { instance_double(Oms::CallTrigger) }
+  let(:oms) { build(:oms) }
+
+  before do
+    allow(Oms::CallTrigger).to receive(:new).with(oms).and_return(call_trigger)
+    allow(call_trigger).to receive(:call)
+  end
+
+  it "triggers service" do
+    described_class.perform_now(oms)
+    expect(call_trigger).to have_received(:call)
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -98,6 +98,16 @@ RSpec.describe Message do
       end
     end
 
+    describe "#eventable_omses" do
+      let(:message) { build(:message) }
+
+      it "delegates to the messageable" do
+        ret = double
+        expect(message.messageable).to receive(:eventable_omses).and_return(ret)
+        expect(message.eventable_omses).to eq(ret)
+      end
+    end
+
     it "should create an event on create" do
       project = create(:project)
       message_1 = create(:message, messageable: project)

--- a/spec/models/project_item_spec.rb
+++ b/spec/models/project_item_spec.rb
@@ -87,6 +87,21 @@ RSpec.describe ProjectItem do
       end
     end
 
+    describe "#eventable_omses" do
+      it "returns an empty list" do
+        expect(subject.eventable_omses).to eq([])
+      end
+
+      context "with offer.primary_oms set" do
+        subject { create(:project_item, offer: create(:offer, primary_oms: primary_oms)) }
+        let(:primary_oms) { create(:oms) }
+
+        it "returns a list with that OMS" do
+          expect(subject.eventable_omses).to eq([primary_oms])
+        end
+      end
+    end
+
     it "should create an event on create" do
       project = create(:project)
       project_item = create(:project_item, project: project)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -127,6 +127,27 @@ RSpec.describe Project do
       end
     end
 
+    describe "#eventable_omses" do
+      it "handles empty project" do
+        expect(subject.eventable_omses).to eq([])
+      end
+
+      context "with project_items with overlapping primary_oms" do
+        before do
+          @oms1 = create(:oms)
+          @oms2 = create(:oms)
+          create(:project_item, project: subject, offer: create(:offer, primary_oms: @oms1))
+          create(:project_item, project: subject, offer: create(:offer, primary_oms: @oms2))
+          create(:project_item, project: subject, offer: create(:offer, primary_oms: @oms2))
+          subject.reload
+        end
+
+        it "merges the OMSes" do
+          expect(subject.eventable_omses).to contain_exactly(@oms1, @oms2)
+        end
+      end
+    end
+
     it "should create an event on create" do
       project = create(:project)
       expect(Event.count).to eq(1)

--- a/spec/serializers/ordering_api/v1/event_serializer_spec.rb
+++ b/spec/serializers/ordering_api/v1/event_serializer_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe OrderingApi::V1::EventSerializer do
   let(:project_item) { create(:project_item, project: project) }
 
   it "properly serializes a project_item event" do
-    event = Event.create(action: :update,
-                         eventable: project_item,
-                         updates: [
-                           { field: "name", before: "zxc", after: "qwe" },
-                           { field: "user_secrets", before: "123", after: "456" },
-                         ])
+    event = create(:event,
+                   action: :update,
+                   eventable: project_item,
+                   updates: [
+                     { field: "name", before: "zxc", after: "qwe" },
+                     { field: "user_secrets", before: "123", after: "456" },
+                   ])
 
     serialized = described_class.new(event).as_json
     expected = {
@@ -39,7 +40,7 @@ RSpec.describe OrderingApi::V1::EventSerializer do
   end
 
   it "it properly serializes a project event" do
-    event = Event.create(action: :create, eventable: project)
+    event = create(:event, action: :create, eventable: project)
 
     serialized = described_class.new(event).as_json
     expected = {

--- a/spec/services/event/call_triggers_spec.rb
+++ b/spec/services/event/call_triggers_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Event::CallTriggers do
+  before do
+    allow(Oms::CallTriggerJob).to receive(:perform_later)
+  end
+
+  it "executes for each returned OMS" do
+    oms1 = double
+    oms2 = double
+
+    described_class.new(double(omses: [oms1, oms2])).call
+
+    expect(Oms::CallTriggerJob).to have_received(:perform_later).with(oms1)
+    expect(Oms::CallTriggerJob).to have_received(:perform_later).with(oms2)
+  end
+
+  it "doesn't execute if no OMSes returned" do
+    described_class.new(double(omses: [])).call
+
+    expect(Oms::CallTriggerJob).not_to have_received(:perform_later)
+  end
+end

--- a/spec/services/oms/call_trigger_spec.rb
+++ b/spec/services/oms/call_trigger_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Oms::CallTrigger do
+  it "doesn't execute if trigger_url.blank?" do
+    allow(Unirest).to receive(:post)
+
+    described_class.new(build(:oms, trigger_url: "")).call
+
+    expect(Unirest).not_to have_received(:post)
+  end
+
+  it "executes if trigger_url.present?" do
+    trigger_url = "url_value"
+    allow(Unirest).to receive(:post)
+
+    described_class.new(build(:oms, trigger_url: trigger_url)).call
+
+    expect(Unirest).to have_received(:post).with(trigger_url)
+  end
+end


### PR DESCRIPTION
Triggers are to be run after an Event creation, so on the Event's
after_commit hook I execute Event::CallTriggers.
In turn for each event.omses it enqueues an Oms::CallTriggerJob, which
then calls Oms::CallTrigger service, executing the actual HTTP request.

The method event.omses returns all the OMSes authorized for an event,
adding the default_oms if necessary.
On the other hand, event.omses calls eventable.eventable_omses to get
the list of authorized OMSes for an eventable.
Each type of eventable implements it:
- project_item: just returns its offer primary_oms,
- project: gathers eventable_omses from its project_items and returns a
           compiled, deduplicated list,
- message: delegates to its messageable.eventable_omses (all
           messageable are also eventable).

## Other changes

### Add spring-commands-rspec

It allows to more efficiently run tests in Auto-Test mode, eg. in
RubyMine.

# How to test

The main output from this PR is that triggers are called on Event creation.
It would be easiest to test locally, where you can set-up a local mock server to log your requests.

I suggest using mockserver: it can be run with `docker run --rm -p 1080:1080 mockserver/mockserver`.
Then, navigate to http://localhost:1080/mockserver/dashboard, where you'll see the mockserver dashboard and all requests it receives.
Try it out by running `curl -X POST http://localhost:1080/test/something` from the cmd. The request should appear in the "Received Requests" panel, it will return 404 but it doesn't matter for the trigger execution.

To prepare and run a local instance of MP, run:
```
rails db:drop db:create db:migrate
rails dev:prime
rails ordering_api:triggers_test_setup
bin/server
```
The server should now be available under http://localhost:5000/.

Then, as a user:
 - Create project p1 (triggers: OMS1)
 - Write a message in p1 (triggers: OMS1)
 - Create project_item pi1_1 from s1_o (triggers: OMS1, OMS2, twice, because of the meta-stable state transition)
 - Write a message in pi1_1 (triggers: OMS1, OMS2)
 - Write a message in p1 (triggers: OMS1, OMS2)
 - Create project_item pi1_2 from s2_o (triggers: OMS1, OMS3, twice, because of the meta-stable state transition)
 - Write a message in pi1_2 (triggers: OMS1, OMS3)
 - Write a message in p1 (triggers: OMS1, OMS2, OMS3)

-----------------------

Closes: #1983.