### PR TITLE
[#2278] Add supplied_voucher_id to project_item attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.20.0-milestone]
+
+### Added
+- [Ordering API] `supplied_voucher_id` project item attribute (@jswk)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [3.19.0-milestone]
 
 ### Added

--- a/app/serializers/api/v1/project_item_serializer.rb
+++ b/app/serializers/api/v1/project_item_serializer.rb
@@ -20,7 +20,7 @@ class Api::V1::ProjectItemSerializer < ActiveModel::Serializer
   end
 
   def attribute_extractor
-    {
+    hash = {
       category: object.service&.categories&.first&.name,
       service: object.service&.name,
       offer: object.name,
@@ -29,6 +29,8 @@ class Api::V1::ProjectItemSerializer < ActiveModel::Serializer
       request_voucher: object.request_voucher,
       order_type: object.order_type,
     }
+    hash[:supplied_voucher_id] = object.voucher_id if object.voucher_id.present?
+    hash
   end
 
   def oms_params

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -34,5 +34,9 @@ FactoryBot.define do
       sequence(:order_type) { :order_required }
       sequence(:order_url) { "http://order.com" }
     end
+
+    factory :voucherable_offer do
+      voucherable { true }
+    end
   end
 end

--- a/spec/factories/project_items.rb
+++ b/spec/factories/project_items.rb
@@ -9,5 +9,11 @@ FactoryBot.define do
 
     offer
     project
+
+    factory :project_item_with_voucher do
+      voucher_id { "some_voucher_id" }
+
+      offer { build(:voucherable_offer) }
+    end
   end
 end

--- a/spec/serializers/api/v1/project_item_serializer_spec.rb
+++ b/spec/serializers/api/v1/project_item_serializer_spec.rb
@@ -82,6 +82,32 @@ RSpec.describe Api::V1::ProjectItemSerializer do
     expect(serialized).to eq(expected)
   end
 
+  context "#supplied_voucher_id" do
+    it "doesn't serialize it if voucher_id is absent" do
+      project_item = create(:project_item)
+
+      serialized = described_class.new(project_item).as_json
+
+      expect(serialized[:attributes]).not_to have_key(:supplied_voucher_id)
+    end
+
+    it "serializes it if voucher_id is present" do
+      project_item = create(:project_item_with_voucher)
+
+      serialized = described_class.new(project_item).as_json
+
+      expect(serialized[:attributes]).to include(supplied_voucher_id: project_item.voucher_id)
+    end
+
+    it "serializes the original value if user_secrets.voucher_id is present" do
+      project_item = create(:project_item_with_voucher, user_secrets: { voucher_id: "some_other_value" })
+
+      serialized = described_class.new(project_item).as_json
+
+      expect(serialized[:attributes]).to include(supplied_voucher_id: project_item.voucher_id)
+    end
+  end
+
   context "#user_secrets" do
     it "obfuscates values" do
       project_item = create(:project_item, user_secrets: { "key-1" => "value", "key-2" => "value" })


### PR DESCRIPTION
The voucher_id value must be passed in open text to OMS somehow to
implement the pre-existing voucher use-case: there is a CP-VoucherID
field in Jira.

## How to test

Create project item with (I) and without (II) voucher ID specified.

It shouldn't matter, if (II) is from a voucherable offer or not.

Once the project items are created, inspect the Ordering API (oms_id=`1`, token=`vJkCgAA153VYx8yBNnYb`) for the created project items.
The output of (I) should have an attribute named `supplied_voucher_id` and output of (II) shouldn't contain it.

If you update (I) to set a different voucher_id in its user_secrets, i.e. send a PATCH with `{"user_secrets":{"voucher_id":"some_other_value"}}`, then the `supplied_voucher_id` should still show the original value and not `some_other_value`. 

Closes: #2278.