### PR TITLE
[#2082] Correct project_item created date label display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.19.0-milestone]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Correct ProjectItem's created date label display (@jswk)
+
+### Security
+
 ## [3.18.0-milestone]
 
 ### Added

--- a/app/views/projects/services/_details.html.haml
+++ b/app/views/projects/services/_details.html.haml
@@ -8,8 +8,11 @@
       = _("Resource offer") + ":"
     %dd= project_item.name
 %dl
-  -# TODO: refactor dynamic translation
-  %dt= t("project_items.service.label.#{map_view_to_order_type(project_item)}")
+  %dt
+    - if project_item.orderable?
+      = _("Order date:")
+    - else
+      = _("Added to the project:")
   %dd= l project_item.created_at, format: :short
 %dl
   %dt= _("Resource access") + ":"

--- a/config/locales/views/project_items/en.yml
+++ b/config/locales/views/project_items/en.yml
@@ -1,13 +1,5 @@
 en:
   project_items:
-    service:
-      label:
-        open_access:
-          "Added to the project:"
-        external:
-          "Added to the project:"
-        orderable:
-          "Order date:"
     opinion:
       prompt:
         Thank you for using EOSC marketplace.

--- a/spec/features/project_services_spec.rb
+++ b/spec/features/project_services_spec.rb
@@ -22,6 +22,35 @@ RSpec.feature "Project services" do
     expect(page).to have_link("Details")
   end
 
+  context "#created_at display" do
+    scenario "The label reads 'Order date' for orderable project_item" do
+      offer = create(:offer, service: service)
+      project_item = create(:project_item, offer: offer, project: project)
+
+      visit project_service_path(project, project_item)
+
+      expect(page).to have_text("Order date:")
+    end
+
+    scenario "The label reads 'Added to the project' for external project_item" do
+      offer = create(:external_offer, service: service)
+      project_item = create(:project_item, offer: offer, project: project)
+
+      visit project_service_path(project, project_item)
+
+      expect(page).to have_text("Added to the project:")
+    end
+
+    scenario "The label reads 'Added to the project' for open_access project_item" do
+      offer = create(:open_access_offer, service: service)
+      project_item = create(:project_item, offer: offer, project: project)
+
+      visit project_service_path(project, project_item)
+
+      expect(page).to have_text("Added to the project:")
+    end
+  end
+
   scenario "I cannot see timeline for open_access order" do
     offer = create(:open_access_offer, service: service)
     project_item = create(:project_item, offer: offer, project: project)


### PR DESCRIPTION
The labels' keys generated using map_view_to_order_type helper got out
of sync with defined translation keys, leading to erroneous display.
For !open_access? project_items, instead of an expected text (i.e.
"Added to the project" or "Order date") the order_type was rendered as a
fallback (for example "Fully Open Access", when the value was a date,
making no sense).

Correct the behaviour to be handled in the view and remove unnecessary
translation entries.

Fixes: #2082.