### PR TITLE
[#2026] Default Offer creation fix

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -85,9 +85,11 @@ class Offer < ApplicationRecord
 
     def check_oms_params
       if current_oms.custom_params.present?
-        oms_params.blank? ? errors.add(:oms_params, "can't be blank") : oms_params_match?
+        if current_oms.mandatory_defaults.present?
+          oms_params.blank? ? errors.add(:oms_params, "can't be blank") : oms_params_match?
+        end
       else
         errors.add(:oms_params, "must be blank if primary oms' custom params are blank") if oms_params.present?
       end
-  end
+    end
 end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Offer do
 
   context "OMS dependencies" do
     it "validates properly against primary oms" do
-      oms = build(:oms, custom_params: { a: { mandatory: false }, b: { mandatory: true, default: "XD" } })
+      oms = create(:oms, custom_params: { a: { mandatory: false }, b: { mandatory: true, default: "XD" } })
 
       expect(build(:offer, oms_params: { a: 1, b: 2 }, primary_oms: oms)).to be_valid
       expect(build(:offer, oms_params: { b: 1 }, primary_oms: oms)).to be_valid
@@ -44,6 +44,9 @@ RSpec.describe Offer do
       expect(build(:offer, oms_params: { c: 1 }, primary_oms: nil)).to_not be_valid
       create(:oms, default: true, custom_params: { c: { mandatory: true, default: "c" } })
       expect(build(:offer, oms_params: { c: 1 }, primary_oms: nil)).to be_valid
+
+      laid_back_oms = create(:oms, custom_params: { d: { mandatory: false } })
+      expect(build(:offer, oms_params: nil, primary_oms: laid_back_oms)).to be_valid
     end
 
     it "returns proper current_oms" do


### PR DESCRIPTION
Fixes an issue where an offer without oms_params would fail validation against an OMS which does have custom params, but none of them are mandatory.

Closes #2026 