### PR TITLE
[#2014] Obfuscate user_direct message content

### DIFF
--- a/app/controllers/api/v1/oms/messages_controller.rb
+++ b/app/controllers/api/v1/oms/messages_controller.rb
@@ -35,7 +35,7 @@ class Api::V1::Oms::MessagesController < Api::V1::Oms::ApiController
     authorize message
 
     if message.save
-      render json: OrderingApi::V1::MessageSerializer.new(message).as_json, status: 201
+      render json: OrderingApi::V1::MessageSerializer.new(message, keep_content?: true).as_json, status: 201
     else
       render json: { error: message.errors.messages }, status: 400
     end
@@ -44,7 +44,7 @@ class Api::V1::Oms::MessagesController < Api::V1::Oms::ApiController
   def update
     attrs = permitted_attributes(@message)
     if @message.update(message: attrs[:content])
-      render json: OrderingApi::V1::MessageSerializer.new(@message).as_json
+      render json: OrderingApi::V1::MessageSerializer.new(@message, keep_content?: true).as_json
     else
       render json: { error: @message.errors.messages }, status: 400
     end

--- a/app/serializers/ordering_api/v1/message_serializer.rb
+++ b/app/serializers/ordering_api/v1/message_serializer.rb
@@ -3,7 +3,7 @@
 class OrderingApi::V1::MessageSerializer < ActiveModel::Serializer
   attribute :id
   attribute :author
-  attribute :message, key: :content
+  attribute :filtered_content, key: :content
   attribute :message_scope, key: :scope
   attributes :created_at, :updated_at
 
@@ -18,6 +18,14 @@ class OrderingApi::V1::MessageSerializer < ActiveModel::Serializer
   def message_scope
     # scope is a reserved keyword in ActiveModel::Serializer
     object.scope
+  end
+
+  def filtered_content
+    if object.user_direct_scope? && !instance_options[:keep_content?]
+      "<OBFUSCATED>"
+    else
+      object.message
+    end
   end
 
   def created_at

--- a/spec/requests/api/v1/oms/messages_controller_spec.rb
+++ b/spec/requests/api/v1/oms/messages_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "OMS Messages API", swagger_doc: "v1/ordering/swagger.json" do
             create(:message, id: 1, messageable: project),
             create(:message, id: 2, messageable: project_item1),
             create(:message, id: 3, messageable: project_item2),
-            create(:message, id: 4, messageable: project),
+            create(:provider_message, scope: :user_direct, id: 4, messageable: project),
             create(:message, id: 5, messageable: project_item1),
             create(:message, id: 6, messageable: project_item2)
           ]
@@ -76,7 +76,7 @@ RSpec.describe "OMS Messages API", swagger_doc: "v1/ordering/swagger.json" do
             create(:message, id: 2, messageable: project_item1),
             create(:message, id: 3, messageable: project_item2),
             create(:message, id: 4, messageable: project),
-            create(:message, id: 5, messageable: project_item1),
+            create(:provider_message, scope: :user_direct, id: 5, messageable: project_item1),
             create(:message, id: 6, messageable: project_item2)
           ]
         }
@@ -242,7 +242,7 @@ RSpec.describe "OMS Messages API", swagger_doc: "v1/ordering/swagger.json" do
               "role": "provider"
             },
             "content": "<content>",
-            "scope": "public",
+            "scope": "user_direct",
           }
         }
         run_test! do |response|
@@ -250,13 +250,13 @@ RSpec.describe "OMS Messages API", swagger_doc: "v1/ordering/swagger.json" do
           expect(project_item.messages.count).to eq(1)
 
           data = JSON.parse(response.body)
-          expect(data).to eq(OrderingApi::V1::MessageSerializer.new(project_item.messages[0]).as_json.deep_stringify_keys)
+          expect(data).to eq(OrderingApi::V1::MessageSerializer.new(project_item.messages[0], keep_content?: true).as_json.deep_stringify_keys)
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end
       end
 
-      response 400, "message created validation failed" do
+      response 400, "payload validation failed" do
         schema "$ref" => "error.json"
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
@@ -440,7 +440,7 @@ RSpec.describe "OMS Messages API", swagger_doc: "v1/ordering/swagger.json" do
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
         let(:project) { create(:project, project_items: [create(:project_item, offer: create(:offer, primary_oms: oms))]) }
-        let(:message) { create(:message, message: "Before update", messageable: project) }
+        let(:message) { create(:message, messageable: project) }
 
         let(:oms_id) { oms.id }
         let(:m_id) { message.id }
@@ -545,7 +545,7 @@ RSpec.describe "OMS Messages API", swagger_doc: "v1/ordering/swagger.json" do
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
         let(:project) { create(:project, project_items: [build(:project_item, offer: build(:offer, primary_oms: oms))]) }
-        let(:message) { create(:provider_message, message: "Before update", messageable: project) }
+        let(:message) { create(:provider_message, scope: :public, message: "Before update", messageable: project) }
 
         let(:oms_id) { oms.id }
         let(:m_id) { message.id }
@@ -572,8 +572,7 @@ RSpec.describe "OMS Messages API", swagger_doc: "v1/ordering/swagger.json" do
         let(:oms_admin) { create(:user) }
         let(:oms) { create(:oms, administrators: [oms_admin]) }
         let(:project_item) { create(:project_item, project: build(:project), offer: build(:offer, primary_oms: oms)) }
-        let(:message) { create(:message, author_role: "provider", author_email: "email@email.com", author_name: "asd",
-                               scope: "user_direct", message: "Before update", messageable: project_item) }
+        let(:message) { create(:provider_message, scope: :user_direct, message: "Before update", messageable: project_item) }
 
         let(:oms_id) { oms.id }
         let(:m_id) { message.id }
@@ -585,7 +584,7 @@ RSpec.describe "OMS Messages API", swagger_doc: "v1/ordering/swagger.json" do
           project_item.reload
 
           data = JSON.parse(response.body)
-          expect(data).to eq(OrderingApi::V1::MessageSerializer.new(message).as_json.deep_stringify_keys)
+          expect(data).to eq(OrderingApi::V1::MessageSerializer.new(message, keep_content?: true).as_json.deep_stringify_keys)
 
           expect(message.message).to eq("After update")
           expect(project_item.messages.first.message).to eq("After update")

--- a/spec/serializers/ordering_api/v1/message_serializer_spec.rb
+++ b/spec/serializers/ordering_api/v1/message_serializer_spec.rb
@@ -42,4 +42,44 @@ RSpec.describe OrderingApi::V1::MessageSerializer do
 
     expect(serialized).to eq(expected)
   end
+
+  it "it properly serializes user_direct provider message" do
+    message = create(:provider_message, scope: "user_direct")
+
+    serialized = described_class.new(message).as_json
+    expected = {
+      id: message.id,
+      author: {
+        email: message.author_email,
+        name: message.author_name,
+        role: message.author_role
+      },
+      content: "<OBFUSCATED>",
+      scope: message.scope,
+      created_at: message.created_at.iso8601,
+      updated_at: message.updated_at.iso8601
+    }
+
+    expect(serialized).to eq(expected)
+  end
+
+  it "doesn't obfuscate user_direct message if asked" do
+    message = create(:provider_message, scope: "user_direct")
+
+    serialized = described_class.new(message, keep_content?: true).as_json
+    expected = {
+      id: message.id,
+      author: {
+        email: message.author_email,
+        name: message.author_name,
+        role: message.author_role
+      },
+      content: message.message,
+      scope: message.scope,
+      created_at: message.created_at.iso8601,
+      updated_at: message.updated_at.iso8601
+    }
+
+    expect(serialized).to eq(expected)
+  end
 end


### PR DESCRIPTION
Closes #2014 

How to test @Marcelinna (mostly copied from https://github.com/cyfronet-fid/marketplace/pull/1982#issuecomment-823921757):

We will artificially create a following situation:
- SOMBO (default), OMS2 and OMS3 omses and their admins
- Project1 (p1) which doesn't have any project_items, but has 2 messages (message1_1 (author: user, scope: public), message1_2 (author: mediator, scope: public))
- Project2 (p2) which has 1 project_item (project_item2_1 (assigned to OMS2)) and no messages
- Project3 (p3) which has 2 project_items (project_item3_1 (assigned to OMS2), project_item3_2 (assigned to OMS3)) and 2 messages (**message3_1 (author: provider, scope: public), message3_2 (author: provider, scope: user_direct)**)

Run
```
rails db:drop db:create db:migrate
rails dev:prime # includes add_sombo task
rails ordering_api:authorization_test_setup
```

Then run this to get admin tokens:
```
rails c
> User.find_by(uid: "iamasomboadmin").authentication_token
> User.find_by(uid: "oms2_admin").authentication_token
> User.find_by(uid: "oms3_admin").authentication_token
```
Copy tokens and use them as 'X-User-Token' in `/api_docs/swagger` (select Ordering API from the top right drop down menu)

Then:
```
POST /api/v1/oms/2/messages
X-User-Token: OMS2 user token
{
  "project_id": 3,
  "project_item_id": 1,
  "content": "super duper secret conrent for user's eyes only",
  "author": {
    "email": "email@email.com",
    "name": "some name",
    "role": "provider"
  },
  "scope": "user_direct"
}
```
(lets call this message **message3_1_1**)

```
POST /api/v1/oms/3/messages
X-User-Token: OMS3 user token
{
  "project_id": 3,
  "project_item_id": 2,
  "content": "public message for every1 to see",
  "author": {
    "email": "email@email.com",
    "name": "some name",
    "role": "provider"
  },
  "scope": "public"
}
```
(lets call this message **message3_2_1**)

```
POST /api/v1/oms/1/messages
X-User-Token: SOMBO user token
{
  "project_id": 3,
  "project_item_id": 2,
  "content": "internal message from mediator",
  "author": {
    "email": "email@email.com",
    "name": "some name",
    "role": "mediator"
  },
  "scope": "internal"
}
```
(lets call this message **message3_2_2**)

Request should result in 200 success and return created items **along with full un-obfuscated contents** - note the message ids!

Then:

8. GET /api/v1/oms/{oms_id}/messages
- `oms_id` = SOMBO id
  - `p_id` = p3 id (query param)
  - as SOMBO admin I should see ['message3_1', 'message3_2'] and status 200 **BUT the message3_2 should have obfuscated content**
    - `pi_id` = project_item3_1 id (query param)
      - as SOMBO admin I should see ['message3_1_1''] and status 200 **BUT the message3_1_1 should have obfuscated content**
    - `pi_id` = project_item3_2 id (query param)
      - as SOMBO admin I should see ['message3_2_1, message3_2_2''] and status 200
- `oms_id` = OMS2 id
  - `p_id` = p3 id (query param)
  - as OMS2 admin I should see ['message3_1', 'message3_2'] and status 200 **BUT the message3_2 should have obfuscated content**
     - `pi_id` = project_item3_1 id (query param)
       - as OMS2 admin I should see ['message3_1_1''] and status 200 **BUT the message3_1_1 should have obfuscated content**
    - `pi_id` = project_item3_2 id (query param)
      - as OMS2 admin I should see 404 "error": "Project item not found"
- `oms_id` = OMS3 id
  - `p_id` = p3 id (query param)
  - as OMS2 admin I should see ['message3_1', 'message3_2'] and status 200 **BUT the message3_2 should have obfuscated content**
     - `pi_id` = project_item3_1 id (query param)
       - as OMS3 admin I should see 404 "error": "Project item not found"
    - `pi_id` = project_item3_2 id (query param)
      - as OMS3 admin I should see ['message3_2_1, message3_2_2''] and status 200

10. GET /api/v1/oms/{oms_id}/messages/{m_id}
   Every OMS should be able to see messages specified in "GET /api/v1/oms/{oms_id}/messages" - any other combination of oms_id and m_id should result in either 403 unauthorized or 404 project/messsage not found **BUT the message3_1_1 AND message3_2 should have obfuscated content**

11. PATCH /api/v1/oms/{oms_id}/messages/{m_id}
- `oms_id` = SOMBO id
  - `m_id` = message3_1_1
    - as a SOMBO admin I should not be able to edit message, and get 403 unauthorized
  - `m_id` = message3_2_1
    - as a SOMBO admin I should not be able to edit message, and get 403 unauthorized
  - `m_id` = message3_2_2
    - as a SOMBO admin I should be able to edit "content" of the message **and returned message should have full un-obfuscated content**
- `oms_id` = OMS2 id
  - `m_id` = message3_1_1
    - as a OMS2 admin I should be able to edit "content" of the message **and returned message should have full un-obfuscated content**
  - `m_id` = message3_2_1
    - as a OMS2 admin I should get 404 message not found
  - `m_id` = message3_2_2
    - as a OMS2 admin  I should get 404 message not found
- `oms_id` = OMS3 id
  - `m_id` = message3_1_1
    - as a OMS3 admin I should get 404 message not found
  - `m_id` = message3_2_1
    - as a OMS3 admin I should be able to edit "content" of the message **and returned message should have full un-obfuscated content**
  - `m_id` = message3_2_2
    - as a OMS3 admin I should not be able to edit message, and get 403 unauthorized
   
12. GET /api/v1/oms/{oms_id}/events
- `oms_id` = SOMBO id
  - as a SOMBO admin I should see events connected to: p1, p2, p3, project_item2_1, project_item3_1, project_item3_2, message1_1, message1_2, message3_1, message3_2, message3_1_1, message3_2_1, message3_2_2 **(but IF you updated the "content" of either message3_2 or message3_1_1 the event['changes] should have obfuscated content!)**
- `oms_id` = OMS2 id
  - as a OMS2 admin I should see events connected to: p2, p3, project_item2_1, project_item3_1, message3_1, message3_2, message3_1_1 **(but IF you updated the "content" of either message3_2 or message3_1_1 the event['changes] should have obfuscated content!)**
- `oms_id` = OMS3 id
  - as a OMS3 admin I should see events connected to: p3, project_item3_2, message3_1, message3_2, message3_2_1, message3_2_2 **(but IF you updated the "content" of message3_2 the event['changes] should have obfuscated content!)**