### PR TITLE
[#2103] Fix creating offers in ordering configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Provider section in search autocomplete redirects to the provider's page (@goreck888)
 - Set `Other` target user at the end of target user list (@goreck888)
 - Add missing connection from Community MP to Offering API in API Docs overview image (@abacz)
+- Allow to create an offer in `ordering_configuration` panel when none exists (@goreck888)
 
 ### Security
 

--- a/app/controllers/services/ordering_configurations_controller.rb
+++ b/app/controllers/services/ordering_configurations_controller.rb
@@ -2,13 +2,13 @@
 
 class Services::OrderingConfigurationsController < Services::ApplicationController
   before_action :authenticate_user!
-  before_action :data_administrator_authorization!, only: :show
+  before_action :load_and_authenticate_service!, only: :show
 
   layout "ordering_configuration"
 
   def show
     @service = Service.includes(:offers).friendly.find(params[:service_id])
-    @offers = @service.offers.published.order(:iid)
+    @offers = @service&.offers&.published&.order(:iid)
     @related_services = @service.related_services
     @related_services_title = "Related resources"
     if current_user&.executive?
@@ -18,7 +18,8 @@ class Services::OrderingConfigurationsController < Services::ApplicationControll
   end
 
   private
-    def data_administrator_authorization!
+    def load_and_authenticate_service!
+      @service = Service.friendly.find(params[:service_id])
       authorize @service, policy_class: OrderingConfigurationPolicy
     end
 end

--- a/app/views/services/ordering_configurations/_about.html.haml
+++ b/app/views/services/ordering_configurations/_about.html.haml
@@ -3,8 +3,7 @@
     %main.col-12.col-xl-9.pr-5.mb-4{ "data-shepherd-tour-target": "service-about" }
 
       = markdown(service.description)
-      - if policy(service).order? && !offers&.empty?
-        = render "layouts/common_parts/services/offers", offers: offers, service: service
+      = render "layouts/common_parts/services/offers", offers: offers, service: service
 
     %sidebar.col-12.col-xl-3{ "data-shepherd-tour-target": "service-classification" }
       - service_sidebar_fields.each do |group|

--- a/spec/features/ordering_configuration_spec.rb
+++ b/spec/features/ordering_configuration_spec.rb
@@ -83,6 +83,34 @@ RSpec.feature "Services in ordering_configuration panel" do
       expect(page).to_not have_link("Delete Offer")
     end
 
+    scenario "I can add an offer if none exists", js: true do
+      service_without_offers = create(:service, resource_organisation: provider, offers: [])
+
+      visit service_ordering_configuration_path(service_without_offers)
+
+      expect(page).to have_content("Add new offer")
+
+      click_on "Add new offer"
+
+      expect {
+        fill_in "Name", with: "new offer 1"
+        fill_in "Description", with: "test offer"
+        find("li", text: "Input").click
+        find("#attributes-list-button").first("svg").click
+
+        within("div.card-text") do
+          fill_in "Name", with: "new input parameter"
+          fill_in "Hint", with: "test"
+          fill_in "Unit", with: "days"
+          select "integer", from: "Value type"
+        end
+        click_on "Create Offer"
+      }.to change { service_without_offers.offers.count }.by(1)
+
+      service_without_offers.reload
+      expect(service_without_offers.offers.last.name).to eq("new offer 1")
+    end
+
     scenario "I can delete offer if there are more than 1" do
       create(:offer, service: service)
 


### PR DESCRIPTION
Fix a possibility to create an offer in the ordering_configuration
panel when a resource has no offers
Fixes #2103