### PR TITLE
[#1959] Fix recaptcha error on Questions form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Don't leak sensitive OMS fields in Offering API (@jswk)
+- Forms for questions about providers/resources are working properly (@goreck888)
 
 ## [3.14.0] 2021-06-11
 

--- a/app/controllers/providers/questions_controller.rb
+++ b/app/controllers/providers/questions_controller.rb
@@ -18,7 +18,7 @@ class Providers::QuestionsController < ApplicationController
                                      text: params[:provider_question][:text],
                                      provider: @provider)
     respond_to do |format|
-      if @question.valid? && verify_recaptcha
+      if @question.valid? && verify_recaptcha(model: @question, attribute: :verified_recaptcha)
         @provider.public_contacts.each  do |contact|
           ProviderMailer.new_question(contact.email, @question.author, @question.email,
                                      @question.text, @provider).deliver_later

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -15,7 +15,7 @@ class ReportsController < ApplicationController
                               email: user&.email || params[:report][:email],
                               text: params[:report][:text])
     respond_to do |format|
-      if @report.valid? && verify_recaptcha
+      if @report.valid? && verify_recaptcha(model: @report, attribute: :verified_recaptcha)
         Report::Create.new(@report).call
         format.js { render js: "window.top.location.reload(true);" }
         flash[:notice] = "Your report was successfully sent"

--- a/app/controllers/services/questions_controller.rb
+++ b/app/controllers/services/questions_controller.rb
@@ -18,7 +18,7 @@ class Services::QuestionsController < ApplicationController
                                      text: params[:service_question][:text],
                                      service: @service)
     respond_to do |format|
-      if @question.valid? && verify_recaptcha
+      if @question.valid? && verify_recaptcha(model: @question, attribute: :verified_recaptcha)
         @service.public_contacts.each  do |contact|
           ServiceMailer.new_question(contact.email, @question.author, @question.email,
                                      @question.text, @service).deliver_later

--- a/app/models/provider/question.rb
+++ b/app/models/provider/question.rb
@@ -5,7 +5,7 @@ class Provider::Question
   include ActiveModel::Conversion
   extend ActiveModel::Naming
 
-  attr_accessor :text, :author, :provider, :email
+  attr_accessor :text, :author, :provider, :email, :verified_recaptcha
 
   validates :text, presence: { message: "Question cannot be blank" }
   validates :author, presence: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,7 +5,7 @@ class Report
   include ActiveModel::Conversion
   extend ActiveModel::Naming
 
-  attr_accessor :text, :author, :email
+  attr_accessor :text, :author, :email, :verified_recaptcha
 
   validates :text, presence: { message: "Description cannot be blank" }
   validates :author, presence: true

--- a/app/models/service/question.rb
+++ b/app/models/service/question.rb
@@ -5,7 +5,7 @@ class Service::Question
   include ActiveModel::Conversion
   extend ActiveModel::Naming
 
-  attr_accessor :text, :author, :service, :email
+  attr_accessor :text, :author, :service, :email, :verified_recaptcha
 
   validates :text, presence: { message: "Question cannot be blank" }
   validates :author, presence: true

--- a/app/views/providers/questions/_form.html.haml
+++ b/app/views/providers/questions/_form.html.haml
@@ -14,4 +14,5 @@
           hint: _("We will send your report to the Provider. You will receive an answer to " + |
                  "%{email} email address.") % { email: current_user&.email || "your" }  |
   -# haml-lint:enable MultilinePipe
-#recaptcha= recaptcha_tags
+  #recaptcha= recaptcha_tags
+  = f.error :verified_recaptcha, class: "invalid-feedback d-block"

--- a/app/views/services/questions/_form.html.haml
+++ b/app/views/services/questions/_form.html.haml
@@ -14,4 +14,5 @@
           hint: _("We will send your report to the Service provider. You will receive an answer to " + |
                  "%{email} email address.") % { email: current_user&.email || "your" }  |
   -# haml-lint:enable MultilinePipe
-#recaptcha= recaptcha_tags
+  #recaptcha= recaptcha_tags
+  = f.error :verified_recaptcha, class: "invalid-feedback d-block"


### PR DESCRIPTION
`verify_recaptcha` method didn't recognize recaptcha tags
in form and returned always false

This PR move recaptcha tags under the form of question and now it works properly
Fixes #1959