### PR TITLE
[#2135] Make OMS visibility depend on resource_organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Improve consistency between Marketplace provider and Provider Component provider form and data model - improvement of User experience (@danielkryska)
+- Provider group OMS visibility now depends on service's resource_organisation instead of on providers (@jswk)
 
 ### Deprecated
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -231,7 +231,7 @@ class Service < ApplicationRecord
   end
 
   def available_omses
-    (OMS.where(default: true).to_a + omses.to_a + OMS.where(type: :global).to_a + providers.map(&:omses).flatten).uniq
+    (OMS.where(default: true).to_a + omses.to_a + OMS.where(type: :global).to_a + resource_organisation&.omses).uniq
   end
 
   private

--- a/spec/lib/ordering_api/add_provider_oms_spec.rb
+++ b/spec/lib/ordering_api/add_provider_oms_spec.rb
@@ -6,7 +6,7 @@ require "ordering_api/add_provider_oms"
 describe OrderingApi::AddProviderOMS do
   let!(:provider) { create(:provider, pid: "test.pid") }
   let!(:another_provider) { create(:provider, pid: "another.pid") }
-  let(:service) { create(:service, providers: [provider]) }
+  let(:service) { create(:service, resource_organisation: provider) }
 
   it "fails if provider is not found" do
     expect(provider.omses.count).to eq(0)

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Offer do
   context "proper_oms?" do
     it "should validate if set oms is available for current offer" do
       provider = create(:provider)
-      service = create(:service, providers: [provider])
+      service = create(:service, resource_organisation: provider)
 
       default_oms = create(:oms, default: true)
       provider_group_oms = create(:oms, type: :provider_group, providers: [provider])

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -78,4 +78,34 @@ RSpec.describe Service do
     subject { build(:service, omses: build_list(:resource_dedicated_oms, 2)) }
     it { should have_many(:omses) }
   end
+
+  context "#available_omses" do
+    subject { build(:service) }
+
+    it "should return empty if there are no OMSes" do
+      expect(subject.available_omses).to eq([])
+    end
+
+    context "when there are registered OMSes" do
+      before do
+        @global_oms = create(:oms)
+        @default_oms = create(:oms, default: true)
+        @provider_oms = create(:provider_group_oms)
+        @resource_oms = create(:resource_dedicated_oms)
+      end
+
+      it "doesn't return if not associated" do
+        subject.update!(providers: [@provider_oms.providers[0]])
+
+        expect(subject.available_omses).to eq([@default_oms, @global_oms])
+      end
+
+      it "returns all associated" do
+        subject.update!(resource_organisation: @provider_oms.providers[0])
+        @resource_oms.update!(service: subject)
+
+        expect(subject.available_omses).to eq([@default_oms, @resource_oms, @global_oms, @provider_oms])
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/resources_controller_spec.rb
+++ b/spec/requests/api/v1/resources_controller_spec.rb
@@ -115,12 +115,13 @@ RSpec.describe Api::V1::ResourcesController, swagger_doc: "v1/offering_swagger.j
 
         let(:provider1) { create(:provider, data_administrators: [data_admin]) }
         let(:provider2) { create(:provider) }
-        let(:service) { create(:service, providers: [provider1, provider2], resource_organisation: provider1) }
+        let(:service) { create(:service, resource_organisation: provider1) }
 
         let!(:default_oms) { create(:oms, type: :global, default: true,
                                     custom_params: { param: { mandatory: true, default: "some_default" },
                                                      other_param: { mandatory: false } }) }
         let!(:provider_group_oms) { create(:oms, type: :provider_group, providers: [provider1, provider2]) }
+        let!(:provider2_group_oms) { create(:oms, type: :provider_group, providers: [provider2]) }
         let!(:resource_oms) { create(:oms, service: service, type: :resource_dedicated) }
         let!(:other_resource_oms) { create(:oms, type: :resource_dedicated, service: build(:service)) }
 


### PR DESCRIPTION
Provider group OMSes were visible to all services, which have one of the
OMSes providers in the service.providers relation.
This behaviour was deemed incorrect, resource_organisation relation
should have been used.
Providers from the service.providers relation don't configure offer and
ordering, the provider from service.resource_organisation does that.

Moreover, the resource_organisation provider may not be present in the
providers relation, causing such provider not to be able to correctly
select such OMS.

Add tests for service.available_omeses.

## How to test

The instance has two extra provider_group OMSes named: "For DIH" (for DIH provider) and "For EUDAT" (for EUDAT provider).
Service `Piloting and co-design of Business Pilots` has resource_organisation set to DIH and has EUDAT in its providers list.

Go to the service in backoffice, and verify that it has only "SOMBO" and "For DIH" OMSes available for selection. "For EUDAT" shouldn't be visible.

On the other hand, when trying to configure any of the EUDAT services (for example "B2ACCESS"), you should be able to select "For EUDAT".

As a baseline, on master there are these two OMSes created too, but for the service `Piloting...` you will see "For EUDAT" there, but no "For DIH" OMS.

## How to prepare test instance

Which service has resource_organisation which isn't on its list of providers?
```ruby
Service.all.select { |p| p.order_type == "order_required" && p.providers.present? && p.providers.exclude?(p.resource_organisation) }.pluck(:name)
```

```ruby
p_dih = Provider.friendly.find("eosc-dih")
oms_dih = OMS.create!(name: "For DIH", type: :provider_group, provider_ids: [p_dih.id])
p_eudat = Provider.friendly.find("eudat")
oms_eudat = OMS.create!(name: "For EUDAT", type: :provider_group, providers: [p_eudat])
```

Fixes: #2135.