### PR TITLE
Use consistent exemplary domain and move hints to yml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Offer webpage field (@jswk)
 
 ### Fixed
+- Improve consistency of exemplary domains in form hints (@jswk)
 - Change img background at /backoffice/providers/<id> from black to transparent on resize (@danielkryska)
 - Add error note on a scientific domain with services deletion (@danielkryska)
 - Change error message at order summary to general - better UX (@danielkryska)

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ configuring JIRA collector in JIRA instance. Sample declaration of this variable
 Note the space separating both scripts sources
 
 ```
-JIRA_COLLECTOR_SCRIPTS="https://jira.domain.com/s/xxx-CDN/xx/00/xxx/x.x.x.x/_/download/batch/com.atlassian.plugins.jquery:jquery/com.atlassian.plugins.jquery:jquery.js?collectorId=00000 https://jira.domain.com/s/xxx/xxx/0/xxx/x.x.x/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-UK&collectorId=yyyyy"
+JIRA_COLLECTOR_SCRIPTS="https://jira.example.com/s/xxx-CDN/xx/00/xxx/x.x.x.x/_/download/batch/com.atlassian.plugins.jquery:jquery/com.atlassian.plugins.jquery:jquery.js?collectorId=00000 https://jira.example.com/s/xxx/xxx/0/xxx/x.x.x/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-UK&collectorId=yyyyy"
 ```
 
 ## Sentry integration

--- a/app/views/projects/_customer_typology_fields.html.haml
+++ b/app/views/projects/_customer_typology_fields.html.haml
@@ -1,4 +1,4 @@
-= f.input :email, hint: _("Email address in your institute's domain"),
+= f.input :email,
   wrapper_html: { class: "hidden-fields",
   "data-target" => "project.input project.research project.project project.singleUser project.privateCompany" },
   input_html: { class: "col-lg-6 form-control-lg" }
@@ -29,13 +29,10 @@
   "data-target" => "project.partnershipCountries", "multiple" => "true" }
 = f.input :project_website_url,
   wrapper_html: { class: "hidden-fields", "data-target" => "project.project project.input" },
-  input_html: { "data-target" => "project.projectWebsiteUrl", class: "col-lg-6 form-control-lg" },
-  hint: _("Url should start with http or https [e.g. http://webpage.org]")
+  input_html: { "data-target" => "project.projectWebsiteUrl", class: "col-lg-6 form-control-lg" }
 = f.input :webpage,
   wrapper_html: { class: "hidden-fields", "data-target" => "project.singleUser project.research project.input" },
-  input_html: { "data-target" => "project.webpage", class: "col-lg-6 form-control-lg" },
-  hint: _("Url should start with http or https [e.g. http://webpage.org]")
+  input_html: { "data-target" => "project.webpage", class: "col-lg-6 form-control-lg" }
 = f.input :company_website_url,
   wrapper_html: { class: "hidden-fields", "data-target" => "project.privateCompany project.input" },
-  input_html: { "data-target" => "project.companyWebsiteUrl", class: "col-lg-6 form-control-lg" },
-  hint: _("Url should start with http or https [e.g. http://webpage.org]")
+  input_html: { "data-target" => "project.companyWebsiteUrl", class: "col-lg-6 form-control-lg" }

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -4,7 +4,7 @@
 
 # ActiveSupport::Reloader.to_prepare do
 #   ApplicationController.renderer.defaults.merge!(
-#     http_host: 'example.org',
+#     http_host: 'example.com',
 #     https: false
 #   )
 # end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -85,37 +85,41 @@ en:
         body: Preferred length of description is up to 140 characters
       service:
         training_information_url: |
-          Url should start with http or https [e.g. http://webpage.org]
+          Url should start with http or https [e.g. https://example.com]
         helpdesk_url: |
-          Url should start with http or https [e.g. http://webpage.org]
+          Url should start with http or https [e.g. https://example.com]
         manual_url: |
-          Url should start with http or https [e.g. http://webpage.org]
+          Url should start with http or https [e.g. https://example.com]
         webpage_url: |
-          Url should start with http or https [e.g. http://webpage.org]<br/>
+          Url should start with http or https [e.g. https://example.com]<br/>
           This url will be available under "Webpage" in Support section in the service view
         sla_url: |
-          Url should start with http or https [e.g. http://webpage.org]
+          Url should start with http or https [e.g. https://example.com]
         access_policies_url: |
-          Url should start with http or https [e.g. http://webpage.org]
+          Url should start with http or https [e.g. https://example.com]
         terms_of_use_url: |
-          Url should start with http or https [e.g. http://webpage.org]
+          Url should start with http or https [e.g. https://example.com]
         tag_list: |
           Use "," to separate tags
         order_target: |
-          Email address - eg. email@domain.com
+          Email address [e.g. email@example.com]
         logo: |
           Supported logo formats: png, gif, jpg, jpeg, pjpeg, tiff,
           vnd.adobe.photoshop and vnd.microsoft.icon
         helpdesk_email: |
-          Email address - eg. email@domain.com
+          Email address [e.g. email@example.com]
       project:
+        email: |
+          Email address in your institute's domain [e.g. email@example.com]
         project_website_url: |
-          Url should start with http or https [e.g. http://webpage.org]
+          Url should start with http or https [e.g. https://example.com]
+        webpage: |
+          Url should start with http or https [e.g. https://example.com]
         company_website_url: |
-          Url should start with http or https [e.g. http://webpage.org]
+          Url should start with http or https [e.g. https://example.com]
       offer:
         order_url: |
-          Url should start with http or https [e.g. http://webpage.org].<br/>
+          Url should start with http or https [e.g. https://example.com].<br/>
           Given URL will be used in the offer order/access mechanism - on the resource access information step this URL
           will be used under 'Go to the order website' / 'Go to the resource' button (depending on the offer order
           type). If it isn't specified it will fall back to the resource's webpage URL.

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Services in backoffice" do
       fill_in "Training information url", with: "https://sample.url"
       fill_in "Restrictions", with: "Reaserch affiliation needed"
       fill_in "Activate message", with: "Welcome!!!"
-      fill_in "Resource Order Target", with: "email@domain.com"
+      fill_in "Resource Order Target", with: "email@example.com"
       fill_in "service_certifications_0", with: "ISO-639"
       fill_in "service_standards_0", with: "standard"
       fill_in "service_open_source_technologies_0", with: "opensource"
@@ -100,7 +100,7 @@ RSpec.feature "Services in backoffice" do
                .and change { Offer.count }.by(1)
 
 
-      expect(user.owned_services.last.order_target).to eq("email@domain.com")
+      expect(user.owned_services.last.order_target).to eq("email@example.com")
 
       expect(page).to have_content("service name")
       expect(page).to have_content("service description")

--- a/spec/models/jira/client_spec.rb
+++ b/spec/models/jira/client_spec.rb
@@ -94,7 +94,7 @@ describe Jira::Client do
                           offer: create(:open_access_offer,
                                         name: "off1",
                                         service: create(:open_access_service,
-                                                        order_target: "email@domain.com",
+                                                        order_target: "email@example.com",
                                                         name: "s1",
                                                         categories: [create(:category, name: "cat1")])),
                           project: create(:project, user: user,
@@ -118,7 +118,7 @@ describe Jira::Client do
                           "offer" => "off1",
                           "attributes" => {}
                         }.to_json,
-                        "SO-ServiceOrderTarget-1" => "email@domain.com",
+                        "SO-ServiceOrderTarget-1" => "email@example.com",
                         "SO-OfferType-1" => { "id" => "20006" } }
 
 


### PR DESCRIPTION
Before, in some places domain.com was used, which is a hosting company,
and in another webpage.org, which is also a domain parked by another
company.

Instead, use the generic IANA-reserved domain for examples, see
https://www.iana.org/domains/reserved.

## How to test

1. Go to a new project (or existing one) form and verify that fields have correct hints:
    1. email: "Email address in your institute's domain [e.g. email@example.com]"
    2. when selected "Customer typology" = "Representing a project"
        1. Project website url: "Url should start with http or https [e.g. https://example.com] "
    2. when selected "Customer typology" = "Single user"
        1. Webpage: "Url should start with http or https [e.g. https://example.com] "
    2. when selected "Customer typology" = "Representing a private company"
        1. Company website url: "Url should start with http or https [e.g. https://example.com]"
2. Other than that, in forms for service and offer a url/email domain should always read example.com, as opposed to webpage.org or domain.com, which were put on display before.