### PR TITLE
[#1988] Purge offer webpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Resource provider can navigate to the ordering parameters management from the Resource Presentation Page (@kmarszalek, @jarekzet)
 
 ### Changed
+- For an Offer, an empty order URL doesn't imply internal ordering (@jswk)
 - More consistent form behaviour for ordering configuration (@jswk)
 
 ### Deprecated
 
 ### Removed
+- Offer webpage field (@jswk)
 
 ### Fixed
 - Change img background at /backoffice/providers/<id> from black to transparent on resize (@danielkryska)

--- a/app/helpers/project_items_helper.rb
+++ b/app/helpers/project_items_helper.rb
@@ -18,10 +18,10 @@ module ProjectItemsHelper
   end
 
   def webpage(project_item)
-    if project_item.external?
-      project_item.order_url
+    if project_item.order_url.blank?
+      project_item.service.webpage_url
     else
-      project_item.webpage
+      project_item.order_url
     end
   end
 

--- a/app/javascript/app/controllers/offer_controller.js
+++ b/app/javascript/app/controllers/offer_controller.js
@@ -2,11 +2,10 @@ import {Controller} from 'stimulus'
 import initChoises from "../choises";
 
 export default class extends Controller {
-  static targets = ["parameters", "webpage", "external",
+  static targets = ["parameters", "external",
                     "attributes", "button", "attributeType"];
 
   initialize() {
-    // this.showWebpage();
     this.indexCounter = 0;
     if (this.attributesTarget.firstElementChild) {
       this.attributesTarget.classList.add("active");
@@ -76,14 +75,4 @@ export default class extends Controller {
       current.parentNode.insertBefore(next, current);
     }
   }
-
-  // showWebpage(event){
-  //   const offerType = this.offerTypeTarget.value
-  //   const external = this.externalTarget.checked
-  //   if (offerType !== "order_required" || external ){
-  //     this.webpageTarget.classList.remove("hidden-fields");
-  //   } else {
-  //     this.webpageTarget.classList.add("hidden-fields");
-  //   }
-  // }
 }

--- a/app/models/concerns/offerable.rb
+++ b/app/models/concerns/offerable.rb
@@ -16,16 +16,11 @@ module Offerable
     validates :description, presence: true
 
     def external?
-      order_required? && !effective_internal?
+      order_required? && !internal
     end
 
     def orderable?
-      order_required? && effective_internal?
+      order_required? && internal
     end
-
-    private
-      def effective_internal?
-        internal || order_url.blank?
-      end
   end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -47,6 +47,7 @@ class Offer < ApplicationRecord
   validates :service, presence: true
   validates :iid, presence: true, numericality: true
   validates :status, presence: true
+  validates :order_url, mp_url: true, if: :order_url?
 
   validate :primary_oms_exists?, if: -> { primary_oms_id.present? }
   validate :proper_oms?, if: -> { primary_oms.present? }

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -112,7 +112,6 @@ class ProjectItem < ApplicationRecord
       self.order_type = offer&.order_type
       self.name = offer&.name
       self.description = offer&.description
-      self.webpage = offer&.webpage
       self.voucherable = offer&.voucherable
       self.order_url = offer&.order_url
       self.internal = offer&.internal

--- a/app/policies/api/v1/offer_policy.rb
+++ b/app/policies/api/v1/offer_policy.rb
@@ -26,7 +26,7 @@ class Api::V1::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name, :description, :webpage, :order_type, :order_url, :primary_oms_id, :internal, oms_params: {},
+    [:name, :description, :order_type, :order_url, :primary_oms_id, :internal, oms_params: {},
      parameters: [:id, :type, :label, :description, :unit, :value_type, :value,
                   config: [:mode, :minimum, :maximum, :minItems, :maxItems, :exclusiveMinimum,
                            :exclusiveMaximum, :start_price, :step_price, :currency, values: []

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -44,7 +44,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:id, :name, :description, :webpage, :order_type, :order_url, :internal,
+    [:id, :name, :description, :order_type, :order_url, :internal,
      :primary_oms_id, oms_params: {},
      parameters_attributes: [:type, :name, :hint, :min, :max,
                              :unit, :value_type, :start_price, :step_price, :currency,

--- a/app/policies/ordering_configuration/offer_policy.rb
+++ b/app/policies/ordering_configuration/offer_policy.rb
@@ -28,7 +28,7 @@ class OrderingConfiguration::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:id, :name, :description, :webpage, :order_type, :order_url, :default, :internal,
+    [:id, :name, :description, :order_type, :order_url, :default, :internal,
      :primary_oms_id, oms_params: {},
      parameters_attributes: [:type, :name, :hint, :min, :max,
                              :unit, :value_type, :start_price, :step_price, :currency,

--- a/app/serializers/api/v1/offer_serializer.rb
+++ b/app/serializers/api/v1/offer_serializer.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::OfferSerializer < ActiveModel::Serializer
   attribute :iid, key: :id
-  attributes :name, :description, :parameters, :order_type, :webpage, :order_url
+  attributes :name, :description, :parameters, :order_type, :order_url
   attribute  :internal, if: -> { object.order_required? }
   attribute :primary_oms_id, if: -> { object.internal? }
   # TODO: https://github.com/cyfronet-fid/marketplace/issues/1964

--- a/app/services/service/create.rb
+++ b/app/services/service/create.rb
@@ -12,7 +12,8 @@ class Service::Create
                                 order_type: @service.order_type || "open_access",
                                 order_url: @service.order_url,
                                 internal: @service.order_url.blank?,
-                                webpage: @service.webpage_url, status: "published", service: @service)).call
+                                status: "published",
+                                service: @service)).call
     @service
   end
 end

--- a/app/services/service/update.rb
+++ b/app/services/service/update.rb
@@ -10,14 +10,12 @@ class Service::Update
     if @service.offers.size == 1
       Offer::Update.new(@service.offers.first, { order_type: @params[:order_type] || @service.order_type,
                                    order_url: @params[:order_url] || @service.order_url,
-                                   webpage: @params[:webpage_url] || @service.webpage_url,
                                    status: "published" }).call
     elsif @service.offers.size == 0
       Offer::Create.new(Offer.new(name: "Offer",
                                   description: "#{@params[:name] || @service.name} Offer",
                                   order_type: @params[:order_type] || @service.order_type,
                                   order_url: @params[:order_url] || @service.order_url,
-                                  webpage: @params[:webpage_url] || @service.webpage_url,
                                   status: "published",
                                   service: @service)).call
     end

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -9,7 +9,6 @@
       input_html: { "data-target": "ordering.orderType",
                     "data-action": "ordering#updateVisibility",
                     class: "form-control-lg col-lg-6" }
-    = f.input :webpage, label: _("Offer website"), input_html: { class: "form-control-lg" }
     = f.input :internal,
       wrapper_html: { "data-target": "ordering.internalWrapper" },
       input_html: { "data-target": "ordering.internal",

--- a/app/views/backoffice/services/offers/_primary_oms_form.haml
+++ b/app/views/backoffice/services/offers/_primary_oms_form.haml
@@ -9,9 +9,16 @@
 %div{ "data-target": "ordering.omsParamsContainer" }
   = form.simple_fields_for Offer::OMSParams.new(offer.oms_params) do |field|
     - available_omses.each do |oms|
-      - oms.custom_params&.each do |param, param_options|
-        - is_missing = param_options["mandatory"] && offer.errors[:oms_params].present? && offer.oms_params[param].blank?
-        = field.input param,
-          required: param_options["mandatory"],
-          wrapper_html: { "data-oms-id": oms.id },
-          input_html: { class:  is_missing ? "is-invalid" : "" }
+      - if oms.custom_params&.present?
+        %label{ "data-oms-id": oms.id }
+          Below we show parameters specified by #{oms.name}, which values will be sent to it alongside
+          the orders for your offer.
+        - oms.custom_params.each do |param, param_options|
+          - is_missing = param_options["mandatory"] && offer.errors[:oms_params].present? && offer.oms_params[param].blank?
+          = field.input param,
+            required: param_options["mandatory"],
+            wrapper_html: { "data-oms-id": oms.id },
+            input_html: { class:  is_missing ? "is-invalid" : "" }
+      - else
+        %label{ "data-oms-id": oms.id }
+          #{oms.name} doesn't specify any parameters.

--- a/app/views/backoffice/services/offers/edit.html.haml
+++ b/app/views/backoffice/services/offers/edit.html.haml
@@ -1,4 +1,5 @@
 - content_for :title, _("Edit Offer")
+- breadcrumb :backoffice_offer_edit, @offer
 .container
   .mb-4.pb-4.border-header
     %h1= _("Edit offer")

--- a/app/views/backoffice/services/offers/new.html.haml
+++ b/app/views/backoffice/services/offers/new.html.haml
@@ -1,5 +1,5 @@
 - content_for :title, _("Create new offer")
-- breadcrumb :backoffice_service_new
+- breadcrumb :backoffice_offer_new, @service
 .container
   .mb-4.pb-4.border-header
     %h1= _("Create new offer")

--- a/app/views/layouts/ordering_configuration.html.haml
+++ b/app/views/layouts/ordering_configuration.html.haml
@@ -10,5 +10,6 @@
       = render "layouts/ordering_configuration/top"
     %main
       .container
+        = render "layouts/breadcrumb"
         = yield
   = render "layouts/footer", root_categories: @root_categories

--- a/app/views/services/ordering_configuration/offers/edit.html.haml
+++ b/app/views/services/ordering_configuration/offers/edit.html.haml
@@ -1,4 +1,5 @@
 - content_for :title, _("Edit Offer")
+- breadcrumb :ordering_configuration_offer_edit, @offer
 .container
   .mb-4.pb-4.border-header
     %h1= _("Edit offer")

--- a/app/views/services/ordering_configuration/offers/new.html.haml
+++ b/app/views/services/ordering_configuration/offers/new.html.haml
@@ -1,5 +1,5 @@
 - content_for :title, _("Create new offer")
-- breadcrumb :backoffice_service_new
+- breadcrumb :ordering_configuration_offer_new, @service
 .container
   .mb-4.pb-4.border-header
     %h1= _("Create new offer")

--- a/config/breadcrumbs/backoffice.rb
+++ b/config/breadcrumbs/backoffice.rb
@@ -56,6 +56,16 @@ crumb :backoffice_service_preview do |service|
   end
 end
 
+crumb :backoffice_offer_new do |service|
+  link "New", new_backoffice_service_offer_path(service)
+  parent :backoffice_service, service
+end
+
+crumb :backoffice_offer_edit do |offer|
+  link "Edit", edit_backoffice_service_offer_path(offer)
+  parent :backoffice_service, offer.service
+end
+
 crumb :backoffice_scientific_domains  do
   link "Scientific Domains", backoffice_scientific_domains_path
   parent :backoffice_root

--- a/config/breadcrumbs/marketplace.rb
+++ b/config/breadcrumbs/marketplace.rb
@@ -32,6 +32,16 @@ crumb :ordering_configuration do |service|
   parent :service, service
 end
 
+crumb :ordering_configuration_offer_new do |service|
+  link "New", new_service_ordering_configuration_offer_path(service)
+  parent :ordering_configuration, service
+end
+
+crumb :ordering_configuration_offer_edit do |offer|
+  link "Edit", edit_service_ordering_configuration_offer_path(offer)
+  parent :ordering_configuration, offer.service
+end
+
 crumb :resource_details do |service|
   link "Details", service_details_path(service)
   if params[:from]

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -91,7 +91,7 @@ en:
         manual_url: |
           Url should start with http or https [e.g. http://webpage.org]
         webpage_url: |
-          Url should start with http or https [e.g. http://webpage.org]</br>
+          Url should start with http or https [e.g. http://webpage.org]<br/>
           This url will be available under "Webpage" in Support section in the service view
         sla_url: |
           Url should start with http or https [e.g. http://webpage.org]
@@ -115,8 +115,10 @@ en:
           Url should start with http or https [e.g. http://webpage.org]
       offer:
         order_url: |
-          Url should start with http or https [e.g. http://webpage.org].
-          This url will be available on service order information step
+          Url should start with http or https [e.g. http://webpage.org].<br/>
+          Given URL will be used in the offer order/access mechanism - on the resource access information step this URL
+          will be used under 'Go to the order website' / 'Go to the resource' button (depending on the offer order
+          type). If it isn't specified it will fall back to the resource's webpage URL.
       project_item:
         additional_comment: |
           Use it to describe your additional comments/questions related to the

--- a/config/locales/views/projects/en.yml
+++ b/config/locales/views/projects/en.yml
@@ -14,7 +14,7 @@ en:
     empty_project:
       description_html: |
         <h3>
-          You have no resources </br>
+          You have no resources <br/>
           in this project yet.
         </h3>
         <ul class= "simple-list">

--- a/config/locales/views/services/en.yml
+++ b/config/locales/views/services/en.yml
@@ -138,7 +138,7 @@ en:
           cancel: Cancel order and quit
         description_html: |
           Please select a Project and review the summary below. Once you submit the order,
-          your request will be sent to a resource provider. </br>
+          your request will be sent to a resource provider. <br/>
           The order status will be visible at your Project space.
       other:
         order:

--- a/db/data.yml
+++ b/db/data.yml
@@ -1927,7 +1927,7 @@ services:
           1:
             name: GEOSS Portal
             description: *notSpecified
-            webpage: http://geosspublish.uat.esaportal.eu/knowledge-producer
+            order_url: http://geosspublish.uat.esaportal.eu/knowledge-producer
     GEO DAB:
         name: &geossDab GEO DAB
         parents: *sharingAndDicoveryParent
@@ -1969,7 +1969,7 @@ services:
           1:
             name: GEOSS DAB
             description: *notSpecified
-            webpage: http://www.geodab.net
+            order_url: http://www.geodab.net
     VLO:
         name: &vloService Virtual Language Observatory
         parents: *sharingAndDicoveryParent
@@ -2083,7 +2083,7 @@ services:
             name: LRS
             description: |
               A web application that suggests language analysis tools for specific data sets.
-            webpage: https://switchboard.clarin.eu/
+            order_url: https://switchboard.clarin.eu/
     VCR:
         name: &vcrService Virtual Collection Registry
         parents: *sharingAndDicoveryParent
@@ -3066,7 +3066,7 @@ services:
           1:
             name: New Particle Formation Event Analysis
             description: *notSpecified
-            webpage: https://services.d4science.org/web/particleformation/
+            order_url: https://services.d4science.org/web/particleformation/
     ENES Climate Analytics Service:
         name: &enes ENES Climate Analytics Service
         parents: *processingAndAnalysisParent
@@ -3449,7 +3449,7 @@ services:
               and life science area into a virtual research community at a worldwide level and provide them
               with a platform integrating and streamlining the computational approaches
               necessary for data analysis and modelling.
-            webpage: http://haddock.science.uu.nl/enmr/services/HADDOCK2.2
+            order_url: http://haddock.science.uu.nl/enmr/services/HADDOCK2.2
     PowerFit:
         name: &powerFit PowerFit
         parents: *processingAndAnalysisParent
@@ -3478,7 +3478,7 @@ services:
         offers:
           1:
             <<: *wenMRService
-            webpage: http://haddock.science.uu.nl/enmr/services/POWERFIT
+            order_url: http://haddock.science.uu.nl/enmr/services/POWERFIT
     DisVis:
         name: &disVis DisVis
         parents: *processingAndAnalysisParent
@@ -3509,7 +3509,7 @@ services:
         offers:
           1:
             <<: *wenMRService
-            webpage: http://haddock.science.uu.nl/enmr/services/DISVIS
+            order_url: http://haddock.science.uu.nl/enmr/services/DISVIS
     CS-ROSETTA:
         name: &csRoseta CS-ROSETTA
         parents: *processingAndAnalysisParent
@@ -3539,7 +3539,7 @@ services:
         offers:
           1:
             <<: *wenMRService
-            webpage: https://haddock.science.uu.nl/enmr/services/CS-ROSETTA3/
+            order_url: https://haddock.science.uu.nl/enmr/services/CS-ROSETTA3/
     AMBER:
         name: &amber AMBER
         parents: *processingAndAnalysisParent
@@ -3575,7 +3575,7 @@ services:
         offers:
           1:
             <<: *wenMRService
-            webpage: http://py-enmr.cerm.unifi.it/access/index
+            order_url: http://py-enmr.cerm.unifi.it/access/index
     FANTEN:
         name: &fanten FANTEN
         parents: *processingAndAnalysisParent
@@ -3607,7 +3607,7 @@ services:
         offers:
           1:
             <<: *wenMRService
-            webpage: http://abs.cerm.unifi.it:8080
+            order_url: http://abs.cerm.unifi.it:8080
     SpotOn:
         name: &spotOn SpotOn
         parents: *processingAndAnalysisParent
@@ -3637,7 +3637,7 @@ services:
         offers:
           1:
             <<: *wenMRService
-            webpage: https://haddock.science.uu.nl/enmr/services/SPOTON
+            order_url: https://haddock.science.uu.nl/enmr/services/SPOTON
     GEP - HRCM:
         name: &gepHRCM GEP - High-Resolution Change Monitoring for the Alpine Region
         parents: *processingAndAnalysisParent
@@ -3671,7 +3671,7 @@ services:
             1:
                 name: GEP Portal
                 description: description
-                webpage: https://geohazards-tep.eo.esa.int/
+                order_url: https://geohazards-tep.eo.esa.int/
     GEP - EO:
         name: &gepEO GEP - EO Services for Earthquake Response and Landslides Analysis
         parents: *sharingAndDicoveryParent
@@ -3703,7 +3703,7 @@ services:
             1:
                 name: GEP Portal
                 description: description
-                webpage: https://geohazards-tep.eo.esa.int/#!
+                order_url: https://geohazards-tep.eo.esa.int/#!
 
     EODC JupyterHub for global Copernicus data:
         name: &eodcJH EODC JupyterHub for global Copernicus data
@@ -3738,7 +3738,7 @@ services:
             name: JupyterHub
             description: |
               EODC JupyterHub provides access to the global EODC Copernicus Data Archive.
-            webpage: https://jupyterhub.eodc.eu
+            order_url: https://jupyterhub.eodc.eu
 #              Eliminate the barrier to get access to and to start to develop algorithms in view of remote sensing data.
 #              Full access to EODC Copernicus satellite data archive.
 #              No need to setup a VM to access data archive.Simple python dev. environment.
@@ -3802,7 +3802,7 @@ services:
             name: EODC Data Catalogue Service
             description: |
               Catalog Service for the Web (CSW)
-            webpage: https://csw.eodc.eu
+            order_url: https://csw.eodc.eu
     Sentinel hub:
         name: &sentinelHub Sentinel Hub
         parents: *sharingAndDicoveryParent
@@ -3954,7 +3954,7 @@ services:
                 name: Cloudferro
                 description: |
                     cloudferro
-                webpage: https://discovery.creodias.eu/dataset
+                order_url: https://discovery.creodias.eu/dataset
     CloudFerro Infrastructure:
         name: &cfi CloudFerro Infrastructure
         parents: [*computeParent, *storageParent, *processingAndAnalysisParent]
@@ -3994,7 +3994,7 @@ services:
                 name: Cloudferro2
                 description: |
                     cloudferro
-                webpage: https://creodias.eu
+                order_url: https://creodias.eu
     Cloudferro Data related Services - EO Finder:
         name: &cfdrsEOF Cloudferro Data related Services - EO Finder
         parents: [*dataManagementParent]
@@ -4026,7 +4026,7 @@ services:
                 name: Cloudferro3
                 description: |
                     cloudferro
-                webpage: https://finder.creodias.eu/www
+                order_url: https://finder.creodias.eu/www
     Cloudferro Data related Services - EO browser:
         name: &cfdrsEOB Cloudferro Data related Services - EO browser
         parents: *dataManagementParent
@@ -4069,7 +4069,7 @@ services:
                 name: Cloudferro4
                 description: |
                     cloudferro
-                webpage: https://browser.creodias.eu
+                order_url: https://browser.creodias.eu
     Check-in:
         name: &checkIn EGI Check-in
         parents: *securityAndOperationsParent
@@ -4412,7 +4412,7 @@ services:
         1:
           name: General access
           description: "a"
-          webpage: https://services.d4science.org/web/alienandinvasivespecies
+          order_url: https://services.d4science.org/web/alienandinvasivespecies
 
 #    OpenAIRE:
 #      name: &openAIRE OpenAIRE

--- a/db/migrate/20210513095954_remove_webpage.rb
+++ b/db/migrate/20210513095954_remove_webpage.rb
@@ -1,0 +1,21 @@
+class RemoveWebpage < ActiveRecord::Migration[6.0]
+  def change
+    exec_update "UPDATE services SET order_url = '' WHERE order_url IS NULL"
+    change_column :services, :order_url, :string, null: false, default: ""
+
+    exec_update "UPDATE offers SET order_url = '' WHERE order_url IS NULL"
+    change_column :offers, :order_url, :string, null: false, default: ""
+
+    exec_update "UPDATE project_items SET order_url = '' WHERE order_url IS NULL"
+    change_column :project_items, :order_url, :string, null: false, default: ""
+
+    exec_update "UPDATE offers SET webpage = '' WHERE webpage IS NULL"
+    exec_update "UPDATE offers SET order_url = webpage WHERE order_url = ''"
+    remove_column :offers, :webpage
+
+    # Do the same for project_items, but use the values from project_item, not from current offer.
+    # This is consistent with our wanting to have a partial "snapshot" of offer saved in the project_item.
+    exec_update "UPDATE project_items SET order_url = webpage WHERE order_url = ''"
+    remove_column :project_items, :webpage
+  end
+end

--- a/db/migrate/20210517142836_effective_internal.rb
+++ b/db/migrate/20210517142836_effective_internal.rb
@@ -1,0 +1,6 @@
+class EffectiveInternal < ActiveRecord::Migration[6.0]
+  def change
+    exec_update "UPDATE offers SET internal = true WHERE order_type = 'order_required' AND order_url = ''"
+    exec_update "UPDATE project_items SET internal = true WHERE order_type = 'order_required' AND order_url = ''"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_113134) do
+ActiveRecord::Schema.define(version: 2021_05_17_142836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,9 +186,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_113134) do
     t.boolean "voucherable", default: false, null: false
     t.string "status"
     t.string "order_type", null: false
-    t.string "webpage"
     t.boolean "internal", default: false
-    t.string "order_url"
+    t.string "order_url", default: "", null: false
     t.boolean "default", default: false
     t.jsonb "oms_params"
     t.bigint "primary_oms_id"
@@ -255,10 +254,9 @@ ActiveRecord::Schema.define(version: 2021_04_27_113134) do
     t.string "name", null: false
     t.text "description", null: false
     t.string "order_type", null: false
-    t.string "webpage"
     t.boolean "voucherable", default: false, null: false
     t.boolean "internal", default: false
-    t.string "order_url"
+    t.string "order_url", default: "", null: false
     t.string "status", default: "created", null: false
     t.jsonb "user_secrets", default: {}, null: false
     t.index ["offer_id"], name: "index_project_items_on_offer_id"
@@ -501,7 +499,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_113134) do
     t.bigint "resource_organisation_id", null: false
     t.string "status_monitoring_url"
     t.string "maintenance_url"
-    t.string "order_url"
+    t.string "order_url", default: "", null: false
     t.string "payment_model_url"
     t.string "pricing_url"
     t.string "security_contact_email", default: "", null: false

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -87,7 +87,7 @@ namespace :dev do
                       scientific_domains: domain,
                       providers: providers,
                       order_type: order_type,
-                      order_url: hash["order_url"] || hash["webpage_url"],
+                      order_url: hash["order_url"] || "",
                       resource_organisation: resource_organisation,
                       webpage_url: hash["webpage_url"],
                       manual_url: hash["manual_url"],
@@ -127,11 +127,13 @@ namespace :dev do
 
   def create_offers(service, offers_hash)
     offers_hash && offers_hash.each do |_, h|
+      effective_order_url = h["order_url"] || service.order_url
       service.offers.create!(name: h["name"],
                             description: h["description"],
-                            webpage: h["webpage"],
                             parameters: Parameter::Array.load(h["parameters"] || []),
                             order_type: h["order_type"].blank? ? service.order_type : h["order_type"],
+                            order_url: effective_order_url.present? ? effective_order_url : "",
+                            internal: effective_order_url.blank?,
                             status: :published)
       puts "    - #{h["name"]} offer generated"
     end

--- a/spec/components/services/inline_order_url_component_spec.rb
+++ b/spec/components/services/inline_order_url_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Services::InlineOrderUrlComponent, type: :component do
     expect(page).to have_link("Go to the order website")
   end
 
-  it "hides button with webpage if order_required order_type" do
+  it "hides button with order_url if order_required order_type" do
     offer = create(:offer, internal: true)
 
     render_inline(Services::InlineOrderUrlComponent.new(offerable: offer))

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     sequence(:description) { |n| "offer #{n} description" }
     sequence(:service) { |n| create(:service, offers_count: 1) }
     sequence(:status) { :published }
-    sequence(:webpage) { |n| "http://webpage#{n}.invalid" }
     sequence(:order_type) { :order_required }
     sequence(:internal) { true }
 

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -276,11 +276,16 @@ RSpec.feature "Services in backoffice" do
       parameters = service.offers.first.parameters
       parameter = parameters.first
 
+      expect(service.offers.count).to eq(1)
+      service.offers.each do |offer|
+        expect(offer.order_url).to_not eq("http://order.com")
+        expect(offer.order_type).to_not eq("fully_open_access")
+      end
+
       visit backoffice_service_path(service)
       click_on "Edit resource"
 
       fill_in "Name", with: "updated name"
-      fill_in "Webpage url", with: "http://service.com"
       fill_in "Order url", with: "http://order.com"
       select "fully_open_access", from: "Order type"
 
@@ -294,9 +299,8 @@ RSpec.feature "Services in backoffice" do
 
       expect(page).to have_text(offer.parameters.first.name)
 
-      expect(offer.webpage).to eq(service.webpage_url)
-      expect(offer.order_url).to eq(service.order_url)
-      expect(offer.order_type).to eq(service.order_type)
+      expect(offer.order_url).to eq("http://order.com")
+      expect(offer.order_type).to eq("fully_open_access")
 
       expect(offer.parameters.size).to eq(1)
 
@@ -352,8 +356,11 @@ RSpec.feature "Services in backoffice" do
 
       service.reload
 
-      expect(service.offers.last.order_type).to eq("order_required")
-      expect(service.offers.last.webpage).to_not eq("http://google.com")
+      expect(service.offers.count).to eq(1)
+      service.offers.each do |offer|
+        expect(offer.order_type).to eq("order_required")
+        expect(offer.order_url).to_not eq("http://google.com")
+      end
 
       visit backoffice_service_path(service)
 
@@ -367,8 +374,10 @@ RSpec.feature "Services in backoffice" do
       click_on "Update Resource"
 
       service.reload
-      expect(service.offers.first.order_type).to eq(service.order_type)
-      expect(service.offers.first.webpage).to eq(service.webpage_url)
+      service.offers.each do |offer|
+        expect(offer.order_type).to eq("open_access")
+        expect(offer.order_url).to eq("http://google.com")
+      end
     end
 
     scenario "I can see warning about no published offers", js: true do

--- a/spec/features/project_services_spec.rb
+++ b/spec/features/project_services_spec.rb
@@ -22,25 +22,31 @@ RSpec.feature "Project services" do
     expect(page).to have_link("Details")
   end
 
-  [:open_access, :external].each do |type|
-    scenario "I cannot see timeline for #{type} order" do
-      offer = create(:offer, service: service, order_type: type == :external ? :order_required : type,
-                     order_url: type == :external ? "http://order.com" : nil)
-      project_item = create(:project_item, offer: offer, project: project)
+  scenario "I cannot see timeline for open_access order" do
+    offer = create(:open_access_offer, service: service)
+    project_item = create(:project_item, offer: offer, project: project)
 
-      visit project_service_path(project, project_item)
+    visit project_service_path(project, project_item)
 
-      expect(page).to_not have_link("Timeline")
-    end
+    expect(page).to_not have_link("Timeline")
   end
 
-  scenario "Project service is immute to the offer change" do
+  scenario "I cannot see timeline for external order" do
+    offer = create(:external_offer, service: service)
+    project_item = create(:project_item, offer: offer, project: project)
+
+    visit project_service_path(project, project_item)
+
+    expect(page).to_not have_link("Timeline")
+  end
+
+  scenario "Project service is immutable to the offer change" do
     offer = create(:offer, service: service,
                    order_type: :open_access,
-                   webpage: "http://old.pl",
+                   order_url: "http://old.pl",
                    voucherable: false)
     project_item = create(:project_item, offer: offer, project: project)
-    offer.update(order_type: :order_required, voucherable: true, webpage: "http://new.pl")
+    offer.update(order_type: :order_required, voucherable: true, order_url: "http://new.pl")
 
     visit project_service_path(project, project_item)
 

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -14,21 +14,6 @@ RSpec.describe Offer do
     it { should have_many(:project_items).dependent(:restrict_with_error) }
   end
 
-  context "is open access" do
-    subject { build(:offer, order_type: :open_access) }
-    it { should_not validate_presence_of(:webpage) }
-  end
-
-  context "is external" do
-    subject { build(:offer, order_type: :order_required, order_url: "http://order.com") }
-    it { should_not validate_presence_of(:webpage) }
-  end
-
-  context "is orderable" do
-    subject { build(:offer, order_type: :order_required) }
-    it { should_not validate_presence_of(:webpage) }
-  end
-
   context "OMS dependencies" do
     it "validates properly against primary oms" do
       oms = create(:oms, custom_params: { a: { mandatory: false }, b: { mandatory: true, default: "XD" } })

--- a/spec/serializers/api/v1/offer_serializer_spec.rb
+++ b/spec/serializers/api/v1/offer_serializer_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Api::V1::OfferSerializer do
         }
       ],
       order_type: offer.order_type,
-      webpage: offer.webpage,
       order_url: offer.order_url,
       internal: true,
       primary_oms_id: offer.primary_oms.id,
@@ -59,7 +58,6 @@ RSpec.describe Api::V1::OfferSerializer do
         }
       ],
       order_type: offer.order_type,
-      webpage: offer.webpage,
       order_url: offer.order_url,
       internal: false
     }
@@ -80,7 +78,6 @@ RSpec.describe Api::V1::OfferSerializer do
       description: offer.description,
       order_type: offer.order_type,
       parameters: [],
-      webpage: offer.webpage,
       order_url: offer.order_url
     }
 

--- a/spec/services/service/create_spec.rb
+++ b/spec/services/service/create_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Service::Create do
     expect(offer.description).to eq("#{service.name} Offer")
     expect(offer.order_type).to eq(service.order_type)
     expect(offer.order_url).to eq(service.order_url)
-    expect(offer.webpage).to eq(service.webpage_url)
     expect(offer.status).to eq("published")
   end
 end

--- a/spec/services/service/update_spec.rb
+++ b/spec/services/service/update_spec.rb
@@ -15,10 +15,7 @@ RSpec.describe Service::Update do
     service = create(:service, offers: [create(:offer)])
     offer = service.offers.first
 
-
-
     described_class.new(service, name: "new name",
-                        webpage_url: "http://service.valid",
                         order_url: "http://order.valid",
                         order_type: "fully_open_access").call
 
@@ -26,7 +23,6 @@ RSpec.describe Service::Update do
 
     expect(offer.order_type).to eq("fully_open_access")
     expect(offer.order_url).to eq("http://order.valid")
-    expect(offer.webpage).to eq("http://service.valid")
     expect(offer.status).to eq("published")
   end
 
@@ -36,7 +32,6 @@ RSpec.describe Service::Update do
     expect(service.offers.size).to eq(0)
 
     described_class.new(service, name: "new name",
-                        webpage_url: "http://service.valid",
                         order_url: "http://order.valid",
                         order_type: "fully_open_access").call
 
@@ -48,7 +43,6 @@ RSpec.describe Service::Update do
 
     expect(offer.order_type).to eq("fully_open_access")
     expect(offer.order_url).to eq("http://order.valid")
-    expect(offer.webpage).to eq("http://service.valid")
     expect(offer.status).to eq("published")
   end
 end


### PR DESCRIPTION
Set the order_url columns to `null: false, default: ""` to avoid
situations where there are records with order_url="" and order_url=null.

Remove column webpage from tables offers and project_items, applying the
same migration method to both, i.e. `order_url = order_url || webpage`.

Remove webpage from offer form, policies, Offer API and
offer_controller.js.

In webpage helper, return order_url and fall back to
service.webpage_url in case order_url.blank?.

Don't propagate service.webpage_url to offer.webpage, as the former
doesn't exist anymore. There is no need to populate offer.order_url with
it, as the order button url falls back to it.

Remove webpage from data.yml, as it was mirroring service.webpage_url
anyway and it doesn't make sense to move it to order_url field.

Correct `</br`> to `<br/>` in texts.

Closes: #1988.

## How to test

Make sure the logic around `orderable?` (i.e. offers and project_items for which `order_type=order_required && internal`) is correct. For example when link to service is presented to user (e.g. in project_items list), that "Order history" is shown for appropriate project_items, and that "Go to the order website" and "Go to the resource" work ok.

### For an offer with `internal=false` (regardless of order_type)

With `order_url` set, the `order_url` value should override `offer.service.webpage_url` when creating the external link button in the ordering wizard.
Otherwise, when order_url will be blank then the button should fall back to `offer.service.webpage_url`.

### For an offer with `internal=true`

The external link button shouldn't be shown.