### PR TITLE
[#1988][#2012] Offers API adjustments

### DIFF
--- a/app/controllers/api/v1/resources/offers_controller.rb
+++ b/app/controllers/api/v1/resources/offers_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::Resources::OffersController < Api::V1::ApplicationController
   end
 
   def update
-    template = transform(permitted_attributes(Offer))
+    template = transform(permitted_attributes(@offer))
     if Offer::Update.new(@offer, template).call
       render json: Api::V1::OfferSerializer.new(@offer).as_json, status: 200
     else
@@ -70,8 +70,8 @@ class Api::V1::Resources::OffersController < Api::V1::ApplicationController
     end
 
     def transform(attributes)
-      unless attributes["parameters"].blank?
-        attributes["parameters"] = Parameter::Array.load(attributes["parameters"])
+      if attributes[:parameters].present?
+        attributes[:parameters] = Parameter::Array.load(attributes[:parameters])
       end
       attributes
     end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -39,6 +39,9 @@ class Offer < ApplicationRecord
   has_many :project_items,
            dependent: :restrict_with_error
 
+  before_validation :set_internal
+  before_validation :set_oms_details
+
   validate :set_iid, on: :create
   validates :service, presence: true
   validates :iid, presence: true, numericality: true
@@ -97,6 +100,19 @@ class Offer < ApplicationRecord
     def proper_oms?
       unless service.available_omses.include? primary_oms
         errors.add(:primary_oms, "has to be available in the resource scope")
+      end
+    end
+
+    def set_internal
+      unless self.order_required?
+        self.internal = false
+      end
+    end
+
+    def set_oms_details
+      unless self.internal?
+        self.primary_oms = nil
+        self.oms_params = nil
       end
     end
 end

--- a/app/policies/api/v1/offer_policy.rb
+++ b/app/policies/api/v1/offer_policy.rb
@@ -26,7 +26,7 @@ class Api::V1::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name, :description, :webpage, :order_type, :order_url, :primary_oms_id, oms_params: {},
+    [:name, :description, :webpage, :order_type, :order_url, :primary_oms_id, :internal, oms_params: {},
      parameters: [:id, :type, :label, :description, :unit, :value_type, :value,
                   config: [:mode, :minimum, :maximum, :minItems, :maxItems, :exclusiveMinimum,
                            :exclusiveMaximum, :start_price, :step_price, :currency, values: []

--- a/app/serializers/api/v1/offer_serializer.rb
+++ b/app/serializers/api/v1/offer_serializer.rb
@@ -2,9 +2,11 @@
 
 class Api::V1::OfferSerializer < ActiveModel::Serializer
   attribute :iid, key: :id
-  attributes :name, :description, :parameters, :order_type, :webpage, :internal, :order_url
-  attribute :primary_oms_id
-  attribute :oms_params, if: -> { object.oms_params.present? } # TODO: https://github.com/cyfronet-fid/marketplace/issues/1964
+  attributes :name, :description, :parameters, :order_type, :webpage, :order_url
+  attribute  :internal, if: -> { object.order_required? }
+  attribute :primary_oms_id, if: -> { object.internal? }
+  # TODO: https://github.com/cyfronet-fid/marketplace/issues/1964
+  attribute :oms_params, if: -> { object.internal? && object.oms_params.present? }
 
   def primary_oms_id
     object.current_oms.id

--- a/db/migrate/20210427113134_set_internal_in_offers.rb
+++ b/db/migrate/20210427113134_set_internal_in_offers.rb
@@ -1,0 +1,7 @@
+class SetInternalInOffers < ActiveRecord::Migration[6.0]
+  def change
+    exec_update "UPDATE offers SET internal = 'false' WHERE order_type != 'order_required'"
+    exec_update "UPDATE offers SET primary_oms_id = null WHERE internal = 'false'"
+    exec_update "UPDATE offers SET oms_params = null WHERE internal = 'false'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_24_151714) do
+ActiveRecord::Schema.define(version: 2021_04_27_113134) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -60,6 +60,51 @@ RSpec.describe Offer do
     end
   end
 
+  context "before_validate hooks" do
+    it "should set primary_oms and oms_params to nil when internal == false on create" do
+      oms = create(:oms, type: :global, custom_params: { a: { mandatory: true, default: "asd" } })
+      offer = create(:offer, order_type: :order_required, internal: false, primary_oms: oms, oms_params: { a: "qwe" })
+      expect(offer.primary_oms).to be_nil
+      expect(offer.oms_params).to be_nil
+    end
+
+    it "should set primary_oms and oms_params to nil when internal == true on update" do
+      oms = create(:oms, type: :global, custom_params: { a: { mandatory: true, default: "asd" } })
+      offer = create(:offer, order_type: :order_required, internal: true, primary_oms: oms, oms_params: { a: "qwe" })
+      expect(offer.primary_oms).to eq(oms)
+      expect(offer.oms_params).to eq({ a: "qwe" }.deep_stringify_keys)
+
+      offer.update(internal: false)
+      offer.reload
+
+      expect(offer.primary_oms).to be_nil
+      expect(offer.oms_params).to be_nil
+    end
+
+    it "should set internal to false and primary_oms, oms_params to nil when order_type != order_required on create" do
+      oms = create(:oms, type: :global, custom_params: { a: { mandatory: true, default: "asd" } })
+      offer = create(:offer, order_type: :open_access, internal: true, primary_oms: oms, oms_params: { a: "qwe" })
+      expect(offer.internal).to be_falsey
+      expect(offer.primary_oms).to be_nil
+      expect(offer.oms_params).to be_nil
+    end
+
+    it "should set internal to false and primary_oms, oms_params to nil when order_type != order_required on update" do
+      oms = create(:oms, type: :global, custom_params: { a: { mandatory: true, default: "asd" } })
+      offer = create(:offer, order_type: :order_required, internal: true, primary_oms: oms, oms_params: { a: "qwe" })
+      expect(offer.internal).to be_truthy
+      expect(offer.primary_oms).to eq(oms)
+      expect(offer.oms_params).to eq({ a: "qwe" }.deep_stringify_keys)
+
+      offer.update(order_type: :open_access)
+      offer.reload
+
+      expect(offer.internal).to be_falsey
+      expect(offer.primary_oms).to be_nil
+      expect(offer.oms_params).to be_nil
+    end
+  end
+
   context "#parameters" do
     it "should defaults to []" do
       expect(create(:offer).reload.parameters).to eq([])

--- a/spec/serializers/api/v1/offer_serializer_spec.rb
+++ b/spec/serializers/api/v1/offer_serializer_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::OfferSerializer do
+  it "properly serializes an order_required internal offer" do
+    offer = create(:offer,
+                   parameters: [build(:constant_parameter)],
+                   primary_oms: create(:oms, type: :global, custom_params: { a: { mandatory: true, default: "asd" } }),
+                   oms_params: { a: "XD" },
+                   order_type: :order_required)
+
+    serialized = JSON.parse(described_class.new(offer).to_json)
+
+    puts serialized
+
+    expected = {
+      id: offer.iid,
+      name: offer.name,
+      description: offer.description,
+      parameters: [
+        {
+          id: offer.parameters.first.id,
+          label: offer.parameters.first.name,
+          description: offer.parameters.first.hint,
+          type: offer.parameters.first.type,
+          value_type: offer.parameters.first.value_type,
+          value: offer.parameters.first.value
+        }
+      ],
+      order_type: offer.order_type,
+      webpage: offer.webpage,
+      order_url: offer.order_url,
+      internal: true,
+      primary_oms_id: offer.primary_oms.id,
+      oms_params: offer.oms_params
+    }
+
+    expect(serialized).to eq(expected.deep_stringify_keys)
+  end
+
+  it "properly serializes an order_required non-internal offer" do
+    offer = create(:offer, parameters: [build(:constant_parameter)], order_type: :order_required, internal: false)
+
+    serialized = JSON.parse(described_class.new(offer).to_json)
+
+    expected = {
+      id: offer.iid,
+      name: offer.name,
+      description: offer.description,
+      parameters: [
+        {
+          id: offer.parameters.first.id,
+          label: offer.parameters.first.name,
+          description: offer.parameters.first.hint,
+          type: offer.parameters.first.type,
+          value_type: offer.parameters.first.value_type,
+          value: offer.parameters.first.value
+        }
+      ],
+      order_type: offer.order_type,
+      webpage: offer.webpage,
+      order_url: offer.order_url,
+      internal: false
+    }
+
+    expect(serialized).to eq(expected.deep_stringify_keys)
+  end
+
+  it "properly serializes a non-order_required offer" do
+    offer = create(:offer, order_type: :open_access, internal: false)
+
+    serialized = JSON.parse(described_class.new(offer).to_json)
+
+    puts serialized
+
+    expected = {
+      id: offer.iid,
+      name: offer.name,
+      description: offer.description,
+      order_type: offer.order_type,
+      parameters: [],
+      webpage: offer.webpage,
+      order_url: offer.order_url
+    }
+
+    expect(serialized).to eq(expected.deep_stringify_keys)
+  end
+end

--- a/swagger/v1/offer/offer_read.json
+++ b/swagger/v1/offer/offer_read.json
@@ -9,7 +9,6 @@
   "required":[
     "name",
     "description",
-    "order_type",
-    "primary_oms_id"
+    "order_type"
   ]
 }


### PR DESCRIPTION
- Added `internal` and `order_type` dependent serialization
- Added before_validation hooks to Offer model to ensure `internal`, `primary_oms`, `oms_params` are set accordingly
- Added migration that sets `internal` to false when `order_type != order_required`

Addresses point 3. in https://github.com/cyfronet-fid/marketplace/issues/2012 (https://github.com/cyfronet-fid/marketplace/issues/2012#issuecomment-828385718).
Addresses 1.iii, 1.iv and point 3. in https://github.com/cyfronet-fid/marketplace/issues/1988 (https://github.com/cyfronet-fid/marketplace/issues/1988#issuecomment-828387266).

How to test locally @Marcelinna:
**Setup**
1. Run this in the terminal:
```
rails db:drop db:create db:migrate && rails dev:prime && rails ordering_api:add_sombo
```

2. Go to `localhost:5000` and log in
3.  Run this in the terminal:
```
rails c
> User.find_by(email: "email used to log in").update(roles_mask: 11)
```

4. Go to `localhost:5000/backoffice/providers`
5. Find "EGI Federation" and click "edit"
6. Scroll down to "Admins" and add yourself - email used to log in

7. Run this in terminal:
```
rails c
> Provider.find_by(name: "EGI Federation")
> Service.find_by(slug: "egi-cloud-compute").update(resource_organisation: p1)
```

8. Go to `/api_docs` and copy the authentication token
9. Go to `/api_docs/swagger` and add your auth token (**Offering API**)

**Tests**
```
POST /api/v1/resources/egi-cloud-compute/offers/
{ 
  "name": "experimental offer",
  "description": "sample description",
  "order_type": "open_access",
  "internal": true,
  "primary_oms_id": 9999,
  "oms_params": {a: "bc"}
}
```
The response should contain created offer but without `internal`, `primary_oms_id` and `oms_params` fields. **note the offer id** (let's call this offer o1)

```
POST /api/v1/resources/egi-cloud-compute/offers/
{ 
  "name": "experimental offer",
  "description": "sample description",
  "order_type": "order_required",
  "internal": false,
  "primary_oms_id": 9999,
  "oms_params": {a: "bc"}
}
```
The response should contain created offer but without `primary_oms_id` nor `oms_params` field. **note the offer id** (let's call this offer o2)

```
POST /api/v1/resources/egi-cloud-compute/offers/
{ 
  "name": "experimental offer",
  "description": "sample description",
  "order_type": "order_required",
  "internal": true,
  "primary_oms_id": 1,
  "oms_params": {order_target: "https://cyfronet.pl"}
}
```
The response should contain created offer with all fields visible. **note the offer id** (let's call this offer o3)

`GET /api/v1/resources/egi-cloud-compute/offers/{offer_id}`
- offer_id = o1: The response should contain offer but without `internal`, `primary_oms_id` and `oms_params` fields.
- offer_id = o2: The response should contain created offer but without `primary_oms_id` and `oms_params` field.
- offer_id = o3: The response should contain created offer with all fields visible. 

```
PATCH /api/v1/resources/egi-cloud-compute/offers/{o1_id}
{ 
  "order_type": "order_required",
  "internal": false,
  "primary_oms_id": 9999,
  "oms_params": {a: "bc"}
}
```
The response should contain updated offer but without `primary_oms_id` nor `oms_params` fields.

```
PATCH /api/v1/resources/egi-cloud-compute/offers/{o2_id}
{ 
  "internal": false,
  "primary_oms_id": 9999,
  "oms_params": {a: "bc"}
}
```
The response should contain updated offer but without `primary_oms_id` nor `oms_params` fields.

```
PATCH /api/v1/resources/egi-cloud-compute/offers/{o3_id}
{ 
  "order_type": "open_access",
  "internal": true,
  "primary_oms_id": 9999,
  "oms_params": {a: "bc"}
}
```
The response should contain updated offer but without 'internal', `primary_oms_id` nor `oms_params` fields.

`GET /api/v1/resources/egi-cloud-compute/offers/{offer_id}`
- offer_id = o1: The response should contain offer but without `primary_oms_id` nor `oms_params` fields.
- offer_id = o2: The response should contain offer but without `primary_oms_id` and `oms_params` field.
- offer_id = o3: The response should contain offer but without `internal`, `primary_oms_id` nor `oms_params` fields.

