### PR TITLE
[#2186] Provider can navigate from PPP to PC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.17.0-milestone]
+
+### Added
+- Resource provider can navigate to the Provider Component from the Provider Presentation Page (@kmarszalek)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [3.16.0-milestone]
 
 ### Added

--- a/app/helpers/backoffice/services_helper.rb
+++ b/app/helpers/backoffice/services_helper.rb
@@ -28,4 +28,8 @@ module Backoffice::ServicesHelper
   def offer_status(offer)
     content_tag(:span, offer.status, class: "badge #{BADGES[offer.status]}")
   end
+
+  def is_offer_missing(param, param_options)
+    param_options["mandatory"] && @offer.errors[:oms_params].present? && @offer.oms_params[param].blank?
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -162,6 +162,10 @@ class Provider < ApplicationRecord
     )
   end
 
+  def administered_by?(user)
+    data_administrators.where(email: user.email).count.positive?
+  end
+
   private
     def remove_empty_array_fields
       array_fields = [

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -196,7 +196,7 @@ class Service < ApplicationRecord
   end
 
   def administered_by?(user)
-    resource_organisation.data_administrators.where(email: user.email).count.positive?
+    resource_organisation.administered_by?(user)
   end
 
   def geographical_availabilities=(value)

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ProviderPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+
+  def data_administrator?
+    record.administered_by?(user)
+  end
+end

--- a/app/views/backoffice/services/offers/_one_offer_edit_form.html.haml
+++ b/app/views/backoffice/services/offers/_one_offer_edit_form.html.haml
@@ -7,7 +7,10 @@
         wrapper_html: { "data-target": "ordering.internalWrapper" },
         input_html: { "data-target": "ordering.internal",
                       "data-action": "ordering#updateVisibility" }
-      = render "backoffice/services/offers/primary_oms_form", form: f, offer: offer, available_omses: service.available_omses
+      = render "backoffice/services/offers/primary_oms_form",
+                form: f,
+                offer: offer,
+                available_omses: service.available_omses
 
   %h4.mt-5.mb-0.text-uppercase
     = _("Offer parameters")

--- a/app/views/backoffice/services/offers/_primary_oms_form.haml
+++ b/app/views/backoffice/services/offers/_primary_oms_form.haml
@@ -14,11 +14,10 @@
           Below we show parameters specified by #{oms.name}, which values will be sent to it alongside
           the orders for your offer.
         - oms.custom_params.each do |param, param_options|
-          - is_missing = param_options["mandatory"] && offer.errors[:oms_params].present? && offer.oms_params[param].blank?
           = field.input param,
             required: param_options["mandatory"],
             wrapper_html: { "data-oms-id": oms.id },
-            input_html: { class:  is_missing ? "is-invalid" : "" }
+            input_html: { class: is_offer_missing(param, param_options) ? "is-invalid" : "" }
       - else
         %label{ "data-oms-id": oms.id }
           #{oms.name} doesn't specify any parameters.

--- a/app/views/providers/_header.html.haml
+++ b/app/views/providers/_header.html.haml
@@ -16,6 +16,8 @@
       = link_to _("Browse resources"),
                     services_path(providers: provider.id),
                     class: "btn btn-primary d-block mb-3", "data-e2e": "btn-browse-resource"
+      - if user_signed_in? && policy(provider).data_administrator?
+        = render "providers/header/drop_down_menu", provider: provider
 .row.service-links
   .col-12.col-lg-9.row
     .col-12.col-sm-3

--- a/app/views/providers/header/_drop_down_menu.html.haml
+++ b/app/views/providers/header/_drop_down_menu.html.haml
@@ -1,0 +1,17 @@
+%a#dropdown-menu-button.dropdown-toggle.btn.btn-outline-secondary.d-block.mb-3{ "aria-expanded" => "false",
+                                                    "aria-haspopup" => "true",
+                                                    "data-toggle" => "dropdown",
+                                                    type: "button" }
+  .menu__label Manage the provider
+.dropdown-menu.shadow
+  %ul
+    %li
+      %a.dropdown-item.dropdown-details{ href:
+            Mp::Application.config.providers_dashboard_url + "/dashboard/#{provider.pid}/stats",
+            target: :_blank, "data-probe": "" }
+        = _("Provider dashboard")
+    %li
+      %a.dropdown-item.dropdown-details{ href:
+            Mp::Application.config.providers_dashboard_url + "/provider/update/#{provider.pid}",
+            target: :_blank, "data-probe": "" }
+        = _("Edit provider details")

--- a/spec/features/provider_spec.rb
+++ b/spec/features/provider_spec.rb
@@ -46,4 +46,30 @@ RSpec.feature "Provider browsing" do
 
     expect(body).to_not have_content "Recently added resources"
   end
+
+  scenario "I can see 'Manage the resource' button if i am an admin provider" do
+    admin = create(:user)
+    dataAdmin = create(:data_administrator, first_name: admin.first_name, last_name: admin.last_name, email: admin.email)
+    provider = create(:provider, data_administrators: [dataAdmin])
+
+    checkin_sign_in_as(admin)
+
+    visit provider_path(provider)
+
+    expect(page).to have_link("Browse resources")
+    expect(page).to have_content("Manage the provider")
+  end
+
+  scenario "I cannnot see 'Manage the resource' button if i am not an admin provider" do
+    user, admin = create_list(:user, 2)
+    dataAdmin = create(:data_administrator, first_name: admin.first_name, last_name: admin.last_name, email: admin.email)
+    provider = create(:provider, data_administrators: [dataAdmin])
+
+    checkin_sign_in_as(user)
+
+    visit provider_path(provider)
+
+    expect(page).to have_link("Browse resources")
+    expect(page).to_not have_content("Manage the provider")
+  end
 end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ServicePolicy do
+  let(:user) { create(:user) }
+  let(:stranger) { create(:user) }
+  let(:data_administrator) { create(:data_administrator, email: user.email) }
+  let(:provider) { create(:provider, data_administrators: [data_administrator]) }
+  let(:service) { create(:service, resource_organisation: provider) }
+
+  subject { described_class }
+
+  def resolve
+    subject::Scope.new(user, Service).resolve
+  end
+
+  permissions :data_administrator? do
+    it "grants access when data administrator" do
+      expect(subject).to permit(user, service)
+    end
+
+    it "denies when not data administrator" do
+      expect(subject).to_not permit(stranger, service)
+    end
+
+    it "denies when data administrator of another resource" do
+      other_service = create(:service)
+      expect(subject).to_not permit(user, other_service)
+    end
+  end
+end


### PR DESCRIPTION
Provider can navigate from the Provider Presentation Page
to the provider dashboard of the Provider Component

To test you need to be provider data_admin.
Add yourself in backoffice as data_admin then go to providers presentation page.

Closes #2186