### PR TITLE
[#1952] Fix validation of min max values in multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Change error message at order summary to general - better UX (@danielkryska)
 - Mail delivery for orderable offers (@jswk)
 - Editorial rights for providers are consistent with established editing policy (@kmarszalek)
+- Validation of multiselect parameter configuration in offers management (@goreck888)
 
 ## [3.11.1] 2021-05-11
 

--- a/app/models/parameter/multiselect.rb
+++ b/app/models/parameter/multiselect.rb
@@ -6,14 +6,14 @@ class Parameter::Multiselect < Parameter
 
   attribute :unit, :string
 
-  validates :min, numericality: { less_than_or_equal_to: ->(p) { p.values&.length || 0 } }
-  validates :max, numericality: { less_than_or_equal_to: ->(p) { p.values&.length || 0 } }
+  validates :min, numericality: { greater_than: 0,  less_than_or_equal_to: ->(p) { p.values&.length || 1 } }
+  validates :max, numericality: { greater_than: 0, less_than_or_equal_to: ->(p) { p.values&.length || 1 } }
   validate :duplicates, if: :values
 
   def dump
     ActiveSupport::HashWithIndifferentAccess.new(
       id: id, type: type, label: name, description: hint,
-      config: { values: cast(values), minItems: (min || 0), maxItems: (max || values.length) },
+      config: { values: cast(values), minItems: (min || 1), maxItems: (max || values.length) },
       value_type: value_type, unit: unit)
   end
 

--- a/app/views/parameters/template/_multiselect.html.haml
+++ b/app/views/parameters/template/_multiselect.html.haml
@@ -6,7 +6,7 @@
     = f.input :unit
 .row
   .col
-    = f.input :min
+    = f.input :min, label: "Minimum items to choose"
   .col
-    = f.input :max
+    = f.input :max, label: "Maximum items to choose"
 

--- a/spec/features/backoffice/parameters_spec.rb
+++ b/spec/features/backoffice/parameters_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Parameters in backoffice" do
+  include OmniauthHelper
+
+  context "As a service portolio manager" do
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
+    let(:service) { create(:service, offers: [create(:offer)]) }
+
+    before { checkin_sign_in_as(user) }
+
+    scenario "I cannot add invalid multiselect parameter", js: true do
+      visit edit_backoffice_service_offer_path(service, service.offers.first)
+
+      find("li", text: "Multiselect").click
+      find("#attributes-list-button").first("svg").click
+
+      within("div.card-text") do
+        fill_in "Name", with: "new multiselect parameter"
+        fill_in "Hint", with: "test"
+        fill_in "Unit", with: "days"
+        select "string", from: "Value type"
+        fill_in "Min", with: 0
+        fill_in "Max", with: 5
+      end
+
+      click_on "Update Offer"
+
+      expect(page).to have_text("Values can't be blank")
+      expect(page).to have_text("Min must be greater than 0")
+      expect(page).to have_text("Max must be less than or equal to 0")
+    end
+
+    scenario "I cannot set min < 1 and max values greater than values size", js: true do
+      offer = service.offers.first
+      offer.update(parameters: [build(:multiselect_parameter)])
+
+      visit edit_backoffice_service_offer_path(service, offer)
+
+      within("div.card-text") do
+        fill_in "Name", with: "new multiselect parameter"
+        fill_in "Hint", with: "test"
+        fill_in "Unit", with: "days"
+        select "string", from: "Value type"
+        fill_in "Min", with: 0
+        fill_in "Max", with: 5
+      end
+
+      click_on "Update Offer"
+
+      expect(page).to have_text("Min must be greater than 0")
+      expect(page).to have_text("Max must be less than or equal to 4")
+    end
+  end
+end


### PR DESCRIPTION
- Change minimum value of selected
items to default 1 instead of 0
- Add validation for min < max

Fixes #1952