### PR TITLE
[HOTFIX] Fix validator messages for MinMax parameter

### DIFF
--- a/app/models/parameter/minmax.rb
+++ b/app/models/parameter/minmax.rb
@@ -12,12 +12,12 @@ module Parameter::Minmax
 
     validates :min, numericality: {
       less_than_or_equal_to: ->(p) { p.max },
-      message: "must be less than maximum value"
+      message: "must be less or equal than maximum value"
     }, if: :max
 
     validates :max, numericality: {
       greater_than_or_equal_to: ->(p) { p.min },
-      message: "must be greater than minimum value"
+      message: "must be greater or equal than minimum value"
     }, if: :min
   end
 end

--- a/app/models/parameter/multiselect.rb
+++ b/app/models/parameter/multiselect.rb
@@ -6,9 +6,21 @@ class Parameter::Multiselect < Parameter
 
   attribute :unit, :string
 
-  validates :min, numericality: { greater_than: 0,  less_than_or_equal_to: ->(p) { p.values&.length || 1 } }
-  validates :max, numericality: { greater_than: 0, less_than_or_equal_to: ->(p) { p.values&.length || 1 } }
+  validates :min, numericality: { greater_than: 0 }
+  validates :max, numericality: { greater_than: 0 }
+
+  validates :min, numericality: { less_than_or_equal_to: ->(p) { p.values&.length || 1 } }, if: :values_and_max?
+  validates :max, numericality: { less_than_or_equal_to: ->(p) { p.values&.length || 1 } }, if: :values_and_min?
+
   validate :duplicates, if: :values
+
+  def values_and_min?
+    values.present? && min.present?
+  end
+
+  def values_and_max?
+    values.present? && min.present?
+  end
 
   def dump
     ActiveSupport::HashWithIndifferentAccess.new(

--- a/spec/features/backoffice/parameters_spec.rb
+++ b/spec/features/backoffice/parameters_spec.rb
@@ -30,7 +30,6 @@ RSpec.feature "Parameters in backoffice" do
 
       expect(page).to have_text("Values can't be blank")
       expect(page).to have_text("Min must be greater than 0")
-      expect(page).to have_text("Max must be less than or equal to 0")
     end
 
     scenario "I cannot set min < 1 and max values greater than values size", js: true do


### PR DESCRIPTION
Min and Max values implemented in parameters
had wrong message: "must be grater/lesser..."
From now it's correct "must be greater/lesser or equal..."