### PR TITLE
[#2005] Store query params in comparison view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - First and last name to Ordering API project owner (@michal-szostak, @jswk)
+- Storing resource query parameters by visiting the comparison page (@goreck888)
 
 ### Changed
 

--- a/app/controllers/comparisons_controller.rb
+++ b/app/controllers/comparisons_controller.rb
@@ -2,15 +2,16 @@
 
 class ComparisonsController < ApplicationController
   include Service::Comparison
+  before_action :query_params, only: [:show, :destroy]
 
   def show
     @services = Service.where(slug: session[:comparison])
     if @services.blank?
       if params[:fromc]
         category = Category.find_by(slug: params[:fromc])
-        redirect_to category_services_path(category)
+        redirect_to category_services_path(category, params: @query_params)
       else
-        redirect_to services_path
+        redirect_to services_path(params: @query_params)
       end
     end
   end
@@ -18,12 +19,16 @@ class ComparisonsController < ApplicationController
   def destroy
     session[:comparison] = []
     respond_to do |format|
-      format.html { redirect_to services_path }
+      format.html { redirect_to services_path(@query_params) }
       format.js { render_json }
     end
   end
 
   private
+    def query_params
+      @query_params = session[:query] || {}
+    end
+
     def render_json
       render json: { data: @services&.map(&:slug), html: bottom_bar }
     end

--- a/app/controllers/comparisons_controller.rb
+++ b/app/controllers/comparisons_controller.rb
@@ -2,7 +2,7 @@
 
 class ComparisonsController < ApplicationController
   include Service::Comparison
-  before_action :query_params, only: [:show, :destroy]
+  before_action :load_query_params_from_session
 
   def show
     @services = Service.where(slug: session[:comparison])
@@ -25,7 +25,7 @@ class ComparisonsController < ApplicationController
   end
 
   private
-    def query_params
+    def load_query_params_from_session
       @query_params = session[:query] || {}
     end
 

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -120,6 +120,8 @@ module Service::Searchable
             params["#{filter.field_name}-all"] unless params["#{filter.field_name}-all"].blank?
       end
       session[:query][:q] = params[:q] unless params[:q].blank?
+      session[:query][:sort] = params[:sort] unless params[:sort].blank?
+      session[:query][:per_page] = params[:per_page] unless params[:per_page].blank?
     end
 
     def filter_classes

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -122,6 +122,7 @@ module Service::Searchable
       session[:query][:q] = params[:q] unless params[:q].blank?
       session[:query][:sort] = params[:sort] unless params[:sort].blank?
       session[:query][:per_page] = params[:per_page] unless params[:per_page].blank?
+      session[:query][:page] = params[:page] unless  params[:page].blank?
     end
 
     def filter_classes

--- a/app/views/backoffice/services/index.html.haml
+++ b/app/views/backoffice/services/index.html.haml
@@ -28,5 +28,6 @@
                            offers: @offers,
                            comparison_enabled: @comparison_enabled,
                            favourite_services: @favourite_services,
-                           show_recommendations: false
+                           show_recommendations: false,
+                           show_comparison: false
 

--- a/app/views/comparisons/show.html.haml
+++ b/app/views/comparisons/show.html.haml
@@ -20,7 +20,8 @@
               %span.helper
               - if service.logo.attached? && service.logo.variable?
                 = image_tag service.logo.variant(resize: "100x100")
-            = link_to comparisons_services_path(slug: service.slug, fromc: params[:fromc]), method: :delete,
+            = link_to comparisons_services_path(slug: service.slug, fromc: params[:fromc], params: @query_params),
+            method: :delete,
               "data-e2e": "delete-service-btn", "data-probe": "" do
               %i.far.fa-trash-alt
             .service-title
@@ -31,7 +32,8 @@
               = service.description.truncate(80, separator: " ")
         - i.times do
           %td.title-col.empty.text-uppercase
-            = link_to _("Add next resource"), services_path, "data-e2e": "add-next-resource-btn", "data-probe": ""
+            = link_to _("Add next resource"), services_path(params: @query_params),
+            "data-e2e": "add-next-resource-btn", "data-probe": ""
       %tr{ class: row_class(row_idx) }
         %th{ "data-toggle": "tooltip",
         title: "The name(s) (or abbreviation(s)) of Provider that manage the Resource in |

--- a/app/views/services/_filters.html.haml
+++ b/app/views/services/_filters.html.haml
@@ -8,5 +8,6 @@
     "data-target": "filter.form" do
     = hidden_field_tag :q, params[:q] if params[:q].present?
     = hidden_field_tag :sort, params[:sort] if params[:sort].present?
+    = hidden_field_tag :per_page, params[:per_page] if params[:per_page].present?
     - filters.each do |filter|
       = render "services/filters/#{filter.type}", filter: filter

--- a/app/views/services/_index.html.haml
+++ b/app/views/services/_index.html.haml
@@ -1,4 +1,6 @@
-.container{ "data-controller": "favourite" }
+- effective_show_comparison = local_assigns.fetch(:show_comparison, true)
+- effective_show_recommendations = local_assigns.fetch(:show_recommendations, true)
+.container
   .row
     .col-lg-3.mb-5
       = render "services/nav/categories", current: category,
@@ -7,10 +9,10 @@
                                           services_count: services_count
       = render "services/filters", filters: filters
 
-    .col-lg-9
+    .col-lg-9{ "data-controller": "favourite #{effective_show_comparison ? "comparison" : ""}" }
       .row.mb-4
         = render "services/active_filters", category: category, active_filters: active_filters
-        - if (not defined? show_recommendations) || show_recommendations
+        - if effective_show_recommendations
           - if ab_test(:recommendation_panel) == "v1" && !recommended_services.blank?
             = render partial: "services/recommendation_panel_v1",
                      locals: { highlights: highlights, category: category, recommended_services: recommended_services }
@@ -25,7 +27,7 @@
                            comparison_enabled: comparison_enabled,
                            remote: true }
 
-        - if (not defined? show_recommendations) || show_recommendations
+        - if effective_show_recommendations
           - if ab_test(:recommendation_panel) == "v2" && !recommended_services.blank?
             = render partial: "services/recommendation_panel_v2",
                      locals: { highlights: highlights, category: category, recommended_services: recommended_services }
@@ -40,4 +42,7 @@
 
         #popup-modal.modal.show{ "data-target": "favourite.popup", tabindex: "-1",
                                   role: "dialog", aria: { hidden: "true" } }
-
+      - if effective_show_comparison
+        #comparison-bar.comparison-bar.fixed-bottom{ class: (session[:comparison]&.size || 0) > 0 ?
+        "d-block" : "d-none", "data-target": "comparison.bar", "data-e2e": "comparison-bar" }
+          = render "comparisons/bar", services: compare_services, category: category

--- a/app/views/services/_order.html.haml
+++ b/app/views/services/_order.html.haml
@@ -1,4 +1,6 @@
 = form_tag url_for, method: :get, role: "search", "data-controller": "order" do
+  = hidden_field_tag :q, params[:q] if params[:q].present?
+  = hidden_field_tag :per_page, params[:per_page] if params[:per_page].present?
   .form-group.row.sort-box
     %label.col-sm-3.control-label.pr-0
       = _("Sort by") + ":"

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -7,7 +7,7 @@
     else
       _("All resources")
     end
-.container{ "data-controller": "comparison" }
+.container
   - @category ? breadcrumb(:category, @category) : breadcrumb(:services)
   = render "services/index", services: @services,
                              pagy: @pagy,
@@ -22,7 +22,5 @@
                              offers: @offers,
                              comparison_enabled: @comparison_enabled,
                              recommended_services: @recommended_services,
-                             favourite_services: @favourite_services
-  #comparison-bar.comparison-bar.fixed-bottom{ class: (session[:comparison]&.size || 0) > 0 ? "d-block" : "d-none",
-  "data-target": "comparison.bar", "data-e2e": "comparison-bar" }
-    = render "comparisons/bar", services: @compare_services, category: @category
+                             favourite_services: @favourite_services,
+                             compare_services: @compare_services

--- a/spec/features/backoffice/providers_spec.rb
+++ b/spec/features/backoffice/providers_spec.rb
@@ -204,9 +204,9 @@ RSpec.feature "Providers in backoffice" do
 
       expect(page).to have_selector("input[value='777abc']")
       page.attach_file("provider_logo", "#{Rails.root}/app/javascript/images/eosc-img.png")
-      fill_in "provider_sources_attributes_0_eid", with: provider.sources.first.eid
+      fill_in "provider_sources_attributes_0_eid", with: "abc777"
       click_on "Update Provider"
-      expect(page).to have_content("eosc_registry: #{ provider.sources.first.eid }")
+      expect(page).to have_content("eosc_registry: abc777")
     end
   end
 end


### PR DESCRIPTION
When user navigates from resources list
to the comparison view, query params are saved now
Fixes #2005