### PR TITLE
Add task to create OMS for provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,3 +355,27 @@ If you want to save database dump to a json file, use:
 ```
 ./bin/rails recommender:serialize_db_to_file
 ```
+
+## Rake tasks
+
+### Adding Provider OMS
+
+Task: `ordering_api:add_provider_oms`.
+
+Arguments (envvars):
+- `ARG_OMS_NAME`, for example `organization_x`, then the OMS will be called `Organization X OMS`
+- `ARG_PROVIDER_PID`, the provider must exist for the task to succeed
+- `ARG_AUTHENTICATION_TOKEN`, optional, the task will update the OMS admin's token to this value
+
+The task will look create an OMS with `type=:provider_group` that is associated with passed provider.
+It will also create an admin user for the OMS, setting its token if passed as argument.
+
+If OMS already exists, then the task will append the provider to the OMS.
+
+Example run:
+```
+rake ordering_api:add_provider_oms \
+  ARG_OMS_NAME="extra_provider" \
+  ARG_PROVIDER_PID="ep" \
+  ARG_AUTHENTICATION_TOKEN="a_token"
+```

--- a/lib/ordering_api/add_provider_oms.rb
+++ b/lib/ordering_api/add_provider_oms.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module OrderingApi
+  class AddProviderOMS
+    def initialize(oms_name, provider_pid, authentication_token)
+      @oms_name = oms_name.snakecase
+      @provider_pid = provider_pid
+      @authentication_token = authentication_token
+    end
+
+    def call
+      provider = Provider.find_by(pid: @provider_pid)
+      if provider.blank?
+        puts "Provider with pid '#{@provider_pid}' not found. It must exist to attach the OMS to it."
+        return
+      end
+
+      admin = User.find_or_initialize_by(uid: "iama#{@oms_name}admin") do |user|
+        user.first_name = @oms_name.titlecase
+        user.last_name = "admin"
+        user.email = "#{@oms_name}_admin@example.com"
+      end
+      admin.authentication_token = @authentication_token if @authentication_token.present?
+      admin.save!
+
+      oms = OMS.find_or_initialize_by(name: "#{@oms_name.titlecase} OMS")
+      oms.type = :provider_group
+      append_if_not_present oms.providers, provider
+      append_if_not_present oms.administrators, admin
+      oms.save!
+
+      puts "OMS id: #{oms.id}, name: '#{oms.name}', providers: #{oms.providers.pluck(:pid).join(", ")}"
+      puts "Admin user uid: '#{admin.uid}', token: '#{admin.authentication_token}'"
+    end
+
+    private
+      def append_if_not_present(association, element)
+        association << element if association.exclude?(element)
+      end
+  end
+end

--- a/lib/tasks/ordering_api.rake
+++ b/lib/tasks/ordering_api.rake
@@ -7,6 +7,12 @@ namespace :ordering_api do
     OrderingApi::AddSombo.new.call
   end
 
+  task add_provider_oms: :environment do
+    OrderingApi::AddProviderOMS.new(
+      ENV["ARG_OMS_NAME"], ENV["ARG_PROVIDER_PID"], ENV["ARG_AUTHENTICATION_TOKEN"]
+    ).call
+  end
+
   task authorization_test_setup: :environment do
     OrderingApi::AuthorizationTestSetup.new.call
   end

--- a/spec/lib/ordering_api/add_provider_oms_spec.rb
+++ b/spec/lib/ordering_api/add_provider_oms_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ordering_api/add_provider_oms"
+
+describe OrderingApi::AddProviderOMS do
+  let!(:provider) { create(:provider, pid: "test.pid") }
+  let!(:another_provider) { create(:provider, pid: "another.pid") }
+  let(:service) { create(:service, providers: [provider]) }
+
+  it "fails if provider is not found" do
+    expect(provider.omses.count).to eq(0)
+
+    described_class.new("name", "other.pid", "token").call
+
+    expect(provider.omses.count).to eq(0)
+  end
+
+  it "creates OMS and adds admin to it" do
+    expect(provider.omses.count).to eq(0)
+
+    described_class.new("test_provider", "test.pid", "token_value").call
+
+    expect(provider.omses.count).to eq(1)
+
+    expect(User.count).to eq(1)
+    expect(User.first.first_name).to eq("Test Provider")
+    expect(User.first.authentication_token).to eq("token_value")
+    expect(OMS.count).to eq(1)
+    expect(OMS.first.name).to eq("Test Provider OMS")
+    expect(OMS.first.administrators.first.first_name).to eq("Test Provider")
+    expect(service.available_omses).to contain_exactly(OMS.first)
+  end
+
+  it "updates token if user exists and creates provider-OMS relationship" do
+    admin = create(:user, uid: "iamatest_provideradmin")
+    create(:oms, name: "Test Provider OMS", administrators: [admin])
+
+    expect(User.count).to eq(1)
+    expect(admin.authentication_token).not_to eq("token_value")
+    expect(provider.omses.count).to eq(0)
+
+    described_class.new("test_provider", "test.pid", "token_value").call
+
+    expect(User.count).to eq(1)
+    expect(admin.reload.authentication_token).to eq("token_value")
+    expect(provider.omses.count).to eq(1)
+  end
+
+  it "can be called multiply to add providers to OMS and update token" do
+    described_class.new("test_provider", "test.pid", "token_value").call
+
+    expect(OMS.first.providers.count).to eq(1)
+
+    expect(User.count).to eq(1)
+    expect(User.first.first_name).to eq("Test Provider")
+    expect(User.first.authentication_token).to eq("token_value")
+    expect(OMS.count).to eq(1)
+    expect(OMS.first.name).to eq("Test Provider OMS")
+    expect(OMS.first.administrators.first.first_name).to eq("Test Provider")
+
+    described_class.new("test_provider", "another.pid", "new_token").call
+
+    expect(OMS.first.providers.count).to eq(2)
+
+    expect(User.count).to eq(1)
+    expect(User.first.first_name).to eq("Test Provider")
+    expect(User.first.authentication_token).to eq("new_token")
+    expect(OMS.count).to eq(1)
+    expect(OMS.first.name).to eq("Test Provider OMS")
+    expect(OMS.first.administrators.first.first_name).to eq("Test Provider")
+  end
+end


### PR DESCRIPTION
The task creates an OMS for provider and its admin if needed.

## How to test

It can be tested by running from the rails console with loaded dev db:
```
Provider.first.update!(pid: "test.pid")
```
It's necessary, as in dev providers don't have PIDs by default.
Then, run from the shell:
```
# It should register an OMS, create admin and associate the OMS with the provider. Token will be generated.
rake ordering_api:add_provider_oms ARG_OMS_NAME="extra_provider" ARG_PROVIDER_PID="test.pid"
# It shouldn't change the OMS, but will update the admin token.
rake ordering_api:add_provider_oms ARG_OMS_NAME="extra_provider" ARG_PROVIDER_PID="test.pid" ARG_AUTHENTICATION_TOKEN="test_token"
```