### PR TITLE
[#1891] Fix providers in comparison and project_item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - For an Offer, an empty order URL doesn't imply internal ordering (@jswk)
 - More consistent form behaviour for ordering configuration (@jswk)
 - From now after click "Stop showing in the MP" on the resource page, offers aren't deleted (@goreck888) 
+- Resource organisation and resource providers are separated in the comparison's and Project Item's views (@goreck888)
 
 ### Deprecated
 

--- a/app/helpers/comparisons_helper.rb
+++ b/app/helpers/comparisons_helper.rb
@@ -15,4 +15,8 @@ module ComparisonsHelper
       {}
     end
   end
+
+  def row_class(idx)
+    idx.even? ? nil : "lightgrey-row"
+  end
 end

--- a/app/helpers/project_items_helper.rb
+++ b/app/helpers/project_items_helper.rb
@@ -37,8 +37,14 @@ module ProjectItemsHelper
     end
   end
 
+  def service_resource_organisation(project_item)
+    organisation = project_item.service.resource_organisation
+    link_to organisation.name, services_path(providers: organisation.id)
+  end
+
   def service_providers_list(project_item)
-    providers = project_item.service.providers.
+    organisation = project_item.service.resource_organisation
+    providers = project_item.service.providers.reject { |p| p == organisation }.
       map { |p| link_to(p.name, services_path(providers: p.id)) }
     safe_join(providers, ", ")
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -227,7 +227,7 @@ class Service < ApplicationRecord
     providers
       .reject(&:blank?)
       .reject { |p| p == resource_organisation }
-      .empty?
+      .size.positive?
   end
 
   def available_omses

--- a/app/views/comparisons/show.html.haml
+++ b/app/views/comparisons/show.html.haml
@@ -1,6 +1,7 @@
 :ruby
   content_for :title, _("Service comparison")
   i = 3 - @services&.size
+  row_idx = 0
   breadcrumb :comparison
 .container
   %table.services-comparison.bordered.shadow-sm.table-responsive
@@ -31,14 +32,24 @@
         - i.times do
           %td.title-col.empty.text-uppercase
             = link_to _("Add next resource"), services_path, "data-probe": ""
-      %tr
+      %tr{ class: row_class(row_idx) }
         %th{ "data-toggle": "tooltip",
-        title: "The name(s) (or abbreviation(s)) of Provider(s) that manage or deliver the Resource in |
+        title: "The name(s) (or abbreviation(s)) of Provider that manage the Resource in |
         federated scenarios." } |
-          = _("Resource Providers")
+          = _("Resource Organisation")
         - @services.each do |service|
-          %td= service.providers.map { |p| p.name }.join(", ")
-      %tr.lightgrey-row
+          %td= service.resource_organisation.name
+        - row_idx += 1
+      - if @services.any? { |s| s.providers.reject { |p| p == s.resource_organisation }.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip",
+          title: "The name(s) (or abbreviation(s)) of Provider(s) that deliver the Resource in |
+          federated scenarios." } |
+            = _("Resource Providers")
+          - @services.each do |service|
+            %td= service.providers.reject { |p| p == service.resource_organisation }.map(&:name).join(", ")
+          - row_idx += 1
+      %tr{ class: row_idx.even? ? nil : "lightgrey-row" }
         %th{ "data-toggle": "tooltip",
         title: "The branch of science, scientific discipline that is related to the Resource." }
           = _("Scientific Domain")
@@ -52,7 +63,8 @@
                 - children.each do |child|
                   %dd
                     %span= child
-      %tr
+        - row_idx += 1
+      %tr{ class: row_class(row_idx) }
         %th{ "data-toggle": "tooltip",
         title: "A named group of Resources that offer access to the same type of Resource or capabilities." }
           = _("Categorisation")
@@ -66,59 +78,76 @@
                 - children.each do |child|
                   %dd
                     %span= child
-      %tr.lightgrey-row
-        %th{ "data-toggle": "tooltip",
-        title: "Type of users/customers that commissions a Provider to deliver a Resource." }
-          = _("Target Users")
-        - @services.each do |service|
-          %td= service.target_users.map { |tg| tg.name }.join(", ")
-      %tr
-        %th{ "data-toggle": "tooltip",
-        title: "The way a user can access the Resource (Remote, Physical, Virtual, etc.)" }
-          = _("Resource Access Type")
-        - @services.each do |service|
-          %td= service.access_types.map { |tg| tg.name }.join(", ")
-      %tr.lightgrey-row
-        %th{ "data-toggle": "tooltip",
-        title: "Eligibility/criteria for granting access to users (excellence-based, free-conditionally, free etc.)" }
-          = _("Resource Access Mode")
-        - @services.each do |service|
-          %td= service.access_modes.map { |sd| sd.name }.join(", ")
-      %tr
-        %th{ "data-toggle": "tooltip",
-        title: "Keywords associated to the Resource to simplify search by relevant keywords." }
-          = _("Tags")
-        - @services.each do |service|
-          %td
-            - service.tag_list.sort.each do |tag|
-              = link_to tag, services_path(tag: tag), class: "badge badge-light"
-      %tr.lightgrey-row
-        %th{ "data-toggle": "tooltip", title: "Locations where the Resource is offered." }
-          = _("Geographical Availability")
-        - @services.each do |service|
-          %td= service.geographical_availabilities.join(", ")
-      %tr
-        %th{ "data-toggle": "tooltip", title: "Languages of the (user interface of the) Resource." }
-          = _("Language Availability")
-        - @services.each do |service|
-          %td
-            %ul
-            - service.language_availability.each do |language|
-              %li= I18nData.languages[language.upcase] || language
-      %tr.lightgrey-row
-        %th{ "data-toggle": "tooltip",
-        title: "The Technology Readiness Level of the Resource updated in the context of the EOSC." }
-          = _("Technology Readiness Level")
-        - @services.each do |service|
-          %td{ "data-toggle": "tooltip", title: service.trl.present? ? trl_description_text(service) : nil }
-            = service.trl.map { |trl| trl.name.upcase }.join(", ")
-      %tr
-        %th{ "data-toggle": "tooltip", title: "Phase of the Resource life-cycle." }
-          = _("Resource Life Cycle Status")
-        - @services.each do |service|
-          - if service.life_cycle_status.present?
-            %td= service.life_cycle_status.first.name
-      %tr.lightgrey-row
+        - row_idx += 1
+      - if @services.any? { |s| s.target_users.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip",
+          title: "Type of users/customers that commissions a Provider to deliver a Resource." }
+            = _("Target Users")
+          - @services.each do |service|
+            %td= service.target_users.map { |tg| tg.name }.join(", ")
+          - row_idx += 1
+      - if @services.any? { |s| s.access_types.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip",
+          title: "The way a user can access the Resource (Remote, Physical, Virtual, etc.)" }
+            = _("Resource Access Type")
+          - @services.each do |service|
+            %td= service.access_types.map { |tg| tg.name }.join(", ")
+          - row_idx += 1
+      - if @services.any? { |s| s.access_modes.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip",
+          title: "Eligibility/criteria for granting access to users (excellence-based, free-conditionally, free etc.)" }
+            = _("Resource Access Mode")
+          - @services.each do |service|
+            %td= service.access_modes.map { |sd| sd.name }.join(", ")
+          - row_idx += 1
+      - if @services.any? { |s| s.tags.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip",
+          title: "Keywords associated to the Resource to simplify search by relevant keywords." }
+            = _("Tags")
+          - @services.each do |service|
+            %td
+              - service.tag_list.sort.each do |tag|
+                = link_to tag, services_path(tag: tag), class: "badge badge-light"
+          - row_idx += 1
+      - if @services.any? { |s| s.geographical_availabilities.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip", title: "Locations where the Resource is offered." }
+            = _("Geographical Availability")
+          - @services.each do |service|
+            %td= service.geographical_availabilities.join(", ")
+          - row_idx += 1
+      - if @services.any? { |s| s.language_availability.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip", title: "Languages of the (user interface of the) Resource." }
+            = _("Language Availability")
+          - @services.each do |service|
+            %td
+              %ul
+              - service.language_availability.each do |language|
+                %li= I18nData.languages[language.upcase] || language
+          - row_idx += 1
+      - if @services.any? { |s| s.trl.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip",
+          title: "The Technology Readiness Level of the Resource updated in the context of the EOSC." }
+            = _("Technology Readiness Level")
+          - @services.each do |service|
+            %td{ "data-toggle": "tooltip", title: service.trl.present? ? trl_description_text(service) : nil }
+              = service.trl.map { |trl| trl.name.upcase }.join(", ")
+          - row_idx += 1
+      - if @services.any? { |s| s.life_cycle_status.present? }
+        %tr{ class: row_class(row_idx) }
+          %th{ "data-toggle": "tooltip", title: "Phase of the Resource life-cycle." }
+            = _("Resource Life Cycle Status")
+          - @services.each do |service|
+            - if service.life_cycle_status.present?
+              %td= service.life_cycle_status.first.name
+          - row_idx += 1
+      %tr{ class: row_class(row_idx) }
         %th{ "data-toggle": "tooltip",
         title: "Information on the order type (requires an ordering procedure, or no ordering and if fully open or |
         requires authentication)" } |

--- a/app/views/projects/services/_details.html.haml
+++ b/app/views/projects/services/_details.html.haml
@@ -25,5 +25,10 @@
     %dd= link_to _("Service Level Agreement"), project_item.service.sla_url
 %dl
   %dt
-    = _("Providers") + ":"
-  %dd= service_providers_list(project_item)
+    = _("Resource Organisation") + ":"
+  %dd= service_resource_organisation(project_item)
+- unless service_providers_list(project_item).blank?
+  %dl
+    %dt
+      = _("Resource Providers") + ":"
+    %dd= service_providers_list(project_item)

--- a/app/views/services/_categorization.html.haml
+++ b/app/views/services/_categorization.html.haml
@@ -4,7 +4,7 @@
       = _("Organisation") + ":"
   %dd.x-small
     %mr-4= resource_organisation(service, highlights)
-- unless service.providers?
+- if service.providers?
   %dl.mb-0
     %dt.x-small
       %span


### PR DESCRIPTION
Add separation for `resource_organisation`
and `providers` in the `comparison`
and `project_item` views

Closes #1891 