### PR TITLE
Prevent non-search-engines bots from indexing

### DIFF
--- a/config/robots.production.txt
+++ b/config/robots.production.txt
@@ -1,2 +1,28 @@
-User-agent: *
+# Allow search engines bots
+User-agent: Bingbot         # Bing
+User-agent: MSNBot
+User-agent: Googlebot       # Google
+User-agent: googlebot-image
+User-agent: googlebot-mobile
+User-agent: Slurp           # Yahoo
+User-agent: yahoo-mmcrawler
+User-agent: yahoo-blogs/v3.9
+User-agent: DuckDuckBot     # Duck duck
+User-agent: Baiduspider     # Baidu (China)
+User-agent: YandexBot       # Yandex (Russia)
+User-agent: Exabot          # Exabot (France)
+User-agent: facebot         # Facebook (Link img preview)
+User-agent: Applebot        # Apple
+User-agent: Teoma           # Other
+User-agent: ia_archiver
+User-agent: naverbot
+User-agent: yeti
+User-agent: psbot
+User-agent: Robozilla
+User-agent: Nutch
 Disallow:
+
+# Disallow all other
+User-agent: *
+Disallow: /
+Crawl-delay: 360


### PR DESCRIPTION
- allowed: Bing, Google, Yahoo, Duck duck, other
- increase the time between indexing up to 3 minutes

---

To verify properly working roobots.txt file for certain search engines, please check:
https://technicalseo.com/tools/robots-txt/

Required actions before verification: upload of robots.txt file to certain URL

Required fields:
URL: https://marketplace.eosc-portal.eu/
User-agent: a bot you are looking for to verify if it's allowed or not
