### PR TITLE
Correct entries in the next-version section of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
-## [Unreleased]
+## [3.14.0-milestone]
 
 ### Added
+- Possibility to import vocabularies via PC REST API (@goreck888)
 
 ### Changed
+- From now after click "Stop showing in the MP" on the resource page, offers aren't deleted (@goreck888)
+- Resource organisation and resource providers are separated in the comparison's and Project Item's views (@goreck888)
 
 ### Deprecated
 
@@ -24,14 +27,11 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - OMS configuration on offer creation and update (@jswk)
-- Possibility to import vocabularies via PC REST API (@goreck888) 
 
 ### Changed
 - Remove order target field from Resource. It is configurable on Offer only now (@jswk)
 - For an Offer, an empty order URL doesn't imply internal ordering (@jswk)
 - More consistent form behaviour for ordering configuration (@jswk)
-- From now after click "Stop showing in the MP" on the resource page, offers aren't deleted (@goreck888) 
-- Resource organisation and resource providers are separated in the comparison's and Project Item's views (@goreck888)
 
 ### Removed
 - Offer webpage field (@jswk)


### PR DESCRIPTION
Also, introduce using a name of the expected next version with
`-milestone` suffix instead of the Unreleased section.
I think that it may be easier to avoid mistakes when merging or adding
changelog entries this way.

When creating a version branch, in the master branch a new section with
the next version should be created.
This would be also more apparent to what version will the feature go,
when operating on a PR.