### PR TITLE
[#2075] Backoffice user cannot edit categories in an eosc_registry resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Fixed
 - Correct ProjectItem's created date label display (@jswk)
 - Proper displaying questions in the resource opinion form (@goreck888)
+- Service owners cannot edit categories in the backoffice view when service upstream is other than MP (@wujuu)
 
 ### Security
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -67,7 +67,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
   end
 
   def cant_edit(attribute)
-    !policy([:backoffice, @service]).permitted_attributes.include?(attribute)
+    policy([:backoffice, @service]).permitted_attributes.exclude?(attribute)
   end
 
   private

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -16,7 +16,6 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   MP_INTERNAL_FIELDS = [
-    [category_ids: []],
     [platform_ids: []],
     :restrictions,
     :status,
@@ -109,7 +108,7 @@ class Backoffice::ServicePolicy < ApplicationPolicy
     if !@record.is_a?(Service) || @record.upstream.nil?
       attrs
     else
-      attrs & MP_INTERNAL_FIELDS
+      MP_INTERNAL_FIELDS
     end
   end
 

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -586,7 +586,7 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_field "service_use_cases_url_0", disabled: true
       expect(page).to have_field "Order type", disabled: true
       expect(page).to have_field "Order url", disabled: true
-      expect(page).to have_field "Categories", disabled: false
+      expect(page).to have_field "Categories", disabled: true
       expect(page).to have_field "Access types", disabled: true
       expect(page).to have_field "Access modes", disabled: true
       expect(page).to have_field "Providers", disabled: true

--- a/spec/policies/backoffice/service_policy_spec.rb
+++ b/spec/policies/backoffice/service_policy_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Backoffice::ServicePolicy do
       expect(policy.permitted_attributes).to match_array([
                                                      :restrictions, :activate_message,
                                                      [platform_ids: []], [owner_ids: []],
-                                                     [category_ids: []], :status, :upstream_id,
+                                                     :status, :upstream_id,
                                                      sources_attributes: [:id, :source_type, :eid, :_destroy]])
     end
   end


### PR DESCRIPTION
Closes #2075.