### PR TITLE
[#1956] Hide opinions for unpublished resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Don't display opinions for unpublished resources on the home page (@goreck888)
 
 ### Security
 - Don't allow to authorize as a user with revoked token (@jswk)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -40,6 +40,9 @@ class HomeController < ApplicationController
     end
 
     def load_opinion
-      @opinion = ServiceOpinion.all.sample
+      @opinion = ServiceOpinion.joins(project_item: { offer: :service }).
+        where(project_item: { offer: { services: { status: [:published,
+                                                            :unverified,
+                                                            :errored] } } }).sample
     end
 end

--- a/app/views/home/_opinions.html.haml
+++ b/app/views/home/_opinions.html.haml
@@ -2,7 +2,7 @@
   = _("Recent opinions")
 
 - if opinion
-  %a.card-title{ href: "#{service_path(opinion.project_item.service)}" }
+  %a#opinion-link.card-title{ href: "#{service_path(opinion.project_item.service)}" }
     = opinion.project_item.service.name
   .row.mt-3
     .col

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -15,6 +15,26 @@ RSpec.feature "Home" do
     expect(page).to have_selector("#q[value='Something']")
   end
 
+  context "service opinions" do
+    let(:service_opinion_published) { create(:service_opinion) }
+    let(:service_opinion_draft) { create(:service_opinion) }
+
+    [:draft, :deleted].each do |status|
+      it "should show service opinions only for published resources" do
+        draft = service_opinion_draft.project_item.service
+        draft.update(status: status)
+        service = service_opinion_published.project_item.service
+
+        visit root_path
+
+        expect(page).to_not have_text("There are no reviews available.")
+
+        expect(page).to_not have_css("#opinion-link", text: draft.name)
+        expect(page).to have_css("#opinion-link", text: service.name)
+      end
+    end
+  end
+
   context "services carousel" do
     let!(:service1) { create(:service, description: "published-service-1", status: :published) }
     let!(:service2) { create(:service, description: "published-service-2", status: :published) }
@@ -70,8 +90,8 @@ RSpec.feature "Home" do
     end
 
     context "user" do
-      let(:admin) { create(:user) }
-      before { checkin_sign_in_as(admin) }
+      let(:user) { create(:user) }
+      before { checkin_sign_in_as(user) }
 
       it "shouldn't see warning" do
         visit "/"


### PR DESCRIPTION
Recent opinions for unpublished resources
are not displayed on the home page
Fixes #1956