### PR TITLE
[#2063] Read version from VERSION file

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ ENV[VAR]
 
 We are currently using the following ENV variables:
 
+  * `MP_VERSION` (Optional) - the application's version (default taken from the file `./VERSION`)
   * `PORT` (Optional) - http server port (default 5000)
   * `CHECKIN_HOST` (Optional) - checkin IDP host (default `aai-dev.egi.eu`)
   * `CHECKIN_IDENTIFIER` (Optional) - checkin IDP identifier (default taken from

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -1,11 +1,5 @@
 - breadcrumb :admin_root
 
-- if ENV["MP_VERSION"]
-  .alert.alert-info.text-center
-    = _("Marketplace version:")
-    %code= ENV["MP_VERSION"]
-- else
-  .alert.alert-warning.text-center
-    = _("Marketplace version not defined in")
-    %code MP_VERSION
-    = _("environment variable")
+.alert.alert-info.text-center
+  = _("Marketplace version:")
+  %code= MP_VERSION

--- a/app/views/layouts/_version.html.haml
+++ b/app/views/layouts/_version.html.haml
@@ -1,3 +1,3 @@
 :javascript
-  console.log("MP VERSION: #{ENV["MP_VERSION"]}")
+  console.log("MP VERSION: #{MP_VERSION}")
 

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+MP_VERSION = ENV["MP_VERSION"] || File.read(Rails.root.join("VERSION")).strip
+
 # time after which user can rate service that starts when service become ready
 # default value is set to 90 days, ENV variable should represent number of days
 RATE_AFTER_PERIOD = ENV["RATE_AFTER_PERIOD"].present? ? (ENV["RATE_AFTER_PERIOD"]).to_i.days : 90.days

--- a/spec/features/admin/version_spec.rb
+++ b/spec/features/admin/version_spec.rb
@@ -6,15 +6,21 @@ RSpec.feature "Marketplace version" do
   include OmniauthHelper
 
   let(:admin) { create(:user, roles: [:admin]) }
+  let(:version) { File.read(Rails.root.join("VERSION")).strip }
 
   before { checkin_sign_in_as(admin) }
 
-  scenario "can been seen in admin main page" do
-    allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("MP_VERSION").and_return("1234")
+  scenario "is visible in admin main page" do
+    visit admin_path
+
+    expect(page).to have_content(version)
+  end
+
+  scenario "is read from MP_VERSION constant" do
+    stub_const("MP_VERSION", "foo:bar")
 
     visit admin_path
 
-    expect(page).to have_content("1234")
+    expect(page).to have_content("foo:bar")
   end
 end


### PR DESCRIPTION
Before, only ENV["MP_VERSION"] was accessed for the version value,
requiring the deployer to set the constant on each run.

Now, the constant still takes precedence if set, but by default the
VERSION file's content is used, making it less error-prone, but allowing
for flexibility in case other behaviour is desired.

In the view, it's no longer necessary to check for the constant's
existence, since if the VERSION file doesn't exist then error is raised
during app initialization.

Fixes: #2063.