### PR TITLE
[#1836] Fix img background on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Change img background at /backoffice/providers/<id> from black to transparent on resize (@danielkryska)
 - Add error note on a scientific domain with services deletion (@danielkryska)
 - Change error message at order summary to general - better UX (@danielkryska)
 - Mail delivery for orderable offers (@jswk)

--- a/app/controllers/users/auth_mock_controller.rb
+++ b/app/controllers/users/auth_mock_controller.rb
@@ -16,6 +16,7 @@ class Users::AuthMockController < ApplicationController
       "#{params[:password]}#{nil}",
       cost: 11
     ).to_s
+
     @user = User.find_by(
       email: params[:email],
       encrypted_password: encrypted_password,

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -27,14 +27,6 @@ module ProviderHelper
     fields.map { |f| record.send(f) }.any? { |v| v.present? }
   end
 
-  def provider_logo(provider, classes = "align-self-center mr-4 float-left img-responsive", resize = "100x67")
-    if provider.logo.attached? && provider.logo.variable?
-      image_tag provider.logo.variant(resize: resize), class: classes
-    else
-      image_pack_tag("eosc-img.png", size: resize, class: classes)
-    end
-  end
-
   def field_tree(service, field)
     parents = service.send(field).map { |f| f.parent.blank? ? f : f.parent }
     Hash[parents.map { |parent| [parent.name, (parent.children & service.send(field)).map(&:name)] } ]

--- a/app/services/importers/logo.rb
+++ b/app/services/importers/logo.rb
@@ -35,11 +35,26 @@ class Importers::Logo
       logo_content_type = "image/png"
     end
     if !logo.blank? && logo_content_type.start_with?("image")
-      @object.logo.attach(io: logo, filename: @object.pid, content_type: logo_content_type)
+      filename = @object.pid.blank? ? "logo_" + to_slug(@object.name) : @object.pid
+      @object.logo.attach(io: logo, filename: filename + extension, content_type: logo_content_type)
     end
   rescue OpenURI::HTTPError, Errno::EHOSTUNREACH, LogoNotAvailableError, SocketError => e
     Rails.logger.warn "ERROR - there was a problem processing image for #{@object.pid} #{@image_url}: #{e}"
   rescue => e
     Rails.logger.warn "ERROR - there was a unexpected problem processing image for #{@object.pid} #{@image_url}: #{e}"
   end
+
+  private
+    def to_slug(ret)
+      ret.downcase!.strip!
+        .gsub!(/['`]/, "")
+        .gsub!(/\s*@\s*/, " at ")
+        .gsub!(/\s*&\s*/, " and ")
+        .gsub!(/\s*[^A-Za-z0-9.-]\s*/, "-")
+        .gsub!(/_+/, "_")
+        .gsub!(/\A[_.]+|[_.]+\z/, "")
+        .gsub!(/-+/, "-")
+        .gsub!(/-$/, "")
+      ret
+    end
 end

--- a/app/views/backoffice/providers/show.html.haml
+++ b/app/views/backoffice/providers/show.html.haml
@@ -6,7 +6,9 @@
   .logo-wrapper
     %span.helper
     - if @provider.logo.attached? && @provider.logo.variable?
-      = provider_logo(@provider)
+      = image_tag @provider.logo.variant(resize: "100x67"), class: "align-self-center mr-4 float-left img-responsive"
+    - else
+      = image_pack_tag "eosc-img.png", size: "100x67", class: "align-self-center mr-4 float-left img-responsive"
   - unless @provider.sources.empty?
     %h3
       = _("External Sources:")

--- a/docs/upgrade/3.12.0.md
+++ b/docs/upgrade/3.12.0.md
@@ -1,0 +1,15 @@
+# Upgrade to 3.12.0
+
+# Standard procedure
+
+All steps run in production scope.
+
+- make database dump and all application files.
+- `bundle install --deployment --without development test`
+- `bundle exec rake assets:clean assets:precompile`
+- `rails db:migrate`
+
+# Special steps
+
+- Run task `rake add_extension_to_images[<ROOT_URL>]` to migrate images,
+where `ROOT_URL` is instance domain

--- a/lib/tasks/add_extensions_to_images.rake
+++ b/lib/tasks/add_extensions_to_images.rake
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "mini_magick"
+
+desc "Add an extension to the images that has lack of them"
+task :add_extension_to_images, [:root_url] => :environment do |_, args|
+  routes_default_host = Rails.application.routes.default_url_options[:host]
+  app_default_host = Mp::Application.default_url_options[:host]
+
+  Rails.application.routes.default_url_options[:host] = args.root_url
+  Mp::Application.default_url_options[:host] = args.root_url
+
+  include Rails.application.routes.url_helpers
+  include ApplicationHelper
+
+  add_extension_to_images
+ensure
+  Rails.application.routes.default_url_options[:host] = routes_default_host
+  Mp::Application.default_url_options[:host] = app_default_host
+end
+
+class LogoNotAvailableError < StandardError
+  def initialize(msg)
+    super(msg)
+  end
+end
+
+def add_extension_to_images
+  objects_with_img = Provider.all.to_a
+                             .push(*Service.all.to_a)
+                             .push(*Category.all.to_a)
+                             .push(*ScientificDomain.all.to_a)
+  objects_with_img.each do |object|
+    if should_rename(object.logo)
+      filename = object.pid.blank? ? "logo_" + to_slug(object.name) : object.pid
+      rename_img(object.logo, filename)
+    end
+  end
+end
+
+def rename_img(attachment, filename)
+  logo = open(url_for(attachment), ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
+  logo_content_type = logo.content_type
+  extension = Rack::Mime::MIME_TYPES.invert[logo_content_type]
+
+  unless [".jpg", ".jpeg", ".pjpeg", ".png", ".gif", ".tiff"].include?(extension)
+    img = MiniMagick::Image.read(logo, extension)
+    img.format "png" do |convert|
+      convert.args.unshift "800x800"
+      convert.args.unshift "-resize"
+      convert.args.unshift "1200"
+      convert.args.unshift "-density"
+      convert.args.unshift "none"
+      convert.args.unshift "-background"
+    end
+    logo = StringIO.new
+    logo.write(img.to_blob)
+    logo.seek(0)
+    logo_content_type = "image/png"
+  end
+  if !logo.blank? && logo_content_type.start_with?("image")
+    attachment.attach(io: logo, filename: filename + extension, content_type: logo_content_type)
+  end
+rescue OpenURI::HTTPError, Errno::EHOSTUNREACH, LogoNotAvailableError, SocketError => e
+  Rails.logger.warn "ERROR - there was a problem processing image for #{@object.pid} #{@image_url}: #{e}"
+rescue => e
+  Rails.logger.warn "ERROR - there was a unexpected problem processing image for #{@object.pid} #{@image_url}: #{e}"
+end
+
+def should_rename(attachment)
+  if attachment.blank? || attachment.filename.blank?
+    return false
+  end
+
+  has_ext = attachment.filename.to_s
+                          .match(/\.(jpg|jpeg|pjpeg|png|gif|tiff")$/)
+  attachment.attached? && !has_ext
+end
+
+def to_slug(ret)
+  ret.downcase!
+  ret.strip!
+  ret.gsub!(/['`]/, "")
+  ret.gsub!(/\s*@\s*/, " at ")
+  ret.gsub!(/\s*&\s*/, " and ")
+  ret.gsub!(/\s*[^A-Za-z0-9.-]\s*/, "-")
+  ret.gsub!(/_+/, "_")
+  ret.gsub!(/\A[_.]+|[_.]+\z/, "")
+  ret.gsub!(/-+/, "-")
+  ret.gsub!(/-$/, "")
+  ret
+end


### PR DESCRIPTION
- Fix all models containing logo field
  - Providers
  - Services
  - Categories
  - Scientific Domains
- Add task migrating images without extension in a name to have one
- Add the image extension to the file name on load
- Set slug as image name on missing pid field

---

Fixing existing images requires migration. Although it's needed to run it with param `ROOT_URL` as for instance domain URL

Example:
`rake add_extension_to_images["http://localhost:5000"]`

---

Before
![image](https://user-images.githubusercontent.com/31220811/117441821-3cea1280-af36-11eb-86fb-11e821f91b92.png)

After
![image](https://user-images.githubusercontent.com/31220811/117441763-2a6fd900-af36-11eb-9d49-4680509ec905.png)

- Extention on Auth Mock endpoint to add roles to user