### PR TITLE
Add e2e tests for filters on services page

### DIFF
--- a/app/views/services/filters/_multiselect_level.html.haml
+++ b/app/views/services/filters/_multiselect_level.html.haml
@@ -2,7 +2,7 @@
   - options.each do |option|
     - muted = option[:count].to_i.zero?
     - target = root ? "multicheckbox.element multicheckbox.item" : "multicheckbox.item"
-    %li{ data: { target: target } }
+    %li{ data: { target: target }, "data-e2e": "filter-checkbox" }
       %label{ class: ("text-muted" if muted) }
         %input.form-check-input{ type: "checkbox", name: "#{name}[]",
           multiple: true, checked: values.include?(option[:id].to_s), value: option[:id],

--- a/app/views/services/filters/_select.html.haml
+++ b/app/views/services/filters/_select.html.haml
@@ -1,6 +1,6 @@
 = render "services/filters/wrapper", filter: filter do
   .form-group
     %select.panel-body.form-control.custom-select.form-control-sm{ name: filter.field_name,
-      "data-action": "change->filter#reload", "data-probe" => "" }
+      "data-action": "change->filter#reload", "data-probe" => "", "data-e2e": "filter-select" }
       = options_for_select(filter.options.map { |x| [x[:name], x[:id]] },
                            params[filter.field_name])

--- a/test/system/cypress.json
+++ b/test/system/cypress.json
@@ -6,7 +6,7 @@
   "testFiles": "**/*.spec.ts",
   "fileServerFolder": "./",
   "supportFile": "./cypress/support/index.ts",
-  "chromeWebSecurity" : false,
+  "chromeWebSecurity": false,
   "retries": {
     "runMode": 0,
     "openMode": 0
@@ -18,4 +18,3 @@
     "debug": false
   }
 }
-

--- a/test/system/cypress/integration/regression_tests/servce-page/filters/dedicated_for.spec.ts
+++ b/test/system/cypress/integration/regression_tests/servce-page/filters/dedicated_for.spec.ts
@@ -1,0 +1,17 @@
+describe("Filter decidated for", () => {
+  beforeEach(() => {
+    cy.visit("/services");
+  });
+  
+  it("should select filter", () => {
+    cy.get("[data-e2e='filter-tag']")
+      .should("not.exist")
+    cy.get("#collapse_target_users [data-e2e='filter-checkbox']")
+      .eq(0)
+      .click();
+    cy.location("href")
+      .should("include", "/services?target_users");
+    cy.get("[data-e2e='filter-tag']")
+      .should("be.visible")
+  });
+});

--- a/test/system/cypress/integration/regression_tests/servce-page/filters/infrastructutes_platforms.spec.ts
+++ b/test/system/cypress/integration/regression_tests/servce-page/filters/infrastructutes_platforms.spec.ts
@@ -1,0 +1,17 @@
+describe("Filter related infrastructures and platforms", () => {
+  beforeEach(() => {
+    cy.visit("/services");
+  });
+  
+  it("should select filter", () => {
+    cy.get("[data-e2e='filter-tag']")
+      .should("not.exist")
+    cy.get("#collapse_related_platforms [data-e2e='filter-checkbox']")
+      .eq(0)
+      .click();
+    cy.location("href")
+      .should("include", "/services?related_platforms");
+    cy.get("[data-e2e='filter-tag']")
+      .should("be.visible");
+  });
+});

--- a/test/system/cypress/integration/regression_tests/servce-page/filters/order_type.spec.ts
+++ b/test/system/cypress/integration/regression_tests/servce-page/filters/order_type.spec.ts
@@ -1,0 +1,21 @@
+describe("Filter order type", () => {
+  beforeEach(() => {
+    cy.visit("/services");
+  });
+
+  it("should select filter", () => {
+    cy.get("[data-e2e='filter-tag']")
+      .should("not.exist")
+    cy.get("#collapse_order_type [data-e2e='filter-select'] > option")
+      .eq(1)
+      .invoke("text")
+      .then(value=>{
+        cy.get("#collapse_order_type [data-e2e='filter-select']")
+          .select(value)
+      })
+    cy.location("href")
+      .should("include", "/services?order_type");
+    cy.get("[data-e2e='filter-tag']")
+      .should("be.visible");
+  });
+});

--- a/test/system/cypress/integration/regression_tests/servce-page/filters/providers.spec.ts
+++ b/test/system/cypress/integration/regression_tests/servce-page/filters/providers.spec.ts
@@ -1,0 +1,18 @@
+describe("Filter providers", () => {
+  beforeEach(() => {
+    cy.visit("/services");
+  });
+  
+  it("should select filter", () => {
+    cy.get("[data-e2e='filter-tag']")
+      .should("not.exist")
+    cy.get("#collapse_providers [data-e2e='filter-checkbox']")
+      .eq(0)
+      .click();
+    cy.location("href")
+      .should("include", "/services?providers");
+    cy.get("[data-e2e='filter-tag']")
+      .should("be.visible");
+  });
+});
+

--- a/test/system/cypress/integration/regression_tests/servce-page/filters/rating.spec.ts
+++ b/test/system/cypress/integration/regression_tests/servce-page/filters/rating.spec.ts
@@ -1,0 +1,21 @@
+describe("Filter rating", () => {
+  beforeEach(() => {
+    cy.visit("/services");
+  });
+  
+  it("should select filter", () => {
+    cy.get("[data-e2e='filter-tag']")
+      .should("not.exist")
+    cy.get("#collapse_rating [data-e2e='filter-select'] > option")
+      .eq(1)
+      .invoke("text")
+      .then(value=>{
+        cy.get("#collapse_rating [data-e2e='filter-select']")
+          .select(value)
+      })
+    cy.location("href")
+      .should("include", "/services?rating");
+    cy.get("[data-e2e='filter-tag']")
+      .should("be.visible");
+  });
+});

--- a/test/system/cypress/integration/regression_tests/servce-page/filters/resource_availability.spec.ts
+++ b/test/system/cypress/integration/regression_tests/servce-page/filters/resource_availability.spec.ts
@@ -1,0 +1,21 @@
+describe("Filter resource availabilities", () => {
+  beforeEach(() => {
+    cy.visit("/services");
+  });
+  
+  it("should select filter", () => {
+    cy.get("[data-e2e='filter-tag']")
+      .should("not.exist")
+    cy.get("#collapse_geographical_availabilities [data-e2e='filter-select'] > option")
+      .eq(1)
+      .invoke("text")
+      .then(value=>{
+        cy.get("#collapse_geographical_availabilities [data-e2e='filter-select']")
+          .select(value)
+      })
+    cy.location("href")
+      .should("include", "/services?geographical_availabilities");
+    cy.get("[data-e2e='filter-tag']")
+      .should("be.visible");
+  });
+});

--- a/test/system/cypress/integration/regression_tests/servce-page/filters/scientific_domains.spec.ts
+++ b/test/system/cypress/integration/regression_tests/servce-page/filters/scientific_domains.spec.ts
@@ -1,0 +1,17 @@
+describe("Filter scientific domains", () => {
+  beforeEach(() => {
+    cy.visit("/services");
+  });
+  
+  it("should select filter", () => {
+    cy.get("[data-e2e='filter-tag']")
+      .should("not.exist")
+    cy.get("#collapse_scientific_domains [data-e2e='filter-checkbox']")
+      .eq(0)
+      .click();
+    cy.location("href")
+      .should("include", "/services?scientific_domains");
+    cy.get("[data-e2e='filter-tag']")
+      .should("be.visible");
+  });
+});


### PR DESCRIPTION
Add e2e tests for filters on services page 

Add test for scientific domains, providers, dedicated for, platforms, order type, rating, resource availability filters

tests select the first element of each filter and check the filter has been turned on and the url is correct