### PR TITLE
Remove webpage from Offering API

### DIFF
--- a/swagger/v1/offer/offer_definitions.json
+++ b/swagger/v1/offer/offer_definitions.json
@@ -385,16 +385,6 @@
         "description":{
           "type":"string"
         },
-        "webpage":{
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "order_type":{
           "type":"string",
           "enum":[

--- a/swagger/v1/offering_swagger.json
+++ b/swagger/v1/offering_swagger.json
@@ -259,7 +259,7 @@
         ],
         "responses": {
           "200": {
-            "description": "offer updated",
+            "description": "doesn't update primary_oms and oms_params and internal if not order_required",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
The field webpage wasn't properly removed when removing webpage from the
model in #2070.

Also, run `rails rswag` to bring API description up to date. 

## How to test

See that webpage field doesn't appear anymore in the Offering API swagger.