### PR TITLE
[#1984] Fix questions in the resource opinion form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Correct ProjectItem's created date label display (@jswk)
+- Proper displaying questions in the resource opinion form (@goreck888)
 
 ### Security
 

--- a/app/views/projects/services/_rating.html.haml
+++ b/app/views/projects/services/_rating.html.haml
@@ -8,6 +8,6 @@
       = _("Thank you for using EOSC marketplace." + |
         "To help us to improve, please share your experience so far.") |
       -# haml-lint:enable MultilinePipe
-  = link_to _("Review service"),
+  = link_to _("Review resource"),
       new_project_service_opinion_path(project, project_item),
       class: "btn btn-primary btn-sm"

--- a/app/views/projects/services/opinions/new.haml
+++ b/app/views/projects/services/opinions/new.haml
@@ -2,7 +2,7 @@
 
 .container
   %h1
-    = _("Service review")
+    = _("Resource review")
   .row.border-5.border-bottom.border-separator.pb-4
     .col-md-3
       .service-image.border
@@ -26,17 +26,22 @@
           %li
             %h3.mt-5
               = _("Answer two questions and share your opinion with other EOSC Marketplace users.")
+          -# haml-lint:disable MultilinePipe
           %li.mt-4
             %strong
-              -# TODO: refactor dynamic translation
-              = t("project_items.opinion.#{map_view_to_order_type(@project_item)}.question1",
-              title: @project_item.service.name)
+              = _("1. How satisfied you are with the %{name} resource on a scale " + |
+                  "of 1 - dissatisfied to 5 - very satisfied?") % { name: @project_item.service.name } |
             = render "stars", field: "service_opinion_service_rating"
           %li.mt-4
             %strong
-              -# TODO: refactor dynamic translation
-              = t("project_items.opinion.#{map_view_to_order_type(@project_item)}.question2")
+              - if @project_item.offer.order_required? && @project_item.offer.internal?
+                = _("2. How satisfied you are with the ordering process on a scale " + |
+                    "of 1 - dissatisfied to 5 - very satisfied?") |
+              - else
+                = _("2. Was adding the resource to the project useful for you on a scale " + |
+                    "of 1 - not useful at all to 5 - very useful?") |
             = render "stars", field: "service_opinion_order_rating"
+          -# haml-lint:enable MultilinePipe
           %li.mt-5
             %p.pt-3
               -# haml-lint:disable MultilinePipe

--- a/config/locales/views/project_items/en.yml
+++ b/config/locales/views/project_items/en.yml
@@ -1,26 +1,5 @@
 en:
   project_items:
-    opinion:
-      prompt:
-        Thank you for using EOSC marketplace.
-        To help us to improve, please share your experience so far.
-      orderable:
-        question1: |
-          1. How satisfied you are with the %{title} resource on a scale of 1 - dissatisfied to 5 - very satisfied?
-        question2: |
-          2. How satisfied you are with the ordering process on a scale of 1 - dissatisfied to 5 - very satisfied?
-      open_access:
-        question1: |
-          1. How satisfied you are with the %{title} resource on a scale of 1 - dissatisfied to 5 - very satisfied?
-        question2: |
-          2. Was adding the resource to the project useful for you on a scale of
-          1 - not useful at all to 5 - very useful?
-      external:
-        question1:
-          1. How satisfied you are with the %{title} resource on a scale of 1 - dissatisfied to 5 - very satisfied?
-        question2:
-          2. Was adding the resource to the project useful for you on a scale of
-          1 - not useful at all to 5 - very useful?
     status:
       created: New
       registered: New

--- a/spec/features/opinions_spec.rb
+++ b/spec/features/opinions_spec.rb
@@ -3,20 +3,64 @@
 require "rails_helper"
 
 RSpec.feature "Service opinions" do
-  context "for open access service" do
-    it "shows user review" do
-      user = create(:user, first_name: "John", last_name: "Doe")
-      project = create(:project, user: user)
-      service = create(:open_access_service)
-      offer = create(:offer, service: service)
-      project_item = create(:project_item, offer: offer, project: project)
-      create(:service_opinion, project_item: project_item, opinion: "my opinion")
+  include OmniauthHelper
 
-      visit service_opinions_path(service)
+  [:open_access, :fully_open_access, :other].each do |type|
+    context "for #{type} service" do
+      let(:user) { create(:user, first_name: "John", last_name: "Doe") }
+      let(:project) { create(:project, user: user) }
+      let(:service) { create(:service, order_type: type) }
+      let(:offer) { create(:offer, order_type: type, service: service) }
+      let(:project_item) { create(:project_item, offer: offer, project: project, status_type: :ready) }
 
-      expect(page).to have_content("John")
-      expect(page).to have_content("D.")
-      expect(page).to have_content("my opinion")
+      it "shows user review" do
+        create(:service_opinion, project_item: project_item, opinion: "my opinion")
+
+        visit service_opinions_path(service)
+
+        expect(page).to have_content("John")
+        expect(page).to have_content("D.")
+        expect(page).to have_content("my opinion")
+      end
+
+      it "shows correct questions in the opinions form" do
+        checkin_sign_in_as(user)
+        visit project_service_path(project, project_item)
+
+        click_on "Review resource"
+
+        expect(page).to have_content("1. How satisfied you are with the #{service.name} resource on a scale " +
+                                     "of 1 - dissatisfied to 5 - very satisfied?")
+
+        expect(page).to have_content("2. Was adding the resource to the project useful for you on a scale " +
+                                     "of 1 - not useful at all to 5 - very useful?")
+      end
+    end
+  end
+  [true, false].each do |internal|
+    context "for orderable resource" do
+      let(:user) { create(:user, first_name: "John", last_name: "Doe") }
+      let(:project) { create(:project, user: user) }
+      let(:service) { create(:service, order_type: :order_required) }
+      let(:offer) { create(:offer, order_type: :order_required, internal: internal, service: service) }
+      let(:project_item) { create(:project_item, offer: offer, project: project, status_type: :ready) }
+
+      it "shows correct questions in the opinions form for internal offer" do
+        checkin_sign_in_as(user)
+        visit project_service_path(project, project_item)
+
+        click_on "Review resource"
+
+        expect(page).to have_content("1. How satisfied you are with the #{service.name} resource on a scale " +
+                                       "of 1 - dissatisfied to 5 - very satisfied?")
+        if internal
+          expect(page).to have_content("2. How satisfied you are with the ordering process on a scale " +
+                                       "of 1 - dissatisfied to 5 - very satisfied?")
+        else
+          expect(page).to have_content("2. Was adding the resource to the project useful for you on a scale " +
+                                       "of 1 - not useful at all to 5 - very useful?")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes displayed "Question1" and "Question2" in the form
Remove dynamic translation from i18n and use GetText
Fixes #1984