### PR TITLE
Improve Offerable logic and use it in OnStatusTypeUpdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Resource Organisation field is required for creating a resource (@kmarszalek)
+- Mail delivery for orderable offers (@jswk)
 
 ## [3.11.0] 2021-04-21
 

--- a/app/components/services/inline_order_url_component.rb
+++ b/app/components/services/inline_order_url_component.rb
@@ -18,7 +18,7 @@ class Services::InlineOrderUrlComponent < ApplicationComponent
   end
 
   def link_name
-    if @offerable.external
+    if @offerable.external?
       _("Go to the order website")
     else
       _("Go to the resource")
@@ -26,6 +26,6 @@ class Services::InlineOrderUrlComponent < ApplicationComponent
   end
 
   def render?
-    !url.blank? && (!@offerable.order_required? || @offerable.external)
+    !url.blank? && !@offerable.orderable?
   end
 end

--- a/app/helpers/project_items_helper.rb
+++ b/app/helpers/project_items_helper.rb
@@ -18,7 +18,7 @@ module ProjectItemsHelper
   end
 
   def webpage(project_item)
-    if project_item.external
+    if project_item.external?
       project_item.order_url
     else
       project_item.webpage

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -95,7 +95,7 @@ module ServiceHelper
   end
 
   def map_view_to_order_type(service_or_offer)
-    if service_or_offer.external
+    if service_or_offer.external?
       "external"
     else
       service_or_offer.order_type

--- a/app/mailers/project_item_mailer.rb
+++ b/app/mailers/project_item_mailer.rb
@@ -57,7 +57,7 @@ class ProjectItemMailer < ApplicationMailer
     load_data(project_item)
 
     mail(to: @user.email,
-         subject: "Status of your service access request in the EOSC Portal Marketplace has changed to Closed",
+         subject: "Status of your service access request in the EOSC Portal Marketplace has changed to CLOSED",
          template_name: "closed")
   end
 

--- a/app/models/concerns/offerable.rb
+++ b/app/models/concerns/offerable.rb
@@ -15,20 +15,17 @@ module Offerable
     validates :name, presence: true
     validates :description, presence: true
 
-    def external
-      order_required? && !internal && order_url.present?
-    end
-
-    def open_access?
-      order_type == "open_access" || order_type == "fully_open_access"
-    end
-
-    def order_required?
-      order_type == "order_required"
+    def external?
+      order_required? && !effective_internal?
     end
 
     def orderable?
-      order_required? && (internal || !external)
+      order_required? && effective_internal?
     end
+
+    private
+      def effective_internal?
+        internal || order_url.blank?
+      end
   end
 end

--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -262,10 +262,10 @@ private
     end
   end
 
-  def map_to_jira_order_type(object)
-    if object.external
+  def map_to_jira_order_type(project_item)
+    if project_item.external?
       "external"
-    elsif object.order_type == "order_required"
+    elsif project_item.order_type == "order_required"
       "orderable"
     else
       "open_access"

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -226,12 +226,8 @@ class Service < ApplicationRecord
     resource_organisation.name
   end
 
-  def external
-    order_type == "order_required" && order_url.present?
-  end
-
-  def orderable?
-    order_type == "order_required" && order_url.blank?
+  def external?
+    order_required? && order_url.present?
   end
 
   def providers?
@@ -253,10 +249,6 @@ class Service < ApplicationRecord
       array_fields.each do |field|
         send(field).present? ? send(:"#{field}=", send(field).reject(&:blank?)) : send(:"#{field}=", [])
       end
-    end
-
-    def open_access_or_external?
-      open_access? || external
     end
 
     def main_category_missing?

--- a/app/services/project_item/ready.rb
+++ b/app/services/project_item/ready.rb
@@ -53,10 +53,6 @@ class ProjectItem::Ready
       @project_item.new_status(status: "ready", status_type: :ready)
     end
 
-    def activate_message
-      service.activate_message || "Your service request is ready"
-    end
-
     def enqueue_rate_service!
       ProjectItemMailer.activate_message(@project_item, @service).deliver_later if service.activate_message.present?
       ProjectItemMailer.rate_service(@project_item).deliver_later(wait_until: RATE_AFTER_PERIOD.from_now)

--- a/spec/javascript/offer_spec.js
+++ b/spec/javascript/offer_spec.js
@@ -21,7 +21,7 @@ describe("OfferController", () => {
     //     '<option value="open_access">open_access</option>' +
     //     '<option value="external">external</option>' +
     //     '</select>' +
-    //     '<input class="form-check-input is-valid boolean optional" data-target="offer.external"' +
+    //     '<input class="form-check-input is-valid boolean optional" data-target="offer.external?"' +
     //     'data-action="change->offer#showWebpage" type="checkbox"' +
     //     'value="1" name="offer[external]" id="offer_external">' +
     //     '<div id="result" data-target="offer.webpage" class="hidden-fields"> </div>' +

--- a/spec/mailers/project_item_spec.rb
+++ b/spec/mailers/project_item_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ProjectItemMailer, type: :mailer do
 
       expect(mail.subject)
           .to match("Status of your service access request in the EOSC Portal Marketplace " \
-                    "has changed to Closed")
+                    "has changed to CLOSED")
       expect(encoded_body).to match(/has been closed/)
       expect(encoded_body).to match(/#{project_service_conversation_url(project, project_item)}/)
       expect(mail.to).to contain_exactly(user.email)

--- a/spec/services/project_item/on_status_type_updated_spec.rb
+++ b/spec/services/project_item/on_status_type_updated_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectItem::OnStatusTypeUpdated do
+  let(:service) { create(:service, order_url: "http://not.empty") }
+  let(:offer) { create(:offer, service: service) }
+
+  context "for orderable? project_item" do
+    let(:project_item) { build(:project_item, offer: offer, order_type: :order_required, order_url: "") }
+
+    it "sends email on :waiting_for_response" do
+      expect {
+        project_item.update!(status_type: :waiting_for_response)
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(ActionMailer::Base.deliveries.last.subject).to eq("Status of your service access request in the EOSC Portal Marketplace has changed to WAITING FOR RESPONSE")
+    end
+
+    it "sends email on :approved" do
+      expect {
+        project_item.update!(status_type: :approved)
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(ActionMailer::Base.deliveries.last.subject).to eq("Status of your service access request in the EOSC Portal Marketplace has changed to APPROVED")
+    end
+
+    it "sends email on :ready" do
+      expect {
+        project_item.update!(status_type: :ready)
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(ActionMailer::Base.deliveries.last.subject).to eq("Status of your service access request in the EOSC Portal Marketplace has changed to READY TO USE")
+    end
+
+    it "sends email on :rejected" do
+      expect {
+        project_item.update!(status_type: :rejected)
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(ActionMailer::Base.deliveries.last.subject).to eq("Status of your service access request in the EOSC Portal Marketplace has changed to REJECTED")
+    end
+
+    it "sends email on :closed" do
+      expect {
+        project_item.update!(status_type: :closed)
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(ActionMailer::Base.deliveries.last.subject).to eq("Status of your service access request in the EOSC Portal Marketplace has changed to CLOSED")
+    end
+
+    context "for aod?" do
+      before do
+        allow(project_item.service).to receive(:aod?).and_return(true)
+      end
+
+      it "sends email on :ready" do
+        expect {
+          project_item.update!(status_type: :ready)
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+        expect(ActionMailer::Base.deliveries.last.subject).to eq("EGI Applications on Demand service approved")
+      end
+
+      context "for voucherable?" do
+        before do
+          allow(project_item.offer).to receive(:voucherable?).and_return(true)
+        end
+
+        it "sends email on :ready" do
+          expect {
+            project_item.update!(status_type: :ready)
+          }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+          expect(ActionMailer::Base.deliveries.last.subject).to eq("Elastic Cloud Compute Cluster (EC3) service with voucher approved")
+        end
+
+        it "sends email on :rejected" do
+          expect {
+            project_item.update!(status_type: :rejected)
+          }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+          expect(ActionMailer::Base.deliveries.last.subject).to eq("Elastic Cloud Compute Cluster (EC3) service with voucher rejected")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/project_item/ready_spec.rb
+++ b/spec/services/project_item/ready_spec.rb
@@ -61,9 +61,12 @@ RSpec.describe ProjectItem::Ready do
       project_item.new_status(status: "custom_created", status_type: :created)
 
       expect { described_class.new(project_item).call }.
-          to change { ActionMailer::Base.deliveries.count }.by(2)
+          to change { ActionMailer::Base.deliveries.count }.by(3)
 
-      expect(ActionMailer::Base.deliveries[-2].subject).to start_with("[EOSC marketplace]")
+      expect(ActionMailer::Base.deliveries[-3].subject)
+        .to eq("Status of your service access request in the EOSC Portal Marketplace has changed to READY TO USE")
+      expect(ActionMailer::Base.deliveries[-2].subject)
+        .to eq("[EOSC marketplace] #{service.name} is ready - usage instructions")
       expect(ActionMailer::Base.deliveries.last.subject).to eq("EOSC Portal - Rate your service")
     end
 
@@ -75,8 +78,10 @@ RSpec.describe ProjectItem::Ready do
       project_item.new_status(status: "custom_created", status_type: :created)
 
       expect { described_class.new(project_item).call }.
-          to change { ActionMailer::Base.deliveries.count }.by(1)
+          to change { ActionMailer::Base.deliveries.count }.by(2)
 
+      expect(ActionMailer::Base.deliveries[-2].subject)
+        .to eq("Status of your service access request in the EOSC Portal Marketplace has changed to READY TO USE")
       expect(ActionMailer::Base.deliveries.last.subject).to eq("EOSC Portal - Rate your service")
     end
 


### PR DESCRIPTION
In conversation with @Marcelinna we decided that improving on what is in this PR is something out of scope of #2002 (#1941) but worth doing anyway, as currently hardly any emails are sent for project_item changes (i.e. most mails are only sent when `service.order_url.blank?`, and it's mostly populated (at least on PR DB) and it's populated for AoD services too, so no emails for voucherable are sent **AT ALL**).

----------------------------

The legacy Jira adapter email sending logic was based on
service.external, which was in some place in project's history migrated
from service to offerable (i.e. offer and project_item).
This caused an inconsitency between mailer and ordering wizard behaviour
(i.e. the mailer hardly sent any mails).

To correct this, switch the ProjectItem::OnStatusTypeUpdated to the
offerable methods.
Also, refactor the current code around offerable, simplifying the
expressions used to enforce the existing logic and prune some unused
methods.

--------------------------

What are your thoughts on this @bwilk? I reckon that @goreck888, you also were correcting this logic recently, so it may be worth a look by you as well.

---------------------------

# How to test

API-key: `W8jzMHDeahxT__rmVGdZ`
oms_id: `1`

Below are services/offers to go through and verify emails are sent.
For each service disregard the values in parens (it's for @jswk not to go crazy).
For each service, as an ordinary user go and order an offer from it (for voucherable don't provide a voucher).
Then set the status_type of such project_item through API to values in list and see if the emails appear, for example for DEEP, set the status_type to "ready", and then you should receive the mail with content [from](https://github.com/cyfronet-fid/marketplace/blob/improve-offerable-and-project-item-mailer-logic/app/views/project_item_mailer/ready_to_use.html.haml).

To set the status_type of project_item: `PATCH /projects/{project_id}/project_item/{project_item_id}` with payload `{"status":{"value": "whatever", "type": "<status_type>"}}`.

DEEP training facility: (order_type=order_required, order_url="")
 - waiting_for_response: :waiting_for_response
 - approved: :approved
 - ready: :ready_to_use
 - rejected: :rejected
 - closed: :closed

100: (order_type=order_required, order_url!="")
 - waiting_for_response: :waiting_for_response
 - approved: :approved
 - ready: :ready_to_use
 - rejected: :rejected
 - closed: :closed

EC3 non-voucherable offer: (order_type=order_required, order_url!="", aod, non-voucherable)
 - waiting_for_response: :waiting_for_response
 - approved: :approved
 - ready: :aod_accepted
 - rejected: :rejected
 - closed: :closed

EC3 voucherable offer: (order_type=order_required, order_url!="", aod, voucherable)
 - waiting_for_response: :waiting_for_response
 - approved: :approved
 - ready: :aod_voucher_accepted
 - rejected: :aod_voucher_rejected
 - closed: :closed


## How to prepare PR instance

```ruby
OrderingApi::AddSombo.new.call
Oms.first.id
User.find_by(uid: "iamasomboadmin").authentication_token
```