### PR TITLE
[#1843] Remove corrupted logos

### DIFF
--- a/lib/tasks/remove_corrupted_logos.rake
+++ b/lib/tasks/remove_corrupted_logos.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "mini_magick"
+
+desc "Remove corrupted logos"
+task remove_corrupted_logos: :environment do
+  service = Service.where(slug: "gbif-spain-spatial-portal").first
+  service.logo.detach
+  service.save
+end


### PR DESCRIPTION
## Context
Currently, we are allowing to save logos in a corrupted state. Especially images with extensions like i. e. `SVG` or expired URL to the binary source. In PR #2078 such occurrences will be not allowed and timeout. The next step will be logging all such errors (#2143) and handle them accordingly. For current state will be enough to remove crashed logos from Services.