### PR TITLE
[#1880] Improve offer ordering configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [Unreleased]
 
 ### Added
+- OMS configuration on offer creation and update (@jswk)
 - Resource provider can navigate to the Provider Component from the Resource Presentation Page (@kmarszalek, @jarekzet)
 - Resource provider can navigate to the ordering parameters management from the Resource Presentation Page (@kmarszalek, @jarekzet)
 
 ### Changed
+- More consistent form behaviour for ordering configuration (@jswk)
 
 ### Deprecated
 

--- a/app/controllers/backoffice/services/offers_controller.rb
+++ b/app/controllers/backoffice/services/offers_controller.rb
@@ -29,7 +29,7 @@ class Backoffice::Services::OffersController < Backoffice::ApplicationController
 
   def update
     template = permitted_attributes(Offer.new)
-    if Offer::Update.new(@offer, update_blank_parameters(template)).call
+    if Offer::Update.new(@offer, transform_attributes(template)).call
       redirect_to backoffice_service_path(@service),
                   notice: "Offer updated correctly"
     else
@@ -52,13 +52,16 @@ class Backoffice::Services::OffersController < Backoffice::ApplicationController
     end
 
     def offer_template
-      temp = update_blank_parameters(permitted_attributes(Offer))
+      temp = transform_attributes(permitted_attributes(Offer))
       Offer.new(temp.merge(service: @service, status: :published))
     end
 
-    def update_blank_parameters(template)
+    def transform_attributes(template)
       if template["parameters_attributes"].blank?
         template["parameters_attributes"] = []
+      end
+      if template["primary_oms_id"].present? && template["oms_params"].nil?
+        template["oms_params"] = {}
       end
       template
     end

--- a/app/controllers/services/ordering_configuration/offers_controller.rb
+++ b/app/controllers/services/ordering_configuration/offers_controller.rb
@@ -29,7 +29,7 @@ class Services::OrderingConfiguration::OffersController < Services::OrderingConf
 
   def update
     template = permitted_attributes(Offer.new)
-    if Offer::Update.new(@offer, update_blank_parameters(template)).call
+    if Offer::Update.new(@offer, transform_attributes(template)).call
       redirect_to service_ordering_configuration_path(@service),
                   notice: "Offer updated correctly"
     else
@@ -55,13 +55,16 @@ class Services::OrderingConfiguration::OffersController < Services::OrderingConf
     end
 
     def offer_template
-      temp = update_blank_parameters(permitted_attributes(Offer))
+      temp = transform_attributes(permitted_attributes(Offer))
       Offer.new(temp.merge(service: @service, default: false, status: :published))
     end
 
-    def update_blank_parameters(template)
+    def transform_attributes(template)
       if template["parameters_attributes"].blank?
         template["parameters_attributes"] = []
+      end
+      if template["primary_oms_id"].present? && template["oms_params"].nil?
+        template["oms_params"] = {}
       end
       template
     end

--- a/app/javascript/app/controllers/ordering_controller.js
+++ b/app/javascript/app/controllers/ordering_controller.js
@@ -1,0 +1,56 @@
+import {Controller} from 'stimulus'
+
+export default class extends Controller {
+  static targets = [
+    "orderType",
+    "internal",
+    "internalWrapper",
+    "primaryOms",
+    "primaryOmsWrapper",
+    "orderUrlWrapper",
+    "omsParamsContainer"
+  ];
+
+  initialize() {
+    this.updateVisibility();
+  }
+
+  updateVisibility() {
+    function doShowOrDisable(el, show) {
+      if (show) {
+        el.classList.remove("hidden-fields");
+      } else {
+        el.classList.add("hidden-fields");
+      }
+      el.querySelectorAll("input, select").forEach(el => {
+        if (show) {
+          el.removeAttribute("disabled");
+        } else {
+          el.setAttribute("disabled", "disabled");
+        }
+      });
+    }
+
+    const isOrderRequired =
+        // The undefined case is that of a default offer with order_type=order_required,
+        // for order_type!=order_required this controller shouldn't be registered at all.
+        !this.hasOrderTypeTarget ||
+        this.orderTypeTarget.value === "order_required";
+    const isInternal = this.internalTarget.checked;
+
+    doShowOrDisable(this.internalWrapperTarget, isOrderRequired);
+
+    if (this.hasOrderUrlWrapperTarget) {
+      doShowOrDisable(this.orderUrlWrapperTarget, !(isOrderRequired && isInternal));
+    }
+
+    doShowOrDisable(this.primaryOmsWrapperTarget, isOrderRequired && isInternal);
+
+    const selectedId = this.primaryOmsTarget.value;
+    const shouldShow = (isOrderRequired && isInternal && !!selectedId) ?
+        (el) => el.getAttribute("data-oms-id") === selectedId : () => false;
+    this.omsParamsContainerTarget.querySelectorAll("[data-oms-id]").forEach(el => {
+      doShowOrDisable(el, shouldShow(el));
+    });
+  }
+}

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -41,6 +41,7 @@ class Offer < ApplicationRecord
 
   before_validation :set_internal
   before_validation :set_oms_details
+  before_validation :sanitize_oms_params
 
   validate :set_iid, on: :create
   validates :service, presence: true
@@ -87,7 +88,7 @@ class Offer < ApplicationRecord
           oms_params.blank? ? errors.add(:oms_params, "can't be blank") : oms_params_match?
         end
       else
-        errors.add(:oms_params, "must be blank if primary oms' custom params are blank") if oms_params.present?
+        errors.add(:oms_params, "must be blank if primary OMS' custom params are blank") if oms_params.present?
       end
     end
 
@@ -113,6 +114,12 @@ class Offer < ApplicationRecord
       unless self.internal?
         self.primary_oms = nil
         self.oms_params = nil
+      end
+    end
+
+    def sanitize_oms_params
+      if oms_params.present?
+        oms_params.select! { |_, v| v.present? }
       end
     end
 end

--- a/app/models/offer/oms_params.rb
+++ b/app/models/offer/oms_params.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Offer::OMSParams
+  MODEL_NAME = ActiveModel::Name.new(self.class, nil, "oms_params")
+
+  def model_name
+    MODEL_NAME
+  end
+
+  def initialize(hash)
+    @object = hash&.symbolize_keys || {}
+  end
+
+  def method_missing(method, *args, &block)
+    if @object.key? method
+      @object[method]
+    elsif @object.respond_to? method
+      @object.send(method, *args, &block)
+    end
+  end
+
+  def has_attribute?(attr)
+    @object.key? attr
+  end
+end

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -45,6 +45,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
 
   def permitted_attributes
     [:id, :name, :description, :webpage, :order_type, :order_url, :internal,
+     :primary_oms_id, oms_params: {},
      parameters_attributes: [:type, :name, :hint, :min, :max,
                              :unit, :value_type, :start_price, :step_price, :currency,
                              :exclusive_min, :exclusive_max, :mode, :values, :value]]

--- a/app/policies/ordering_configuration/offer_policy.rb
+++ b/app/policies/ordering_configuration/offer_policy.rb
@@ -28,7 +28,8 @@ class OrderingConfiguration::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:id, :name, :description, :webpage, :order_type, :order_url, :default,
+    [:id, :name, :description, :webpage, :order_type, :order_url, :default, :internal,
+     :primary_oms_id, oms_params: {},
      parameters_attributes: [:type, :name, :hint, :min, :max,
                              :unit, :value_type, :start_price, :step_price, :currency,
                              :exclusive_min, :exclusive_max, :mode, :values, :value]]

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -1,15 +1,23 @@
 = simple_form_for offer_form_source_module, html: { "data-controller": "offer" } do |f|
-  .col-lg-8.pl-0
+  .col-lg-8.pl-0{ "data-controller": "ordering" }
     = f.error_notification
     = f.hidden_field :id
     = f.input :name, input_html: { class: "form-control-lg" }
     = f.input :description, input_html: { rows: 10 }
     = f.input :order_type, collection: Offer.order_types.keys.map(&:to_sym),
       selected: (offer.order_type || service.order_type),
-      input_html: { class: "form-control-lg col-lg-6" }
+      input_html: { "data-target": "ordering.orderType",
+                    "data-action": "ordering#updateVisibility",
+                    class: "form-control-lg col-lg-6" }
     = f.input :webpage, label: _("Offer website"), input_html: { class: "form-control-lg" }
-    = f.input :internal, label: _("Internal Marketplace ordering")
-    = f.input :order_url, input_html: { class: "form-control-lg" }
+    = f.input :internal,
+      wrapper_html: { "data-target": "ordering.internalWrapper" },
+      input_html: { "data-target": "ordering.internal",
+                    "data-action": "ordering#updateVisibility" }
+    = f.input :order_url,
+      wrapper_html: { "data-target": "ordering.orderUrlWrapper" },
+      input_html: { class: "form-control-lg" }
+    = render "backoffice/services/offers/primary_oms_form", form: f, offer: offer, available_omses: service.available_omses
 
   %h4.mt-5.mb-0.text-uppercase
     = _("Offer parameters")

--- a/app/views/backoffice/services/offers/_one_offer_edit_form.html.haml
+++ b/app/views/backoffice/services/offers/_one_offer_edit_form.html.haml
@@ -1,5 +1,14 @@
 = simple_form_for offer_form_source_module, html: { "data-controller": "offer" } do |f|
-  = f.hidden_field :id
+  .col-lg-8.pl-0{ "data-controller": offer.order_required? ? "ordering" : "" }
+    = f.error_notification
+    = f.hidden_field :id
+    - if offer.order_required?
+      = f.input :internal,
+        wrapper_html: { "data-target": "ordering.internalWrapper" },
+        input_html: { "data-target": "ordering.internal",
+                      "data-action": "ordering#updateVisibility" }
+      = render "backoffice/services/offers/primary_oms_form", form: f, offer: offer, available_omses: service.available_omses
+
   %h4.mt-5.mb-0.text-uppercase
     = _("Offer parameters")
   .row.parameters-section

--- a/app/views/backoffice/services/offers/_primary_oms_form.haml
+++ b/app/views/backoffice/services/offers/_primary_oms_form.haml
@@ -1,0 +1,17 @@
+= form.input :primary_oms_id, collection: available_omses,
+  value_method: :id,
+  label_method: :name,
+  include_blank: false,
+  wrapper_html: { "data-target": "ordering.primaryOmsWrapper" },
+  input_html: { "data-target": "ordering.primaryOms",
+                "data-action": "ordering#updateVisibility",
+                class: "form-control-lg col-lg-6" }
+%div{ "data-target": "ordering.omsParamsContainer" }
+  = form.simple_fields_for Offer::OMSParams.new(offer.oms_params) do |field|
+    - available_omses.each do |oms|
+      - oms.custom_params&.each do |param, param_options|
+        - is_missing = param_options["mandatory"] && offer.errors[:oms_params].present? && offer.oms_params[param].blank?
+        = field.input param,
+          required: param_options["mandatory"],
+          wrapper_html: { "data-oms-id": oms.id },
+          input_html: { class:  is_missing ? "is-invalid" : "" }

--- a/app/views/backoffice/services/offers/edit.html.haml
+++ b/app/views/backoffice/services/offers/edit.html.haml
@@ -1,6 +1,8 @@
 - content_for :title, _("Edit Offer")
 .container
-  %h2= _("Edit Offer")
+  .mb-4.pb-4.border-header
+    %h1= _("Edit offer")
+
   - if @service.offers.size == 1
     = render "one_offer_edit_form",
       offer: @offer,

--- a/app/views/services/ordering_configuration/offers/edit.html.haml
+++ b/app/views/services/ordering_configuration/offers/edit.html.haml
@@ -1,6 +1,8 @@
 - content_for :title, _("Edit Offer")
 .container
-  %h2= _("Edit Offer")
+  .mb-4.pb-4.border-header
+    %h1= _("Edit offer")
+
   - if @service.offers.size == 1
     = render "backoffice/services/offers/one_offer_edit_form",
       offer: @offer,

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -54,6 +54,10 @@ en:
       provider:
         esfri_types: ESFRI Type
         esfri_domains: ESFRI Domains
+      offer:
+        internal: Use EOSC Portal as the order management platform
+        order_url: Order / access URL
+        primary_oms_id: Order Management System
     #   defaults:
     #     password: 'Password'
     #   user:
@@ -110,9 +114,6 @@ en:
         company_website_url: |
           Url should start with http or https [e.g. http://webpage.org]
       offer:
-        webpage: |
-          Url should start with http or https [e.g. http://webpage.org].
-          This url will be available on service order information step
         order_url: |
           Url should start with http or https [e.g. http://webpage.org].
           This url will be available on service order information step

--- a/lib/tasks/test_bootstrap.rake
+++ b/lib/tasks/test_bootstrap.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_bootstrap/omses_with_different_custom_params"
+
+namespace :test_bootstrap do
+  task :add_role_to_user, [:email, :role] => :environment do |_, args|
+    TestBootstrap::AddRoleToUser.new(args.email, args.role).call
+  end
+
+  task omses_with_different_custom_params: :environment do
+    TestBootstrap::OMSesWithDifferentCustomParams.new.call
+  end
+end

--- a/lib/test_bootstrap/add_role_to_user.rb
+++ b/lib/test_bootstrap/add_role_to_user.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module TestBootstrap
+  class AddRoleToUser
+    def initialize(email, role)
+      @email = email
+      @role = role
+    end
+
+    def call
+      puts "Adding role '#{@role}' to user with email '#{@email}'"
+      user = User.find_by!(email: @email)
+
+      if User.valid_roles.exclude?(@role.to_sym)
+        puts "Role must be a valid role, i.e. one of #{User.valid_roles}"
+        return
+      end
+
+      user.roles << @role
+      user.save!
+    end
+  end
+end

--- a/lib/test_bootstrap/omses_with_different_custom_params.rb
+++ b/lib/test_bootstrap/omses_with_different_custom_params.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module TestBootstrap
+  class OMSesWithDifferentCustomParams
+    def initialize; end
+
+    def call
+      puts "Creating OMS2 (with two params, mandatory and not) and OMS3 (without params)"
+      OMS.create!(name: "OMS2", type: "global",
+                  custom_params: {
+                    other_param_mandatory: {
+                      mandatory: true,
+                      default: "very needed"
+                    },
+                    yet_another: {
+                      mandatory: false
+                    }
+                  })
+      OMS.create!(name: "OMS3", type: "global", custom_params: {})
+    end
+  end
+end

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -640,6 +640,79 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_field "service_sources_attributes_0_eid", disabled: false
       expect(page).to have_field "Synchronized at", disabled: true
     end
+
+    scenario "I can edit offer OMS", js: true do
+      oms1 = create(:oms, name: "OMS1", custom_params: { "foo": { "mandatory": true, "default": "baz" } })
+      oms2 = create(:oms, name: "OMS2", custom_params: {})
+      service = create(:service, name: "my service", status: :draft)
+      offer = create(:offer, name: "offer1", description: "desc", service: service, internal: false)
+      create(:offer, service: service)
+
+      service.reload
+
+      visit backoffice_service_path(service)
+      first(".btn.btn-outline-secondary.font-weight-bold").click
+
+      check "Use EOSC Portal as the order management platform"
+      select "OMS1", from: "Order Management System"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.internal).to be_falsey
+
+      fill_in "Foo", with: "bar"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.internal).to be_truthy
+      expect(offer.primary_oms).to eq(oms1)
+      expect(offer.oms_params).to eq({ "foo" => "bar" })
+
+      first(".btn.btn-outline-secondary.font-weight-bold").click
+
+      select "OMS2", from: "Order Management System"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.primary_oms).to eq(oms2)
+      expect(offer.oms_params).to eq({})
+    end
+
+    scenario "I can edit default offer OMS", js: true do
+      oms1 = create(:oms, name: "OMS1", custom_params: { "foo": { "mandatory": true, "default": "baz" } })
+      oms2 = create(:oms, name: "OMS2", custom_params: {})
+      service = create(:service, name: "my service", status: :draft)
+      offer = create(:offer, name: "offer1", description: "desc", service: service, internal: false)
+
+      service.reload
+
+      visit backoffice_service_path(service)
+      first(".btn.btn-outline-secondary.font-weight-bold").click
+
+      check "Use EOSC Portal as the order management platform"
+      select "OMS1", from: "Order Management System"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.internal).to be_falsey
+
+      fill_in "Foo", with: "bar"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.internal).to be_truthy
+      expect(offer.primary_oms).to eq(oms1)
+      expect(offer.oms_params).to eq({ "foo" => "bar" })
+
+      first(".btn.btn-outline-secondary.font-weight-bold").click
+
+      select "OMS2", from: "Order Management System"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.primary_oms).to eq(oms2)
+      expect(offer.oms_params).to eq({})
+    end
   end
 
   context "as a service owner" do

--- a/spec/features/ordering_configuration_spec.rb
+++ b/spec/features/ordering_configuration_spec.rb
@@ -101,5 +101,78 @@ RSpec.feature "Services in ordering_configuration panel" do
       expect(page).to have_content("Offer removed successfully")
       expect(service.offers.size).to eq(1)
     end
+
+    scenario "I can edit offer OMS", js: true do
+      oms1 = create(:oms, name: "OMS1", custom_params: { "foo": { "mandatory": true, "default": "baz" } })
+      oms2 = create(:oms, name: "OMS2", custom_params: {})
+      service = create(:service, name: "my service", resource_organisation: provider, status: :draft)
+      offer = create(:offer, name: "offer1", description: "desc", service: service, internal: false)
+      create(:offer, service: service)
+
+      service.reload
+
+      visit service_ordering_configuration_path(service)
+      first(".btn.btn-outline-secondary.font-weight-bold").click
+
+      check "Use EOSC Portal as the order management platform"
+      select "OMS1", from: "Order Management System"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.internal).to be_falsey
+
+      fill_in "Foo", with: "bar"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.internal).to be_truthy
+      expect(offer.primary_oms).to eq(oms1)
+      expect(offer.oms_params).to eq({ "foo" => "bar" })
+
+      first(".btn.btn-outline-secondary.font-weight-bold").click
+
+      select "OMS2", from: "Order Management System"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.primary_oms).to eq(oms2)
+      expect(offer.oms_params).to eq({})
+    end
+
+    scenario "I can edit default offer OMS", js: true do
+      oms1 = create(:oms, name: "OMS1", custom_params: { "foo": { "mandatory": true, "default": "baz" } })
+      oms2 = create(:oms, name: "OMS2", custom_params: {})
+      service = create(:service, name: "my service", resource_organisation: provider, status: :draft)
+      offer = create(:offer, name: "offer1", description: "desc", service: service, internal: false)
+
+      service.reload
+
+      visit service_ordering_configuration_path(service)
+      first(".btn.btn-outline-secondary.font-weight-bold").click
+
+      check "Use EOSC Portal as the order management platform"
+      select "OMS1", from: "Order Management System"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.internal).to be_falsey
+
+      fill_in "Foo", with: "bar"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.internal).to be_truthy
+      expect(offer.primary_oms).to eq(oms1)
+      expect(offer.oms_params).to eq({ "foo" => "bar" })
+
+      first(".btn.btn-outline-secondary.font-weight-bold").click
+
+      select "OMS2", from: "Order Management System"
+      click_on "Update Offer"
+
+      offer.reload
+      expect(offer.primary_oms).to eq(oms2)
+      expect(offer.oms_params).to eq({})
+    end
   end
 end


### PR DESCRIPTION
Partly address #2012 and #1988.

Make the offer ordering form show/hide fields as dictated by the
business logic.

Also, add OMS selection to the form. The possible values are taken from
available_omses, and oms_params are emitted in HTML for all the OMSes.
The stimulus controller changes their visibility and disabled state
according to the chosen OMS.

## How to test

1. As a logged-in user go to Backoffice space.
2. Select any resource for editing.
3. Click "Add new offer" in " Parameters and offers "
4. For order_type not equal to `order_required` you should see no "Use EOSC Portal as an order management platform" checkbox, no "Order / access URL" nor OMS selection. Note that you will still see "Offer website" field, it will be removed in the scope of other PR.
5. Select order_type=`order_required`, a selected "Use EOSC Portal as an order management platform" should appear and OMS selection.
6. You should be able to choose any available OMS (SOMBO, OMS2 and OMS3) and fill in its parameters (the required fields will have asterisk, but as there are defaults they won't have to be actually filled-in for the form to pass).
7. Deselect the "Use EOSC Portal as an order management platform" checkbox: OMS selection should disappear and you should be able to enter "Order / access URL".

## How to prepare PR instance

```ruby
rails ordering_api:add_sombo
rails test_bootstrap:omses_with_different_custom_params
rails test_bootstrap:add_role_to_user[<tester_email>,service_portfolio_manager]
```

Fixes: #1880.