### PR TITLE
[#2236] Fix autocomplete unnecessary reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Proper displaying questions in the resource opinion form (@goreck888)
 - Service owners cannot edit categories in the backoffice view when service upstream is other than MP (@wujuu)
 - Disable reloading search autocomplete list after click on its element (@goreck888)
+- Keep search input after redirect from autocomplete (@goreck888)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Correct ProjectItem's created date label display (@jswk)
 - Proper displaying questions in the resource opinion form (@goreck888)
 - Service owners cannot edit categories in the backoffice view when service upstream is other than MP (@wujuu)
+- Disable reloading search autocomplete list after click on its element (@goreck888)
 
 ### Security
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -12,10 +12,10 @@ class ServicesController < ApplicationController
   def index
     if params["object_id"].present?
       if params["type"] == "provider"
-        redirect_to provider_path(Provider.friendly.find(params["object_id"]),
+        redirect_to provider_path(Provider.friendly.find(params["object_id"]), q: params["q"],
                                  anchor: ("offer-#{params["anchor"]}" if params["anchor"].present?))
       elsif params["type"] == "service"
-        redirect_to service_path(Service.friendly.find(params["object_id"]),
+        redirect_to service_path(Service.friendly.find(params["object_id"]), q: params["q"],
                                  anchor: ("offer-#{params["anchor"]}" if params["anchor"].present?))
       end
     end

--- a/app/javascript/app/controllers/autocomplete_controller.js
+++ b/app/javascript/app/controllers/autocomplete_controller.js
@@ -142,7 +142,6 @@ export default class extends Controller {
       detail: { value: value, textValue: textValue }
     }))
 
-    this.inputTarget.focus()
     this.resultsTarget.hidden = true
   }
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -61,5 +61,9 @@ FactoryBot.define do
         content_type: "image/png"
       )
     end
+
+    after(:create) do |provider, _evaluator|
+      provider.reindex(refresh: true)
+    end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -171,4 +171,24 @@ RSpec.feature "Service searching in top bar", js: true do
     expect(page).to_not have_text ("Cyfronet > DDDD Something 2")
     expect(page).to_not have_text ("Cyfronet > DDDD Something 3")
   end
+
+  [:service, :provider].each do |type|
+    scenario "doesn't show the autocomplete results after clicking an #{type} item", js: true, search: true do
+      object = create(type)
+      fill_in "q", with: object.name
+      expect(page).to have_css("#-option-0")
+      find(:css, "li[id='-option-0']").click
+      expect(page).to have_selector(".autocomplete-results", visible: false)
+    end
+
+    scenario "it preserves the query input after redirect to the #{type} item", js: true, search: true do
+      object = create(type)
+      fill_in "q", with: object.name
+      expect(page).to have_css("#-option-0")
+      find(:css, "li[id='-option-0']").click
+      expect(page).to have_current_path(send("#{type}_path", object, q: object.name))
+
+      expect(page).to have_selector("#q[value='#{object.name}']")
+    end
+  end
 end


### PR DESCRIPTION
Fix reloading autocomplete list
after clicking on an item
After page reload search input
is filled with previously clicked item label

**NOTICE**
Fixed redirect_to `/null` isn't merged into master yet.

Fixes #2236