### PR TITLE
[#1965] Reindex resource by offer update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.21.0-milestone]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Reindexing and update resource `order type` by offers update or remove (@goreck888)
+
+### Security
+
 ## [3.20.0-milestone]
 
 ### Added

--- a/app/controllers/backoffice/services/offers_controller.rb
+++ b/app/controllers/backoffice/services/offers_controller.rb
@@ -63,7 +63,7 @@ class Backoffice::Services::OffersController < Backoffice::ApplicationController
       if template["primary_oms_id"].present? && template["oms_params"].nil?
         template["oms_params"] = {}
       end
-      template
+      template.except(:from)
     end
 
     def find_service

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -107,7 +107,7 @@ module ServiceHelper
   end
 
   def order_type(service)
-    types = service&.offers.map { |o| o.order_type }.uniq
+    types = ([service&.order_type] + service&.offers.published.map { |o| o.order_type }).compact.uniq
     if types.size > 1
       "various"
     else

--- a/app/models/service/search.rb
+++ b/app/models/service/search.rb
@@ -30,7 +30,7 @@ module Service::Search
       platforms: platforms.map(&:id),
       geographical_availabilities: geographical_availabilities.map(&:alpha2),
       target_users: target_users.map(&:id),
-      order_type: [order_type] << offers.map(&:order_type),
+      order_type: [order_type] << offers.published.map(&:order_type),
       tags: tag_list,
       source: upstream&.source_type,
       offers: offers.ids,

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -36,7 +36,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:id, :name, :description, :order_type, :order_url, :internal,
+    [:id, :name, :description, :order_type, :order_url, :internal, :from,
      :primary_oms_id, oms_params: {},
      parameters_attributes: [:type, :name, :hint, :min, :max,
                              :unit, :value_type, :start_price, :step_price, :currency,

--- a/app/services/offer/create.rb
+++ b/app/services/offer/create.rb
@@ -7,7 +7,10 @@ class Offer::Create
 
   def call
     @offer.save
-
+    if @offer.service.offers.published.size == 1
+      @offer.update(order_type: @offer.service.order_type)
+    end
+    @offer.service.reindex
     @offer
   end
 end

--- a/app/services/offer/destroy.rb
+++ b/app/services/offer/destroy.rb
@@ -6,10 +6,16 @@ class Offer::Destroy
   end
 
   def call
+    @service = @offer.service
     if @offer&.project_items.present?
       @offer.update(status: :deleted)
     else
       @offer.destroy
     end
+    if @service.offers.published.size == 1
+      @service.offers.published.last.update(order_type: @service&.order_type)
+    end
+    @service.reindex
+    true
   end
 end

--- a/app/services/offer/update.rb
+++ b/app/services/offer/update.rb
@@ -7,10 +7,12 @@ class Offer::Update
   end
 
   def call
-    if @offer.service.offers_count == 1
+    if @offer.service.offers.published.size == 1
       @offer.update(@params)
     else
       @offer.update(@params.merge(default: false))
     end
+    @offer.service.reindex
+    @offer.valid?
   end
 end

--- a/app/services/service/update.rb
+++ b/app/services/service/update.rb
@@ -7,11 +7,11 @@ class Service::Update
   end
 
   def call
-    if @service.offers.size == 1
+    if @service.offers.published.size == 1
       Offer::Update.new(@service.offers.first, { order_type: @params[:order_type] || @service.order_type,
                                    order_url: @params[:order_url] || @service.order_url,
                                    status: "published" }).call
-    elsif @service.offers.size == 0
+    elsif @service.offers.published.size == 0
       Offer::Create.new(Offer.new(name: "Offer",
                                   description: "#{@params[:name] || @service.name} Offer",
                                   order_type: @params[:order_type] || @service.order_type,

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -376,6 +376,22 @@ RSpec.feature "Services in backoffice" do
       end
     end
 
+    scenario "I can update offer's order_type from service by removing second offer" do
+      service = create(:service, order_type: :other)
+      other_offer = create(:offer, order_type: :other, service: service)
+      offer_to_update = create(:offer, order_type: :order_required, service: service)
+
+      visit edit_backoffice_service_offer_path(service, other_offer)
+
+      click_on "Delete Offer"
+
+      expect(page).to have_content("Offer removed successfully")
+      service.reload
+      expect(service.order_type).to eq("other")
+      offer_to_update.reload
+      expect(offer_to_update.order_type).to eq("other")
+    end
+
     scenario "I can see warning about no published offers", js: true do
       service = create(:service)
 
@@ -728,6 +744,8 @@ RSpec.feature "Services in backoffice" do
 
       visit backoffice_service_path(service)
       click_on "Edit"
+
+      expect(page).to have_content("Name")
 
       fill_in "Name", with: "Owner can edit service draft"
       click_on "Update Resource"

--- a/spec/lib/import/resources_spec.rb
+++ b/spec/lib/import/resources_spec.rb
@@ -111,7 +111,7 @@ describe Import::Resources do
     end
 
     it "should update service which has upstream to external id and repeated providers" do
-      service = create(:service)
+      service = create(:service, order_type: :other)
       create(:offer, service: service)
       source = create(:service_source, eid: "phenomenal.phenomenal", service_id: service.id, source_type: "eosc_registry")
       service.update!(upstream_id: source.id)

--- a/spec/requests/api/v1/resources/offers_controller_spec.rb
+++ b/spec/requests/api/v1/resources/offers_controller_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Api::V1::Resources::OffersController, swagger_doc: "v1/offering_s
 
         let(:data_admin_user) { create(:user) }
         let!(:data_administrator) { create(:data_administrator, email: data_admin_user.email) }
-        let!(:service) { create(:service,
+        let!(:service) { create(:service, order_type: "open_access",
                                 resource_organisation: create(:provider, data_administrators: [data_administrator]))}
         let(:offer_payload) { { name: "New offer",
                                 description: "sample description",
@@ -211,7 +211,7 @@ RSpec.describe Api::V1::Resources::OffersController, swagger_doc: "v1/offering_s
 
         let(:data_admin_user) { create(:user) }
         let!(:data_administrator) { create(:data_administrator, email: data_admin_user.email) }
-        let!(:service) { create(:service,
+        let!(:service) { create(:service, order_type: "open_access",
                                 resource_organisation: create(:provider, data_administrators: [data_administrator]))}
         let(:offer_payload) { { name: "New offer",
                                 description: "sample description",
@@ -244,7 +244,7 @@ RSpec.describe Api::V1::Resources::OffersController, swagger_doc: "v1/offering_s
 
         let(:data_admin_user) { create(:user) }
         let!(:data_administrator) { create(:data_administrator, email: data_admin_user.email) }
-        let!(:service) { create(:service,
+        let!(:service) { create(:service, order_type: "open_access",
                                 resource_organisation: create(:provider, data_administrators: [data_administrator]))}
         let(:offer_payload) { { name: "New offer",
                                 description: "sample description",

--- a/spec/services/service/update_spec.rb
+++ b/spec/services/service/update_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Service::Update do
   end
 
   it "creates new offer by service update if offers_count equals 0" do
-    service = create(:service)
+    service = create(:service, order_type: "fully_open_access")
 
     expect(service.offers.size).to eq(0)
 


### PR DESCRIPTION
Add resources reindexing by offer update/remove
(needed for valid `order_type` queries in ES)
Add changing resource order type
after multiple offers deletion
Fixes #1965 

## Offers logic

@jswk this is information for offers logic update

- Add a new offer with different order_type as in service causes change labels to the "various types", filters are searching by order_type of offers and a service
- Set default offer by removing other offers will update offer order_type from a service
- Create the first offer will update offer order_type from a service

### NOTICE
If we remove default offer (offer with the same order_type as in a service) and we have a few offers with different types, existing offers will be not updated for compatibility with the service order_type.