### PR TITLE
[#2182] Fix choices of scientific domains in the project form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Don't display opinions for unpublished resources on the home page (@goreck888)
+- Show a tree structure of scientific domains to choose in the project form (@goreck888)
 
 ### Security
 - Don't allow to authorize as a user with revoked token (@jswk)

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -7,7 +7,9 @@
   = f.input :name, input_html: { class: "col-lg-6 form-control-lg" }
   = f.input :reason_for_access, input_html: { class: "col-lg-8 form-control-lg textarea-lg" }
   = f.association :scientific_domains, multiple: true,
-    wrapper_html: { class: "col-lg-8 pl-0 pr-0" }, input_html: { data: { choice: true } }
+    wrapper_html: { class: "col-lg-8 pl-0 pr-0" }, input_html: { data: { choice: true } },
+                collection: ScientificDomain.child_names.map { |name, sd| [name, sd.id] },
+                label_method: :first, value_method: :second
   = f.input :additional_information,
   input_html: { class: "col-lg-8 form-control-lg textarea-md" }
   %h4

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -31,6 +31,18 @@ RSpec.feature "Project" do
       expect(new_project.name).to eq("First test")
     end
 
+    scenario "Scientific domains are displayed as nested tree" do
+      parent = create(:scientific_domain)
+      child = create(:scientific_domain, parent: parent)
+
+      visit projects_path
+
+      click_on "Create new project"
+
+      expect(page).to have_content(parent.name)
+      expect(page).to have_content("#{parent.name} ⇒ #{child.name}")
+    end
+
     scenario "I can see first project services when entering My projects" do
       project = create(:project, user: user)
       service = create(:service, name: "The best service ever")


### PR DESCRIPTION
Show scientific domains to choose as a tree structure
as it is in providers and resources forms
Fixes #2182