### PR TITLE
[#2088] Auth all services sub-pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Set `Other` target user at the end of target user list (@goreck888)
 - Add missing connection from Community MP to Offering API in API Docs overview image (@abacz)
 - Allow to create an offer in `ordering_configuration` panel when none exists (@goreck888)
+- Secure the public service endpoints when it's deleted or it's draft (@danielkryska)
 
 ### Security
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,10 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery
 
+  rescue_from ActiveRecord::RecordNotFound do |_|
+    redirect_back fallback_location: "/404"
+  end
+
   rescue_from Pundit::NotAuthorizedError do |exception|
     redirect_back fallback_location: root_path,
                   alert: not_authorized_message(exception)

--- a/app/controllers/concerns/service/categorable.rb
+++ b/app/controllers/concerns/service/categorable.rb
@@ -5,7 +5,6 @@ module Service::Categorable
 
   included do
     before_action :init_categories_tree, only: :index
-    rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_services
   end
 
   def category_counters(scope, filters)
@@ -24,10 +23,6 @@ module Service::Categorable
       @subcategories_with_counters = subcategories_with_counters&.
         partition { |cid, c|  c[:category][:name] != "Other" }&.flatten(1)
       @services_total ||= counters[nil]
-    end
-
-    def redirect_to_services
-      redirect_to :services
     end
 
     def category

--- a/app/controllers/services/application_controller.rb
+++ b/app/controllers/services/application_controller.rb
@@ -26,7 +26,7 @@ class Services::ApplicationController < ApplicationController
 
     def load_and_authenticate_service!
       @service = Service.friendly.find(params[:service_id])
-      authorize(@service, :order?)
+      authorize(ServiceContext.new(@service, params.key?(:from) && params[:from] === "backoffice_service"), :order?)
       @wizard = ProjectItem::Wizard.new(@service)
     end
 

--- a/app/controllers/services/details_controller.rb
+++ b/app/controllers/services/details_controller.rb
@@ -16,6 +16,7 @@ class Services::DetailsController < ApplicationController
 
   def index
     @service = Service.friendly.find(params[:service_id])
+    authorize(ServiceContext.new(@service, params.key?(:from) && params[:from] === "backoffice_service"), :show?)
     @related_services = @service.related_services
     @related_services_title = "Related resources"
     @question = Service::Question.new(service: @service)

--- a/app/controllers/services/opinions_controller.rb
+++ b/app/controllers/services/opinions_controller.rb
@@ -16,6 +16,7 @@ class Services::OpinionsController < ApplicationController
 
   def index
     @service = Service.friendly.find(params[:service_id])
+    authorize(ServiceContext.new(@service, params.key?(:from) && params[:from] === "backoffice_service"), :show?)
     @related_services = @service.related_services
     @related_services_title = "Related resources"
     @service_opinions = ServiceOpinion.includes(project_item: :offer).

--- a/app/controllers/services/ordering_configuration/offers_controller.rb
+++ b/app/controllers/services/ordering_configuration/offers_controller.rb
@@ -7,6 +7,7 @@ class Services::OrderingConfiguration::OffersController < Services::OrderingConf
 
   def new
     @offer = Offer.new(service: @service)
+    authorize(ServiceContext.new(@service, params.key?(:from) && params[:from] === "backoffice_service"), :show?)
     authorize @offer
   end
 
@@ -20,27 +21,27 @@ class Services::OrderingConfiguration::OffersController < Services::OrderingConf
     @offer = Offer::Create.new(template).call
 
     if @offer.persisted?
-      redirect_to service_ordering_configuration_path(@service),
+      redirect_to service_ordering_configuration_path(@service, from: params[:offer][:from]),
                   notice: "New offer has been created"
     else
-      render :new, status: :bad_request
+      render :new, status: :bad_request, locals: { from: params[:offer][:from] }
     end
   end
 
   def update
     template = permitted_attributes(Offer.new)
     if Offer::Update.new(@offer, transform_attributes(template)).call
-      redirect_to service_ordering_configuration_path(@service),
+      redirect_to service_ordering_configuration_path(@service, from:  params[:offer][:from]),
                   notice: "Offer updated correctly"
     else
-      render :edit, status: :bad_request
+      render :edit, status: :bad_request, locals: { from: params[:offer][:from] }
     end
   end
 
   def destroy
     @offer = @service.offers.find_by(iid: params[:id])
     if Offer::Destroy.new(@offer).call
-      redirect_to service_ordering_configuration_path(@service),
+      redirect_to service_ordering_configuration_path(@service, from: params[:from]),
                   notice: "Offer removed successfully"
     end
   end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -31,7 +31,8 @@ class ServicesController < ApplicationController
     @service = Service.
                includes(:offers, :target_relationships).
                friendly.find(params[:id])
-    authorize @service
+
+    authorize(ServiceContext.new(@service, params.key?(:from) && params[:from] === "backoffice_service"))
     @offers = policy_scope(@service.offers.published).order(:created_at)
     @related_services = @service.target_relationships
     @related_services_title = "Suggested compatible resources"

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -169,7 +169,7 @@ module ServiceHelper
 
   def edit_offer_link(service, offer, controller_name)
     if controller_name == "ordering_configurations"
-      edit_service_ordering_configuration_offer_path(service, offer)
+      edit_service_ordering_configuration_offer_path(service, offer, from: params[:from])
     elsif controller_name == "services"
       edit_backoffice_service_offer_path(service, offer)
     end

--- a/app/models/service_context.rb
+++ b/app/models/service_context.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ServiceContext
+  attr_reader :service, :from_backoffice, :status
+
+  def initialize(service, from_backoffice)
+    @service = service
+    @status = service.status
+    @from_backoffice = from_backoffice
+  end
+end

--- a/app/policies/ordering_configuration/service_context_policy.rb
+++ b/app/policies/ordering_configuration/service_context_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class OrderingConfiguration::ServiceContextPolicy < ServiceContextPolicy
+  def show?
+    super && record.service.administered_by?(user)
+  end
+end

--- a/app/policies/ordering_configuration_policy.rb
+++ b/app/policies/ordering_configuration_policy.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class OrderingConfigurationPolicy < ApplicationPolicy
-  def show?
-    record.administered_by?(user)
-  end
-end

--- a/app/policies/service_context_policy.rb
+++ b/app/policies/service_context_policy.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class ServiceContextPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.where(status: [:published, :unverified, :errored])
+    end
+  end
+
+  def show?
+    ServiceContextPolicy.permitted?(user, record.service, record.from_backoffice)
+  end
+
+  def order?
+    ServiceContextPolicy.permitted?(user, record.service, record.from_backoffice) &&
+      record.service.offers? &&
+      record.service.offers.any? { |s| s.published? }
+  end
+
+  def self.permitted?(user, service, from_backoffice = false)
+    has_permission = ServiceContextPolicy.has_public_access(service) ||
+      (service.status === "draft" && ServiceContextPolicy.has_additional_access(user, service) && from_backoffice)
+    raise ActiveRecord::RecordNotFound unless has_permission
+    true
+  end
+
+  private
+    def self.has_public_access(record)
+      record.published? ||
+        record.unverified? ||
+        record.errored?
+    end
+
+    def self.has_additional_access(user, record)
+      if user.blank?
+        return false
+      end
+
+      user.service_portfolio_manager? ||
+        record.owned_by?(user) ||
+        record.administered_by?(user)
+    end
+end

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -7,10 +7,6 @@ class ServicePolicy < ApplicationPolicy
     end
   end
 
-  def show?
-    record.published? || record.unverified? || record.errored?
-  end
-
   def order?
     record.offers? && record.offers.any? { |s| s.published? }
   end

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -1,4 +1,6 @@
 = simple_form_for offer_form_source_module, html: { "data-controller": "offer" } do |f|
+  = f.hidden_field :from, value: local_assigns[:from]
+
   .col-lg-8.pl-0{ "data-controller": "ordering" }
     = f.error_notification
     = f.hidden_field :id

--- a/app/views/backoffice/services/offers/_one_offer_edit_form.html.haml
+++ b/app/views/backoffice/services/offers/_one_offer_edit_form.html.haml
@@ -1,4 +1,6 @@
 = simple_form_for offer_form_source_module, html: { "data-controller": "offer" } do |f|
+  = f.hidden_field :from, value: local_assigns[:from]
+
   .col-lg-8.pl-0{ "data-controller": offer.order_required? ? "ordering" : "" }
     = f.error_notification
     = f.hidden_field :id

--- a/app/views/backoffice/services/offers/edit.html.haml
+++ b/app/views/backoffice/services/offers/edit.html.haml
@@ -9,7 +9,8 @@
       offer: @offer,
       service: @service,
       offer_form_source_module: [:backoffice, @service, @offer],
-      back_link: backoffice_service_path(@service)
+      back_link: backoffice_service_path(@service),
+      from: params[:from] || local_assigns[:from]
   - else
     = render "form",
       offer: @offer,
@@ -17,6 +18,5 @@
       show_delete_button: true,
       offer_form_source_module: [:backoffice, @service, @offer],
       offer_delete_link: backoffice_service_offer_path(@service, @offer),
-      back_link: backoffice_service_path(@service)
-
-
+      back_link: backoffice_service_path(@service),
+      from: params[:from] || local_assigns[:from]

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -73,7 +73,8 @@
                 target: :_blank, "data-probe": "" }
                 = _("Edit resource details")
             %li
-              %a.dropdown-item.dropdown-offers{ href: service_ordering_configuration_path(service, anchor: "offers") }
+              %a.dropdown-item.dropdown-offers{ href: service_ordering_configuration_path(service, anchor: "offers",
+                                                from: params[:from]) }
                 = _("Set parameters and offers")
       %span.ordertype-label
         %i{ class: "ordertype #{order_type(service)}" }

--- a/app/views/services/ordering_configuration/offers/edit.html.haml
+++ b/app/views/services/ordering_configuration/offers/edit.html.haml
@@ -4,17 +4,20 @@
   .mb-4.pb-4.border-header
     %h1= _("Edit offer")
 
+  - from = params[:from] || from
   - if @service.offers.size == 1
     = render "backoffice/services/offers/one_offer_edit_form",
       offer: @offer,
       service: @service,
       offer_form_source_module: [@service, :ordering_configuration, @offer],
-      back_link: service_ordering_configuration_path(@service)
+      back_link: service_ordering_configuration_path(@service, from: from),
+      from: from
   - else
     = render "backoffice/services/offers/form",
       offer: @offer,
       service: @service,
       show_delete_button: true,
       offer_form_source_module: [@service, :ordering_configuration, @offer],
-      offer_delete_link: service_ordering_configuration_offer_path(@service, @offer),
-      back_link: service_ordering_configuration_path(@service)
+      offer_delete_link: service_ordering_configuration_offer_path(@service, @offer, from: from),
+      back_link: service_ordering_configuration_path(@service, from: from),
+      from: from

--- a/app/views/services/ordering_configuration/offers/new.html.haml
+++ b/app/views/services/ordering_configuration/offers/new.html.haml
@@ -9,4 +9,5 @@
     offer: @offer,
     show_delete_button: false,
     offer_form_source_module: [@service, :ordering_configuration, @offer],
-    back_link: service_ordering_configuration_path(@service)
+    back_link: service_ordering_configuration_path(@service, from: params[:from]),
+    from: params[:from]

--- a/app/views/services/ordering_configurations/_header.html.haml
+++ b/app/views/services/ordering_configurations/_header.html.haml
@@ -25,7 +25,9 @@
     .vertical-center-inner.access-type
       = link_to _("Back to the resource"), service_path(service),
         class: "btn btn-outline-primary d-block mb-3"
-      = link_to _("Set parameters and offers"), service_ordering_configuration_path(service, anchor: "offers"),
+      = link_to _("Set parameters and offers"), service_ordering_configuration_path(service,
+                                                                                    anchor: "offers",
+                                                                                    from: params[:from]),
         class: "btn btn-outline-secondary d-block mb-3"
       %span.ordertype-label
         %i{ class: "ordertype #{order_type(service)}" }

--- a/config/breadcrumbs/marketplace.rb
+++ b/config/breadcrumbs/marketplace.rb
@@ -28,7 +28,7 @@ crumb :service do |service|
 end
 
 crumb :ordering_configuration do |service|
-  link "Ordering configuration", service_ordering_configuration_path(service)
+  link "Ordering configuration", service_ordering_configuration_path(service, from: params[:from])
   parent :service, service
 end
 
@@ -38,7 +38,7 @@ crumb :ordering_configuration_offer_new do |service|
 end
 
 crumb :ordering_configuration_offer_edit do |offer|
-  link "Edit", edit_service_ordering_configuration_offer_path(offer)
+  link "Edit", edit_service_ordering_configuration_offer_path(offer, from: params[:from])
   parent :ordering_configuration, offer.service
 end
 

--- a/config/locales/pundit.en.yml
+++ b/config/locales/pundit.en.yml
@@ -1,9 +1,3 @@
 en:
   pundit:
-    default: "You are not authorized to see this page"
-    project_policy:
-      "destroy?": "Projects with pending or active resource access request cannot be deleted or archived"
-    service_policy:
-      "show?": "This resource is not published in the Marketplace yet, therefore it cannot be accessed.
-        If you are the Resource Owner or Resource Portfolio Manager and wish to manage this resource,
-        please log in and go to the Backoffice tab."
+    default: "You are not authorized to see this page."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,17 +186,15 @@ Rails.application.routes.draw do
   match "communities", to: "pages#communities", via: "get", as: :communities
   match "about_projects", to: "pages#about_projects", via: "get", as: :about_projects
 
-  if Rails.env.production?
-    match "/404", to: "errors#not_found", via: :all
-    match "/422", to: "errors#unprocessable", via: :all
-    match "/500", to: "errors#internal_server_error", via: :all
-  end
-
   if Rails.env.development?
     get "designsystem" => "designsystem#index"
     get "designsystem/:file" => "designsystem#show",
       constraints: { file: %r{[^/\.]+} }
   end
+
+  match "/404", to: "errors#not_found", via: :all
+  match "/422", to: "errors#unprocessable", via: :all
+  match "/500", to: "errors#internal_server_error", via: :all
 
   root "home#index"
 end

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -82,6 +82,6 @@ RSpec.feature "Service categories" do
   scenario "navigating to nonexistent category should redirect to :services" do
     category = build(:category, slug: "noncategory", name: "noncategory")
     visit category_services_path(category, per_page: "1")
-    expect(page).to have_current_path(services_path)
+    expect(page).to have_current_path("/404")
   end
 end

--- a/spec/features/ordering_configuration_spec.rb
+++ b/spec/features/ordering_configuration_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature "Services in ordering_configuration panel" do
 
       service.reload
 
-      visit service_ordering_configuration_path(service)
+      visit service_ordering_configuration_path(service, from: "backoffice_service")
       first(".btn.btn-outline-secondary.font-weight-bold").click
 
       check "Use EOSC Portal as the order management platform"
@@ -175,7 +175,7 @@ RSpec.feature "Services in ordering_configuration panel" do
 
       service.reload
 
-      visit service_ordering_configuration_path(service)
+      visit service_ordering_configuration_path(service, from: "backoffice_service")
       first(".btn.btn-outline-secondary.font-weight-bold").click
 
       check "Use EOSC Portal as the order management platform"

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -65,10 +65,7 @@ RSpec.feature "Service browsing" do
       service = create(:service, status: :draft)
       visit service_path(service)
 
-      expect(page).to have_content("This resource is not published in the Marketplace yet, " +
-      "therefore it cannot be accessed. If you are the Resource Owner or Resource Portfolio Manager and wish " +
-      "to manage this resource, please log in and go to the Backoffice tab.")
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq("/404")
     end
 
     scenario "shows related services" do

--- a/spec/policies/service_context_policy_spec.rb
+++ b/spec/policies/service_context_policy_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ServiceContextPolicy do
+  let(:user) { create(:user) }
+  let(:data_administrator) { create(:data_administrator, email: user.email) }
+  let(:provider) { create(:provider, data_administrators: [data_administrator]) }
+  let(:service) { create(:service, resource_organisation: provider) }
+
+  subject { described_class }
+
+  def resolve
+    subject::Scope.new(user, Service).resolve
+  end
+
+  permissions ".scope" do
+    it "not allows draft services" do
+      create(:service, status: :draft)
+
+      expect(resolve.count).to eq(0)
+    end
+
+    it "not allows deleted services" do
+      create(:service, status: :deleted)
+
+      expect(resolve.count).to eq(0)
+    end
+
+    it "allows published services" do
+      create(:service, status: :published)
+
+      expect(resolve.count).to eq(1)
+    end
+
+    it "allows unverified services" do
+      create(:service, status: :unverified)
+
+      expect(resolve.count).to eq(1)
+    end
+  end
+
+  permissions :show? do
+    it "is granted for published service" do
+      expect(subject).to permit(user, ServiceContext.new(build(:service, status: :published), false))
+    end
+
+    it "is granted for unverified service" do
+      expect(subject).to permit(user, ServiceContext.new(build(:service, status: :unverified), false))
+    end
+
+    it "portfolio manager is granted for draft service" do
+      allow(user).to receive(:service_portfolio_manager?).and_return(true)
+      expect(subject).to permit(user, ServiceContext.new(build(:service, status: :draft), true))
+    end
+
+    it "owner is granted for draft service" do
+      service = build(:service, status: :draft)
+      allow(service).to receive(:owned_by?).with(user).and_return(true)
+      expect(subject).to permit(user, ServiceContext.new(service, true))
+    end
+
+    it "admin is granted for draft service" do
+      service = build(:service, status: :draft)
+      allow(service).to receive(:administered_by?).with(user).and_return(true)
+      expect(subject).to permit(user, ServiceContext.new(service, true))
+    end
+
+    it "denies for draft service" do
+      permit(user, build(:service, status: :draft))
+    rescue e
+      expect(e).to be_an_instance_of(Pundit::NotAuthorizedError)
+      expect(e.query).to be("draft")
+    end
+
+    it "denies for deleted service" do
+      allow(user).to receive(:service_portfolio_manager?).and_return(true)
+
+      service = build(:service, status: :draft)
+      allow(service).to receive(:owned_by?).with(user).and_return(true)
+      allow(service).to receive(:administered_by?).with(user).and_return(true)
+
+      permit(user, build(:service, status: :deleted))
+    rescue e
+      expect(e).to be_an_instance_of(Pundit::NotAuthorizedError)
+      expect(e.query).to be("removed")
+    end
+  end
+
+  permissions :order? do
+    it "grants access when there are offers" do
+      service = create(:service)
+      create(:offer, service: service)
+
+      expect(subject).to permit(user, ServiceContext.new(service.reload, true))
+    end
+
+    it "denies when there is not offers" do
+      expect(subject).to_not permit(user, ServiceContext.new(build(:service), true))
+    end
+  end
+end

--- a/spec/policies/service_policy_spec.rb
+++ b/spec/policies/service_policy_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe ServicePolicy do
       expect(resolve.count).to eq(0)
     end
 
+    it "not allows deleted services" do
+      create(:service, status: :deleted)
+
+      expect(resolve.count).to eq(0)
+    end
+
     it "allows published services" do
       create(:service, status: :published)
 
@@ -32,33 +38,6 @@ RSpec.describe ServicePolicy do
       create(:service, status: :unverified)
 
       expect(resolve.count).to eq(1)
-    end
-  end
-
-  permissions :show? do
-    it "is granted for published service" do
-      expect(subject).to permit(user, build(:service, status: :published))
-    end
-
-    it "is granted for unvefiried service" do
-      expect(subject).to permit(user, build(:service, status: :unverified))
-    end
-
-    it "denies for draft service" do
-      expect(subject).to_not permit(user, build(:service, status: :draft))
-    end
-  end
-
-  permissions :order? do
-    it "grants access when there are offers" do
-      service = create(:service)
-      create(:offer, service: service)
-
-      expect(subject).to permit(user, service.reload)
-    end
-
-    it "denies when there is not offers" do
-      expect(subject).to_not permit(user, build(:service))
     end
   end
 

--- a/spec/requests/backoffice/services_spec.rb
+++ b/spec/requests/backoffice/services_spec.rb
@@ -32,5 +32,39 @@ RSpec.describe "Backoffice service" do
 
       expect(service).to be_draft
     end
+
+    it "I can't publish a offer when a service has a deleted status" do
+      service = create(:service, owners: [user], status: :deleted)
+      offer = create(:offer, service: service)
+
+      post backoffice_service_offer_publish_path(service, offer)
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq(I18n.t("default", scope: :pundit))
+    end
+
+    it "I can't change a offer to draft when a service has a deleted status" do
+      service = create(:service, owners: [user], status: :deleted)
+      offer = create(:offer, service: service)
+
+      post backoffice_service_offer_draft_path(service, offer)
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq(I18n.t("default", scope: :pundit))
+    end
+
+    it "I can't publish a service with deleted status" do
+      service = create(:service, owners: [user], status: :deleted)
+
+      post backoffice_service_publish_path(service)
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq(I18n.t("default", scope: :pundit))
+    end
+
+    it "I can't change status to a service with deleted status" do
+      service = create(:service, owners: [user], status: :deleted)
+
+      post backoffice_service_draft_path(service)
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq(I18n.t("default", scope: :pundit))
+    end
   end
 end

--- a/spec/requests/public/services_spec.rb
+++ b/spec/requests/public/services_spec.rb
@@ -1,0 +1,477 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Services" do
+  context "as a logged in service portfolio manager" do
+    let(:user) { create(:user, roles: [:service_portfolio_manager]) }
+    before { login_as(user) }
+
+    context "when service has deleted status" do
+      it "I can't see a service" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a service with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_path(service, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a offer" do
+        service = create(:service, owners: [user], status: :deleted)
+        offer = create(:offer, service: service)
+
+        get service_offers_path(service, offer)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a offer with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+        offer = create(:offer, service: service)
+
+        get service_offers_path(service, offer, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a configuration" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_configuration_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a configuration with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_configuration_path(service, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a information" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_information_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a information with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_information_path(service, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a summary" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_summary_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a summary with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_summary_path(service, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't cancel" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        delete service_cancel_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't cancel with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        delete service_cancel_path(service, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't create a new question" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get new_service_question_path(service, format: :js)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see the opinions" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_opinions_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see the opinions with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_opinions_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see details" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_details_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see details with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get service_details_path(service, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a ordering configuration" do
+        service = create(:service, owners: [user], status: :deleted, offers: [create(:offer)])
+
+        get service_ordering_configuration_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a ordering configuration with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted, offers: [create(:offer)])
+
+        get service_ordering_configuration_path(service, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't create a new offer" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get new_service_ordering_configuration_offer_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't create a new offer with param 'from'" do
+        service = create(:service, owners: [user], status: :deleted)
+
+        get new_service_ordering_configuration_offer_path(service, from: "backoffice_service")
+        expect(response).to redirect_to "/404"
+      end
+    end
+
+    context "when service has draft status" do
+      it "I can't see a service" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can see a service" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't see a offer" do
+        service = create(:service, owners: [user], status: :draft, offers_count: 1)
+        offer = create(:offer, service: service)
+
+        get service_offers_path(service, offer)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can see a offer" do
+        service = create(:service, owners: [user], status: :draft, offers_count: 1)
+        offer = create(:offer, service: service)
+
+        get service_offers_path(service, offer, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't see a configuration" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_configuration_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can see a configuration" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_configuration_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't see a information" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_information_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can see a information" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_information_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't see a summary" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_summary_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can see a summary" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_summary_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't cancel" do
+        service = create(:service, owners: [user], status: :draft)
+
+        delete service_cancel_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can cancel" do
+        service = create(:service, owners: [user], status: :draft)
+
+        delete service_cancel_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't create a new question" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get new_service_question_path(service, format: :js)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see the opinions" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_opinions_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see the opinions" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_opinions_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't see details" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_details_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can see details" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get service_details_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't see a ordering configuration" do
+        service = create(:service, owners: [user], status: :draft, offers: [create(:offer)])
+
+        get service_ordering_configuration_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a ordering configuration" do
+        service = create(:service, owners: [user], status: :draft, offers: [create(:offer)])
+
+        get service_ordering_configuration_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+
+      it "I can't create a new offer" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get new_service_ordering_configuration_offer_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can create a new offer" do
+        service = create(:service, owners: [user], status: :draft)
+
+        get new_service_ordering_configuration_offer_path(service, from: "backoffice_service")
+        expect(response).not_to redirect_to "/404"
+      end
+    end
+  end
+
+  context "as a logged in user" do
+    let(:user) { create(:user) }
+    before { login_as(user) }
+
+    context "when service has deleted status" do
+      it "I can't see a service" do
+        service = create(:service, status: :deleted)
+
+        get service_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a offer" do
+        service = create(:service, status: :deleted)
+        offer = create(:offer, service: service)
+
+        get service_offers_path(service, offer)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a configuration" do
+        service = create(:service, status: :deleted)
+
+        get service_configuration_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a information" do
+        service = create(:service, status: :deleted)
+
+        get service_information_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a summary" do
+        service = create(:service, status: :deleted)
+
+        get service_summary_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't cancel" do
+        service = create(:service, status: :deleted)
+
+        delete service_cancel_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't create a new question" do
+        service = create(:service, status: :deleted)
+
+        get new_service_question_path(service, format: :js)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see the opinions" do
+        service = create(:service, status: :deleted)
+
+        get service_opinions_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see details" do
+        service = create(:service, status: :deleted)
+
+        get service_details_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a ordering configuration" do
+        service = create(:service, status: :deleted, offers: [create(:offer)])
+
+        get service_ordering_configuration_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't create a new offer" do
+        service = create(:service, status: :deleted)
+
+        get new_service_ordering_configuration_offer_path(service)
+        expect(response).to redirect_to "/404"
+      end
+    end
+
+    context "when service has draft status" do
+      it "I can't see a service" do
+        service = create(:service, status: :draft)
+
+        get service_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a offer" do
+        service = create(:service, status: :draft)
+        offer = create(:offer, service: service)
+
+        get service_offers_path(service, offer)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a configuration" do
+        service = create(:service, status: :draft)
+
+        get service_configuration_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a information" do
+        service = create(:service, status: :draft)
+
+        get service_information_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a summary" do
+        service = create(:service, status: :draft)
+
+        get service_summary_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't cancel" do
+        service = create(:service, status: :draft)
+
+        delete service_cancel_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't create a new question" do
+        service = create(:service, status: :draft)
+
+        get new_service_question_path(service, format: :js)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see the opinions" do
+        service = create(:service, status: :draft)
+
+        get service_opinions_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see details" do
+        service = create(:service, status: :draft)
+
+        get service_details_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't see a ordering configuration" do
+        service = create(:service, status: :draft, offers: [create(:offer)])
+
+        get service_ordering_configuration_path(service)
+        expect(response).to redirect_to "/404"
+      end
+
+      it "I can't create a new offer" do
+        service = create(:service, status: :draft)
+
+        get new_service_ordering_configuration_offer_path(service)
+        expect(response).to redirect_to "/404"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- disable all edition/creation of deleted service related
items
- auth services offers
- auth services configuration
- auth services information
- auth services summary
- auth services cancel
- auth services question
- auth services opinions
- auth services details
- auth services ordering_configuration
- auth services ordering_configuration offers
- users with `Service portfolio manager` privilege or owning/administrating `service` can see `resource` in `draft` mode
- Service with status `delete` can be seen only in backoffice