### PR TITLE
[#2012] Remove service.order_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Resource provider can navigate to the ordering parameters management from the Resource Presentation Page (@kmarszalek, @jarekzet)
 
 ### Changed
+- Remove order target field from Resource. It is configurable on Offer only now (@jswk)
 - For an Offer, an empty order URL doesn't imply internal ordering (@jswk)
 - More consistent form behaviour for ordering configuration (@jswk)
 

--- a/app/models/jira/client.rb
+++ b/app/models/jira/client.rb
@@ -291,7 +291,7 @@ private
     when "SO-1"
       encode_order_properties(project_item)
     when "SO-ServiceOrderTarget"
-      project_item.service.order_target
+      project_item.offer.oms_params&.fetch("order_target", nil) || ""
     when "SO-OfferType"
       { "id" => @jira_config[:custom_fields][:select_values]["SO-OfferType".to_sym][map_to_jira_order_type(project_item).to_sym] }
     else

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -159,7 +159,6 @@ class Service < ApplicationRecord
   validate :logo_variable, on: [:create, :update]
   validates :scientific_domains, presence: true
   validates :status, presence: true
-  validates :order_target, allow_blank: true, email: true
   validates :trl, length: { maximum: 1 }
   validates :life_cycle_status, length: { maximum: 1 }
   validates :geographical_availabilities, presence: true

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -18,7 +18,6 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   MP_INTERNAL_FIELDS = [
     [category_ids: []],
     [platform_ids: []],
-    :order_target,
     :restrictions,
     :status,
     :activate_message,
@@ -89,7 +88,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
       :webpage_url, :manual_url, :helpdesk_url,
       :helpdesk_email, :security_contact_email, :training_information_url,
       :privacy_policy_url, [use_cases_url: []], :restrictions,
-      :order_target, :status_monitoring_url, :maintenance_url,
+      :status_monitoring_url, :maintenance_url,
       :order_url, :payment_model_url, :pricing_url,
       [funding_body_ids: []], [funding_program_ids: []],
       [access_type_ids: []], [access_mode_ids: []],

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -372,7 +372,7 @@
             = f.input :maintenance_url, disabled: cant_edit(:maintenance_url)
         .card.shadow-sm.rounded
           %button.btn.btn-link{ type: "button", class: ("collapsed" if collapsed?(service,
-              [:order_type, :order_url, :order_target])),
+              [:order_type, :order_url])),
               data: { toggle: "collapse", target: "#order" },
               aria: { expanded: true, controls: "order" } }
             .card-header.text-left{ id: "order-header" }
@@ -385,7 +385,7 @@
                     %i.fas.fa-chevron-up
         .collapse{ id: "order", "aria-labelledby": "order-header",
             "data-parent": "#accordion-form",
-            class: ("show" unless collapsed?(service, [:order_type, :order_url, :order_target])) }
+            class: ("show" unless collapsed?(service, [:order_type, :order_url])) }
           .card-body
             .row
               .col-12
@@ -394,9 +394,6 @@
             .row
               .col-12
                 = f.input :order_url, disabled: cant_edit(:order_url)
-            .row
-              .col-12
-                = f.input :order_target, label: _("Resource Order Target"), disabled: cant_edit(:order_target)
         .card.shadow-sm.rounded
           %button.btn.btn-link{ type: "button", class: ("collapsed" if collapsed?(service,
               [:payment_model_url, :pricing_url])),

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -101,8 +101,6 @@ en:
           Url should start with http or https [e.g. https://example.com]
         tag_list: |
           Use "," to separate tags
-        order_target: |
-          Email address [e.g. email@example.com]
         logo: |
           Supported logo formats: png, gif, jpg, jpeg, pjpeg, tiff,
           vnd.adobe.photoshop and vnd.microsoft.icon

--- a/db/migrate/20210518101302_remove_service_order_target.rb
+++ b/db/migrate/20210518101302_remove_service_order_target.rb
@@ -1,0 +1,16 @@
+class RemoveServiceOrderTarget < ActiveRecord::Migration[6.0]
+  def change
+    exec_update "
+      UPDATE offers
+      SET
+          oms_params = ('{\"order_target\": \"' || services.order_target || '\"}')::jsonb
+      FROM services
+      WHERE
+            offers.service_id = services.id AND
+            services.order_target <> '' AND
+            offers.order_type = 'order_required' AND
+            offers.internal = true;
+    "
+    remove_column :services, :order_target
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_142836) do
+ActiveRecord::Schema.define(version: 2021_05_18_101302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -491,7 +491,6 @@ ActiveRecord::Schema.define(version: 2021_05_17_142836) do
     t.string "order_type"
     t.string "status"
     t.integer "upstream_id"
-    t.string "order_target", default: "", null: false
     t.string "helpdesk_email", default: ""
     t.integer "project_items_count", default: 0, null: false
     t.string "version"

--- a/lib/ordering_api/add_sombo.rb
+++ b/lib/ordering_api/add_sombo.rb
@@ -15,15 +15,10 @@ module OrderingApi
         oms.type = :global
         oms.default = true
         oms.custom_params = { order_target: { mandatory: false } }
-        oms.administrators = [sombo_admin]
       end
 
-      Service.all.each do |s|
-        s.offers.each do |o|
-          if o.current_oms == sombo && s.order_target.present?
-            o.update(oms_params: { order_target: s.order_target })
-          end
-        end
+      unless sombo.administrators.include?(sombo_admin)
+        sombo.administrators << sombo_admin
       end
     end
   end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -34,7 +34,6 @@ FactoryBot.define do
     sequence(:version) { nil }
     sequence(:trl) { [create(:trl)] }
     sequence(:synchronized_at) { Time.now - 2.days }
-    sequence(:order_target) { "admin@admin.com" }
 
     upstream { nil }
 

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -78,7 +78,6 @@ RSpec.feature "Services in backoffice" do
       fill_in "Training information url", with: "https://sample.url"
       fill_in "Restrictions", with: "Reaserch affiliation needed"
       fill_in "Activate message", with: "Welcome!!!"
-      fill_in "Resource Order Target", with: "email@example.com"
       fill_in "service_certifications_0", with: "ISO-639"
       fill_in "service_standards_0", with: "standard"
       fill_in "service_open_source_technologies_0", with: "opensource"
@@ -98,9 +97,6 @@ RSpec.feature "Services in backoffice" do
       expect { click_on "Create Resource" }.
         to change { user.owned_services.count }.by(1)
                .and change { Offer.count }.by(1)
-
-
-      expect(user.owned_services.last.order_target).to eq("email@example.com")
 
       expect(page).to have_content("service name")
       expect(page).to have_content("service description")
@@ -557,7 +553,6 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_field "Owners", disabled: false
       expect(page).to have_field "Funding bodies", disabled: false
       expect(page).to have_field "Funding programs", disabled: false
-      expect(page).to have_field "Resource Order Target", disabled: false
       expect(page).to have_field "Language availability", disabled: false
       expect(page).to have_field "Geographical availabilities", disabled: false
       expect(page).to have_field "Terms of use url", disabled: false
@@ -627,7 +622,6 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_field "Funding programs", disabled: true
       expect(page).to have_field "service_grant_project_names_0", disabled: true
       expect(page).to have_field "Owners", disabled: false
-      expect(page).to have_field "Resource Order Target", disabled: false
       expect(page).to have_field "Language availability", disabled: true
       expect(page).to have_field "Geographical availabilities", disabled: true
       expect(page).to have_field "Resource geographic locations", disabled: true

--- a/spec/models/jira/client_spec.rb
+++ b/spec/models/jira/client_spec.rb
@@ -23,9 +23,13 @@ describe Jira::Client do
 
     user = create(:user, first_name: "John", last_name: "Doe", uid: "uid1")
     project_item = create(:project_item,
-          offer: create(:offer, name: "off1", service: create(:service,
-                                                              name: "s1",
-                                                              categories: [create(:category, name: "cat1")])),
+          offer: create(:offer,
+                        name: "off1",
+                        service: create(:service,
+                                        name: "s1",
+                                        categories: [create(:category, name: "cat1")]),
+                        primary_oms: create(:oms, custom_params: { "order_target": { "mandatory": false } }),
+                        oms_params: { "order_target": "admin@example.com" }),
           project: create(:project, user: user, name: "My Secret Project",
                           user_group_name: "New user group", reason_for_access: "some reason"),
           properties: [
@@ -75,7 +79,7 @@ describe Jira::Client do
                            "Harvesting endpoint" => "aaaaa",
                          }
                        }.to_json,
-                       "SO-ServiceOrderTarget-1" => "admin@admin.com",
+                       "SO-ServiceOrderTarget-1" => "admin@example.com",
                        "SO-OfferType-1" => { "id" => "20005" } }
 
     issue = double(:Issue)
@@ -94,7 +98,6 @@ describe Jira::Client do
                           offer: create(:open_access_offer,
                                         name: "off1",
                                         service: create(:open_access_service,
-                                                        order_target: "email@example.com",
                                                         name: "s1",
                                                         categories: [create(:category, name: "cat1")])),
                           project: create(:project, user: user,
@@ -118,7 +121,7 @@ describe Jira::Client do
                           "offer" => "off1",
                           "attributes" => {}
                         }.to_json,
-                        "SO-ServiceOrderTarget-1" => "email@example.com",
+                        "SO-ServiceOrderTarget-1" => "",
                         "SO-OfferType-1" => { "id" => "20006" } }
 
 
@@ -140,7 +143,7 @@ describe Jira::Client do
                                         voucherable: true,
                                         service: create(:open_access_service,
                                                         name: "s1",
-                                                                 categories: [create(:category, name: "cat1")])),
+                                                        categories: [create(:category, name: "cat1")])),
                           voucher_id: "123123",
                           project: create(:project, user: user,
                                           name: "My Secret Project",
@@ -163,7 +166,7 @@ describe Jira::Client do
                           "offer" => "off1",
                           "attributes" => {}
                         }.to_json,
-                        "SO-ServiceOrderTarget-1" => "admin@admin.com",
+                        "SO-ServiceOrderTarget-1" => "",
                         "SO-OfferType-1" => { "id" => "20006" } }
 
     issue = double(:Issue)
@@ -204,7 +207,7 @@ describe Jira::Client do
                           "offer" => "off1",
                           "attributes" => {}
                         }.to_json,
-                        "SO-ServiceOrderTarget-1" => "admin@admin.com",
+                        "SO-ServiceOrderTarget-1" => "",
                         "SO-OfferType-1" => { "id" => "20006" } }
 
     issue = double(:Issue)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -58,20 +58,6 @@ RSpec.describe Service do
     expect(s1.related_services).to contain_exactly(s2, s3)
   end
 
-  it "requires service_order_target to be an email" do
-    service = create(:service)
-    service.order_target = "not-valid-email"
-    expect(service.valid?).to be_falsey
-    service.order_target = "valid@email.com"
-    expect(service.valid?).to be_truthy
-  end
-
-  it "allows service_order_target to be blank" do
-    service = create(:service)
-    service.order_target = ""
-    expect(service.valid?).to be_truthy
-  end
-
   context "#owned_by?" do
     it "is true when user is in the owners list" do
       owner = create(:user)
@@ -80,7 +66,7 @@ RSpec.describe Service do
       expect(service.owned_by?(owner)).to be_truthy
     end
 
-    it "is false when user is not in the owers list" do
+    it "is false when user is not in the owners list" do
       stranger = create(:user)
       service = create(:service)
 

--- a/spec/policies/backoffice/service_policy_spec.rb
+++ b/spec/policies/backoffice/service_policy_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Backoffice::ServicePolicy do
                                                   [changelog: []],
                                                   :helpdesk_email, :security_contact_email,
                                                   :training_information_url, :restrictions,
-                                                  :order_target, :status_monitoring_url, :maintenance_url,
+                                                  :status_monitoring_url, :maintenance_url,
                                                   :order_url, :payment_model_url, :pricing_url,
                                                   [related_service_ids: []], [required_service_ids: []],
                                                   [manual_related_service_ids: []],
@@ -58,7 +58,7 @@ RSpec.describe Backoffice::ServicePolicy do
       source = create(:service_source, source_type: :eic, service: service)
       service.update!(upstream: source)
       policy = described_class.new(service_owner, service)
-      expect(policy.permitted_attributes).to match_array([:order_target,
+      expect(policy.permitted_attributes).to match_array([
                                                      :restrictions, :activate_message,
                                                      [platform_ids: []], [owner_ids: []],
                                                      [category_ids: []], :status, :upstream_id,


### PR DESCRIPTION
Migrate the values of service.order_target to existing
`order_required && internal` offers' oms_params and remove the column.

In legacy Jira integration, get the SO-ServiceOrderTarget value from the
offer. Make sure that in case no such value is found an empty string is
emitted, matching the existing solution.

Remove the order_target logic from add_sombo rake task, and make sure
that the task handles case when SOMBO OMS already exists, but
sombo_admin doesn't (see #2079).

Fixes: #2012. Fixes: #2079.

## How to test

There should be no "Resource order target" field in service edit form.

When ordering "B2ACCESS", see that Jira receives field `SO-ServiceOrderTarget=support@eudat.eu`.