### PR TITLE
[#2171] Hide token on API docs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - OMS trigger basic authentication (@jswk)
+- API authorization token reveal by "Show token" button on the `api_docs` page (@goreck888, @jarekzet, @kmarszalek)
 
 ### Changed
 - Enhance the Ordering API OMS trigger (@jswk)
 - API authorization token can now only be revoked by regenerating it (@jswk)
+- `api_docs` page is available for unlogged user (@goreck888)
 
 ### Deprecated
 

--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApiDocsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: :create
 
   def show
     @subsection = extract_subsection

--- a/app/javascript/app/controllers/token_controller.js
+++ b/app/javascript/app/controllers/token_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+    static targets = ["button", "content"]
+
+    connect() {
+        this.hide();
+    }
+
+    toggle() {
+        if(this.contentTarget.classList.contains("show-token")) {
+            this.hide();
+        } else {
+            this.show();
+        }
+    }
+
+    show() {
+        this.contentTarget.classList.add("show-token")
+        this.contentTarget.innerHTML = this.contentTarget.dataset.token
+        this.buttonTarget.innerHTML = "Hide token";
+    }
+
+    hide() {
+        this.contentTarget.classList.remove("show-token")
+        this.contentTarget.innerHTML = "********************"
+        this.buttonTarget.innerHTML = "Show token";
+    }
+}

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -4417,6 +4417,13 @@ textarea.form-control.is-invalid {
     font-weight: bold;
     font-size: 20px;
     line-height: 27px;
+    margin-bottom: 5px;
+  }
+
+  .token-visibility {
+    color: $palette-gray-70;
+    font-size: 12px;
+    font-weight: bold;
   }
 }
 

--- a/app/views/api_docs/show.html.haml
+++ b/app/views/api_docs/show.html.haml
@@ -2,13 +2,22 @@
 
 .container
   %h1 API
-  .container
+  .container{ "data-controller": "token" }
     .row.pt-4.pb-4.pl-3.pr-3.mt-4.shadow-sm.rounded.service-box.tokens
-      .col-12.col-md-7
+      .col-12.col-md-7.vertical-middle
         .icon
           %i.fas.fa-key
-        .mt-4
-          - unless current_user.valid_token?
+        .mt-2
+          - if current_user&.valid_token?
+            %p.mb-1
+              %i.fas.fa-check-circle
+              Your token is active:
+            %p.active{ "data-target": "token.content", "data-token": "#{current_user&.authentication_token}" }
+              = "*" * 20
+            %a#toggler.text-uppercase.underline-light.token-visibility{ "data-target": "token.button",
+              "data-action": "click->token#toggle" }
+              Show token
+          - elsif current_user.present?
             %p
               You don't have an authentication token yet.
               %br
@@ -16,18 +25,18 @@
               %b Generate token
               to get one.
           - else
-            %p.mb-0
-              %i.fas.fa-check-circle
-              Your token is active:
-            %p.active
-              = current_user.authentication_token
+            %p
+              Log in to access your authentication token.
       .col-12.col-md-5.token-button
-        - unless current_user.valid_token?
+        - if current_user&.valid_token?
+          %p
+            = link_to "Regenerate token", api_docs_path, method: :post, class: "btn btn-outline-danger float-right"
+        - elsif current_user.present?
           %p
             = link_to "Generate token", api_docs_path, method: :post, class: "btn btn-primary float-right"
         - else
           %p
-            = link_to "Regenerate token", api_docs_path, method: :post, class: "btn btn-outline-danger float-right"
+            = link_to "Log in", user_checkin_omniauth_authorize_path, class: "btn btn-primary float-right"
   %h2.mb-5 EOSC Marketplace API Documentation
   .container
     .row


### PR DESCRIPTION
Allow unlogged users to get the api_docs page
After log in api docs shows only '*' signs
Added button to reveal the token
Closes #2171