### PR TITLE
[#2029] remove elements from choices in the forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Fixed
 - Don't leak sensitive OMS fields in Offering API (@jswk)
 - Forms for questions about providers/resources are working properly (@goreck888)
+- Ability to clear a choice field in the forms (@goreck888)
 
 ## [3.14.0] 2021-06-11
 

--- a/app/controllers/backoffice/providers_controller.rb
+++ b/app/controllers/backoffice/providers_controller.rb
@@ -51,10 +51,12 @@ class Backoffice::ProvidersController < Backoffice::ApplicationController
       redirect_to backoffice_provider_path(@provider),
                   notice: "Provider updated correctly"
     else
-      if @provider.public_contacts.all? { |contact| contact.marked_for_destruction? }
+      if @provider.public_contacts.present? && @provider.public_contacts.
+        all? { |contact| contact.marked_for_destruction? }
         @provider.public_contacts[0].reload
       end
-      if @provider.data_administrators.all? { |admin| admin.marked_for_destruction? }
+      if @provider.data_administrators.present? && @provider.data_administrators.
+        all? { |admin| admin.marked_for_destruction? }
         @provider.data_administrators[0].reload
       end
       render :edit, status: :bad_request

--- a/app/views/backoffice/providers/form/_classification.html.haml
+++ b/app/views/backoffice/providers/form/_classification.html.haml
@@ -16,7 +16,7 @@
           class: ("show" unless collapsed?(provider, [:scientific_domains, :tag_list])) }
   .card-body
     = f.association :scientific_domains, disabled: cant_edit([scientific_domain_ids: []]),
-              input_html: { data: { choice: true } }, include_hidden: false,
+              input_html: { data: { choice: true } },
               collection: sd,
               label_method: :first, value_method: :second
     = f.input :tag_list, multiple: true, input_html: { class: "form-control" },

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -107,7 +107,7 @@
             class: ("show" unless collapsed?(service, [:scientific_domains,
                               :categories, :target_users, :access_types, :access_modes, :tag_list])) }
           .card-body
-            = f.association :scientific_domains, input_html: { data: { choice: true } }, include_hidden: false,
+            = f.association :scientific_domains, input_html: { data: { choice: true } },
             disabled: cant_edit([scientific_domain_ids: []]),
             collection: ScientificDomain.child_names.map { |name, sd| [name, sd.id] },
             label_method: :first, value_method: :second
@@ -117,7 +117,6 @@
             = f.association :target_users,
               label: _("Dedicated For"),
               input_html: { data: { choice: true }, class: "target_users" },
-              include_hidden: false,
               disabled: cant_edit([target_user_ids: []])
             = f.association :access_types, input_html: { data: { choice: true } },
                             disabled: cant_edit([access_type_ids: []])
@@ -146,7 +145,7 @@
                 disabled: cant_edit([geographical_availabilities: []]),
                 input_html: { data: { choice: true },  "multiple" => "true" }
             = f.input :language_availability, input_html: { multiple: true, data: { choice: true } },
-            include_hidden: false, collection: I18nData.languages.map { |k, v| [v, k] },
+            collection: I18nData.languages.map { |k, v| [v, k] },
             disabled: cant_edit([language_availability: []])
 
         .card.shadow-sm.rounded

--- a/app/views/profiles/_form.html.haml
+++ b/app/views/profiles/_form.html.haml
@@ -5,10 +5,10 @@
         %h3
           = _("Additional information")
 
-      = f.association :categories, multiple: true, include_hidden: false,
+      = f.association :categories, multiple: true,
       collection: Category.child_names.map { |name, c| [name, c.id] },
       input_html: { data: { choice: true } }
-      = f.association :scientific_domains, multiple: true, include_hidden: false,
+      = f.association :scientific_domains, multiple: true,
       collection: ScientificDomain.child_names.map { |name, sd| [name, sd.id] },
       input_html: { data: { choice: true } }
     .col-12.col-md-5.profile-edit.ml-auto

--- a/app/views/projects/_customer_typology_fields.html.haml
+++ b/app/views/projects/_customer_typology_fields.html.haml
@@ -22,7 +22,7 @@
   "data-target" => "project.singleUser project.privateCompany project.input" },
   input_html: { "data-target" => "project.originCountry", class: "col-lg-6 form-control-lg" }
 = f.input :countries_of_partnership, as: :select, collection: Country.all.map { |c| [ c.name, "value" => c.alpha2 ] },
-  include_blank: false, include_hidden: false,
+  include_blank: false,
   wrapper_html: { class: "hidden-fields col-lg-8 pl-0 pr-0",
   "data-target" => "project.partnershipCountries project.input project.research project.project" },
   input_html: { class: "choices-multiple-no-sorting col-lg-6 form-control-lg", data: { choice: true },

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -6,7 +6,7 @@
     = _("Usage")
   = f.input :name, input_html: { class: "col-lg-6 form-control-lg" }
   = f.input :reason_for_access, input_html: { class: "col-lg-8 form-control-lg textarea-lg" }
-  = f.association :scientific_domains, multiple: true, include_hidden: false,
+  = f.association :scientific_domains, multiple: true,
     wrapper_html: { class: "col-lg-8 pl-0 pr-0" }, input_html: { data: { choice: true } }
   = f.input :additional_information,
   input_html: { class: "col-lg-8 form-control-lg textarea-md" }


### PR DESCRIPTION
Remove unnecessary `include_hidden: false` attribute in the forms.
It causes submitted form doesn't have information, that field is empty.

Fixes #2029 