### PR TITLE
[#1987] Add manage resource navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- Add manage resource navigation (@danielkryska)
 
 ### Changed
 


### PR DESCRIPTION
**Acceptance criteria**
- [ ] logged in user without resource admin privileges does not see "Manage the resource" button
- [ ] logged in user with the resource admin privileges sees "Manage the resource" button
- [x] "Manage the resource" button is a dropdown list and has 2 options: Edit resource details, Set parameters and offers
- [x] Clicking on the 'Set parameters and offers' redirects to edit ordering configuration: 
services/$SERVICE_ID/ordering_configuration#offers
- [ ] "Back to the resource button" in the ordering configuration view redirects to the MP RPP
- [x] "Manage the resource" button look is adequate to the design provided above
- [ ] Ordering configuration management works as it works now
- [ ] (Edge case) if during the opened session in the RPP,  the logged user looses the admin privileges, clicking on 'Edit resource detail' button should is handled accordingly
- [ ] Backoffice tab in production is visible only for the MP admin role  -  @bwilk , please confirm 