### PR TITLE
[#2034] Don't remove offers by drafting resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Remove order target field from Resource. It is configurable on Offer only now (@jswk)
 - For an Offer, an empty order URL doesn't imply internal ordering (@jswk)
 - More consistent form behaviour for ordering configuration (@jswk)
+- From now after click "Stop showing in the MP" on the resource page, offers aren't deleted (@goreck888) 
 
 ### Deprecated
 

--- a/app/services/service/draft.rb
+++ b/app/services/service/draft.rb
@@ -7,6 +7,5 @@ class Service::Draft
 
   def call
     @service.update(status: :draft)
-    @service.offers.each { |o| Offer::Draft.new(o).call }
   end
 end

--- a/spec/services/service/draft_spec.rb
+++ b/spec/services/service/draft_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Service::Draft do
     described_class.new(service).call
 
     expect(service.reload).to be_draft
-    expect(offer.reload).to be_draft
+    expect(offer.reload).to_not be_draft
   end
 end


### PR DESCRIPTION
Change the behavior of set status of resource to draft
Now offers don't disappear after click
"Stop showing in the MP"
Fixes #2034