### PR TITLE
[#2047] Move "Other" target user at the end of a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Provider section in search autocomplete redirects to the provider's page (@goreck888)
+- Set `Other` target user at the end of target user list (@goreck888)
 
 ### Security
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,6 +12,6 @@ class PagesController < ApplicationController
   end
 
   def target_users
-    @target_users = TargetUser.all.order(:name)
+    @target_users = TargetUser.all.order(:name).partition { |tu|  tu.name != "Other" }.flatten(1)
   end
 end


### PR DESCRIPTION
As a part of ticket #2047 there was a need to move
"Other" target user at the end of list
available at `/target_users/` page
Fixes #2047