### PR TITLE
[#2144] Add UID to author in Ordering API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [3.15.0-milestone]
 
 ### Added
+- Message author's and project owner's UID field in the Ordering API (@jswk)
 
 ### Changed
 - Improve consistency between Marketplace provider and Provider Component provider form and data model - improvement of User experience (@danielkryska)

--- a/app/controllers/api/v1/omses/messages_controller.rb
+++ b/app/controllers/api/v1/omses/messages_controller.rb
@@ -91,6 +91,7 @@ class Api::V1::OMSes::MessagesController < Api::V1::ApplicationController
     def transform(attributes)
       transformed = Hash.new
       if attributes[:author].present?
+        transformed[:author_uid] = attributes[:author][:uid]
         transformed[:author_email] = attributes[:author][:email]
         transformed[:author_name] = attributes[:author][:name]
         transformed[:author_role] = attributes[:author][:role]

--- a/app/policies/api/v1/message_policy.rb
+++ b/app/policies/api/v1/message_policy.rb
@@ -34,7 +34,7 @@ class Api::V1::MessagePolicy < ApplicationPolicy
       :project_item_id,
       :content,
       :scope,
-      author: [:email, :name, :role]
+      author: [:uid, :email, :name, :role]
     ]
   end
 

--- a/app/serializers/api/v1/message_serializer.rb
+++ b/app/serializers/api/v1/message_serializer.rb
@@ -8,11 +8,19 @@ class Api::V1::MessageSerializer < ActiveModel::Serializer
   attributes :created_at, :updated_at
 
   def author
-    {
-      email: object.role_user? ? object.author.email : object.author_email,
-      name: object.role_user? ? object.author.full_name : object.author_name,
-      role: object.author_role
-    }
+    if object.role_user?
+      {
+        uid: object.author&.uid,
+        email: object.author&.email,
+        name: object.author&.full_name
+      }
+    else
+      {
+        uid: object.author_uid,
+        email: object.author_email,
+        name: object.author_name
+      }
+    end.merge({ role: object.author_role }).select { |_, value| value.present? }
   end
 
   def message_scope

--- a/app/serializers/api/v1/project_serializer.rb
+++ b/app/serializers/api/v1/project_serializer.rb
@@ -8,6 +8,7 @@ class Api::V1::ProjectSerializer < ActiveModel::Serializer
 
   def owner
     {
+      uid: object.user.uid,
       email: object.user.email,
       name: object.user.full_name
     }

--- a/db/migrate/20210614131726_add_author_uid_to_message.rb
+++ b/db/migrate/20210614131726_add_author_uid_to_message.rb
@@ -1,0 +1,5 @@
+class AddAuthorUidToMessage < ActiveRecord::Migration[6.0]
+  def change
+    add_column :messages, :author_uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_08_090039) do
+ActiveRecord::Schema.define(version: 2021_06_14_131726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2021_06_08_090039) do
     t.string "author_name"
     t.string "author_role", null: false
     t.string "scope", null: false
+    t.string "author_uid"
     t.index ["author_id"], name: "index_messages_on_author_id"
     t.index ["author_role"], name: "index_messages_on_author_role"
     t.index ["messageable_type", "messageable_id"], name: "index_messages_on_messageable_type_and_messageable_id"

--- a/spec/serializers/api/v1/message_serializer_spec.rb
+++ b/spec/serializers/api/v1/message_serializer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::V1::MessageSerializer do
     expected = {
       id: message.id,
       author: {
+        uid: message.author.uid,
         email: message.author.email,
         name: message.author.full_name,
         role: message.author_role
@@ -24,14 +25,33 @@ RSpec.describe Api::V1::MessageSerializer do
   end
 
   it "it properly serializes a provider message" do
-    message = create(:provider_message)
+    message = create(:provider_message, author_uid: "example@idp")
 
     serialized = described_class.new(message).as_json
     expected = {
       id: message.id,
       author: {
+        uid: message.author_uid,
         email: message.author_email,
         name: message.author_name,
+        role: message.author_role
+      },
+      content: message.message,
+      scope: message.scope,
+      created_at: message.created_at.iso8601,
+      updated_at: message.updated_at.iso8601
+    }
+
+    expect(serialized).to eq(expected)
+  end
+
+  it "it properly serializes a provider message with minimal author information" do
+    message = create(:provider_message, author_email: nil, author_name: nil)
+
+    serialized = described_class.new(message).as_json
+    expected = {
+      id: message.id,
+      author: {
         role: message.author_role
       },
       content: message.message,

--- a/spec/serializers/api/v1/project_serializer_spec.rb
+++ b/spec/serializers/api/v1/project_serializer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::V1::ProjectSerializer do
     expected = {
       id: project.id,
       owner: {
+        uid: project.user.uid,
         name: project.user.full_name,
         email: project.user.email,
       },
@@ -39,6 +40,7 @@ RSpec.describe Api::V1::ProjectSerializer do
     expected = {
       id: project.id,
       owner: {
+        uid: project.user.uid,
         name: project.user.full_name,
         email: project.user.email,
       },

--- a/swagger/v1/message/message_read.json
+++ b/swagger/v1/message/message_read.json
@@ -5,6 +5,7 @@
     "author": {
       "type": "object",
       "properties": {
+        "uid": {"type": "string"},
         "email": {"type": "string"},
         "name": {"type": "string"},
         "role": {"type": "string",

--- a/swagger/v1/message/message_write.json
+++ b/swagger/v1/message/message_write.json
@@ -6,6 +6,7 @@
     "author": {
       "type": "object",
       "properties": {
+        "uid": {"type": "string"},
         "email": {"type": "string"},
         "name": {"type": "string"},
         "role": {"type": "string",

--- a/swagger/v1/ordering_swagger.json
+++ b/swagger/v1/ordering_swagger.json
@@ -322,7 +322,14 @@
         ],
         "responses": {
           "200": {
-            "description": "message found"
+            "description": "message found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "message/message_read.json"
+                }
+              }
+            }
           },
           "401": {
             "description": "user not recognized",

--- a/swagger/v1/project/project_read.json
+++ b/swagger/v1/project/project_read.json
@@ -5,11 +5,12 @@
     "owner": {
       "type": "object",
       "properties": {
+        "uid": {"type": "string"},
         "email": {"type": "string"},
         "name": {"type": "string"}
       },
       "additionalProperties": false,
-      "required": ["email", "name"]
+      "required": ["uid", "email", "name"]
     },
     "project_items": {
       "type": "array",


### PR DESCRIPTION
Extend the Ordering API by adding `uid` property to author: both for
project and messages.

Allow to specify the extra field for provider and mediator messages as
well. Add it as an optional field in POST request to /messages endpoint.

Add missing GET /api/v1/oms/{oms_id}/messages/{m_id} ref.

## How to test

SOMBO token: `LBPcykf7dpzi_GmfXLzs`.

Create a project and a project item. Add messages to both.

Using Ordering API:

Verify that when you GET a project then the field `owner` now has the field `uid`.
Verify that when you GET any of your messages, then the field `author` has the field `uid`.

Verify that if you POST a message to project or project_item and specify field `uid` in `author` then its value is persisted and returned in this message GET responses.

Closes: #2144.