### PR TITLE
[#2176] Only allow to regenerate API token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,16 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Enhance the Ordering API OMS trigger (@jswk)
+- API authorization token can now only be revoked by regenerating it (@jswk)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+### Security
+- Don't allow to authorize as a user with revoked token (@jswk)
 
 ## [3.15.0] 2021-06-28
 

--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -11,14 +11,7 @@ class ApiDocsController < ApplicationController
   end
 
   def create
-    unless current_user.valid_token?
-      generate_token
-    end
-    redirect_to api_docs_path
-  end
-
-  def destroy
-    revoke_token
+    regenerate_token
     redirect_to api_docs_path
   end
 
@@ -32,11 +25,7 @@ class ApiDocsController < ApplicationController
       end
     end
 
-    def generate_token
-      current_user.update(authentication_token: User.generate_token)
-    end
-
-    def revoke_token
-      current_user.update(authentication_token: "revoked")
+    def regenerate_token
+      current_user.update!(authentication_token: nil)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,10 +56,6 @@ class User < ApplicationRecord
   end
 
   def valid_token?
-    authentication_token != "revoked" && authentication_token.present?
-  end
-
-  def self.generate_token
-    Devise.friendly_token
+    authentication_token.present?
   end
 end

--- a/app/views/api_docs/show.html.haml
+++ b/app/views/api_docs/show.html.haml
@@ -27,7 +27,7 @@
             = link_to "Generate token", api_docs_path, method: :post, class: "btn btn-primary float-right"
         - else
           %p
-            = link_to "Revoke token", api_docs_path, method: :delete, class: "btn btn-outline-danger float-right"
+            = link_to "Regenerate token", api_docs_path, method: :post, class: "btn btn-outline-danger float-right"
   %h2.mb-5 EOSC Marketplace API Documentation
   .container
     .row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,7 +151,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :api_docs, only: [:show, :create, :destroy]
+  resource :api_docs, only: [:show, :create]
 
   resource :admin, only: :show
   namespace :admin do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,5 +28,12 @@ FactoryBot.define do
     factory :user_with_favourites do
       sequence(:favourite_services) { |n| [create(:service)] }
     end
+
+    factory :user_with_token do
+      sequence(:authentication_token) { |n| "token_#{n}" }
+    end
+    factory :user_with_empty_token do
+      authentication_token { "  " }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,22 +44,24 @@ RSpec.describe User do
     end
   end
 
+  # This is relevant for users who where created before introducing simple_token_authentication, they will have null
+  # authentication_tokens.
   context "#valid_token?" do
-    it "is false when token is nil or 'revoked'" do
-      user = create(:user)
-      user.update(authentication_token: "revoked")
+    it "is false when token is nil" do
+      user = build(:user)
 
-      expect(user.valid_token?).to be false
-
-      # Workaround of the fact that 'simple_authentication_token' automatically generates token when you try to save
-      # model object to database and model.authentication_token = nil.
-      # Workaround is that we don't do 'user model.update(attribute: value)', but rather 'model.attribute = value'
-      user.authentication_token = nil
       expect(user.valid_token?).to be false
     end
 
-    it "is true when token is not nil or 'revoked'" do
-      user = create(:user)
+    it "is false when token is empty" do
+      user = build(:user_with_empty_token)
+
+      expect(user.valid_token?).to be false
+    end
+
+    it "is true when token is present" do
+      user = build(:user_with_token)
+
       expect(user.valid_token?).to be true
     end
   end


### PR DESCRIPTION
Setting authorization_token to `revoked` made authorizing as such user
possible in the API. Having a unique constraint on that column also
prevented several users to have the token revoked simulataneously.

Remove possibility to revoke token altogether, leaving only the ability
to regenerate it.

Nevertheless, handle the case of blank? token, as it will appear for
users which created their accounts before simple_token_authorization was
added to the project.

Fixes: #2176.