### PR TITLE
[#1961] Fix sorting for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Disable reloading search autocomplete list after click on its element (@goreck888)
 - Keep search input after redirect from autocomplete (@goreck888)
 - Fix incorrect classification value on PC sync - better User Experience (@danielkryska)
+- Alphabetical sorting by name for the Resources (@kmarszalek, @goreck888)
 
 ### Security
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -182,8 +182,8 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
     end
 
     def sort_options
-      @sort_options = [["by name A-Z", "name"],
-                       ["by name Z-A", "-name"],
+      @sort_options = [["by name A-Z", "sort_name"],
+                       ["by name Z-A", "-sort_name"],
                        ["draft first", "status"],
                        ["published first", "-status"],
                        ["by rate 1-5", "rating"],

--- a/app/controllers/concerns/service/sortable.rb
+++ b/app/controllers/concerns/service/sortable.rb
@@ -27,7 +27,7 @@ module Service::Sortable
             end
           end
         else
-          sort_options[:name] = :asc
+          sort_options[:sort_name] = :asc
         end
       end
     end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -52,8 +52,8 @@ class ServicesController < ApplicationController
 
   private
     def sort_options
-      @sort_options = [["by name A-Z", "name"],
-                       ["by name Z-A", "-name"],
+      @sort_options = [["by name A-Z", "sort_name"],
+                       ["by name Z-A", "-sort_name"],
                        ["by rate 1-5", "rating"],
                        ["by rate 5-1", "-rating"],
                        ["Best match", "_score"]]

--- a/app/models/service/search.rb
+++ b/app/models/service/search.rb
@@ -12,12 +12,13 @@ module Service::Search
       highlight: [:name, :tagline, :resource_organisation_name, :provider_names]
   end
 
-  # search_data are definition whitch
+  # search_data are definition which
   # fields are mapped to elasticsearch
   def search_data
     {
       service_id: id,
       name: name,
+      sort_name: name.downcase,
       tagline: tagline,
       description: description,
       status: status,

--- a/spec/controllers/concerns/sortable_spec.rb
+++ b/spec/controllers/concerns/sortable_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SortableFakeController do
 
   context "ordering" do
     it "should by default sort by name" do
-      expect(controller.send(:ordering)).to eq(name: :asc)
+      expect(controller.send(:ordering)).to eq(sort_name: :asc)
     end
 
     it "should return ascending ordering by rating" do

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -201,12 +201,29 @@ RSpec.feature "Service browsing" do
 
     scenario "should by default sort services by name, ascending" do
       create(:service, name: "Service c")
-      create(:service, name: "Service b")
+      create(:service, name: "service b")
       create(:service, name: "Service a")
 
       visit services_path
 
-      names = ["Service a", "Service b", "Service c"]
+      names = ["Service a", "service b", "Service c"]
+      all(@services_selector).each_with_index do |service_box, i|
+        expect(service_box).to have_content(names[i])
+      end
+
+      # Above implementation can be replaced with below after fixing split gem use_ab_test
+      # expect(page.body.index("Service a")).to be < page.body.index("Service b")
+      # expect(page.body.index("Service b")).to be < page.body.index("Service c")
+    end
+
+    scenario "should sort services by name, descending" do
+      create(:service, name: "Service c")
+      create(:service, name: "service b")
+      create(:service, name: "Service a")
+
+      visit services_path(sort: "-sort_name")
+
+      names = ["Service c", "service b", "Service a"]
       all(@services_selector).each_with_index do |service_box, i|
         expect(service_box).to have_content(names[i])
       end


### PR DESCRIPTION
- Fixed sorting by name
- Added test that checks sorting with lower/upper cases

Elasticsearch follows ASCII sort order, the bytes that represent
capital letters have lower ASCII values than that of lowercase letters.
By changing name to name.downcase in search_data we can sort resources
in alphabetical order regardless of their ASCII codes.

Closes #1961 