### PR TITLE
Nav active-state regression fix

### DIFF
--- a/app/views/layouts/order/_nav.html.haml
+++ b/app/views/layouts/order/_nav.html.haml
@@ -5,6 +5,6 @@
       :ruby
         state = :disabled if state == :next
         state = :next if state == :active
-        state = :active if step_name == step_key.to_s
+        state = :active if step_name == step_key
 
       = order_nav_link(step_title(step_name), url_for([service, step_name]), state)


### PR DESCRIPTION
The nav component assumed that step_names were strings instead of
symbols, which changed with recent rails hotfix.