### PR TITLE
[#1986] Provider can navigate from RPP to PC

### DIFF
--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -61,6 +61,12 @@
             %li
               %a.dropdown-item.dropdown-details{ href:
                 Mp::Application.config.providers_dashboard_url +
+                "/resource-dashboard/#{resource_organisation_pid(service)}/#{service.pid}/stats",
+                target: :_blank, "data-probe": "" }
+                = _("Resource dashboard")
+            %li
+              %a.dropdown-item.dropdown-details{ href:
+                Mp::Application.config.providers_dashboard_url +
                 "/provider/#{resource_organisation_pid(service)}/resource/update/#{service.pid}",
                 target: :_blank, "data-probe": "" }
                 = _("Edit resource details")


### PR DESCRIPTION
Provider can navigate from the Resource Presentation Page to the resource dashboard of the Provider Component

no changelog because there already is entry that covers this change:
- Resource provider can navigate to the Provider Component from the Resource Presentation Page (@kmarszalek, @jarekzet)
![Zrzut ekranu 2021-05-12 o 12 21 21](https://user-images.githubusercontent.com/6060538/117959713-94182a80-b31c-11eb-8963-967d9c0ed84e.png)

-> https://beta.providers.eosc-portal.eu/resource-dashboard/west-life/west-life.3dbionotes/stats