### PR TITLE
Don't recommend unpublished services

### DIFF
--- a/app/serializers/recommender/service_serializer.rb
+++ b/app/serializers/recommender/service_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Recommender::ServiceSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :tagline, :countries, :order_type, :rating
+  attributes :id, :name, :description, :tagline, :countries, :order_type, :rating, :status
   attribute :category_ids, key: :categories
   attribute :provider_ids, key: :providers
   attribute :resource_organisation_id, key: :resource_organisation


### PR DESCRIPTION
This PR solves issue #1998 on the marketplace side. Should be considered together with cyfronet-fid/recommender-system#51 (that solves this issue on the recommender side).

Now, services sent by a recommender are checked for status before displaying in recommendation panel. If some of them has status other than "published" the recommendation panel isn't displayed.