### PR TITLE
[#2299] Fix default offer's order_type bad mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Reindexing and update resource `order type` by offers update or remove (@goreck888)
+- Default offer's `order type` correct mapping from a resource (@goreck888)
 
 ### Security
 

--- a/app/services/offer/create.rb
+++ b/app/services/offer/create.rb
@@ -7,9 +7,6 @@ class Offer::Create
 
   def call
     @offer.save
-    if @offer.service.offers.published.size == 1
-      @offer.update(order_type: @offer.service.order_type)
-    end
     @offer.service.reindex
     @offer
   end

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -10,7 +10,8 @@
       selected: (offer.order_type || service.order_type),
       input_html: { "data-target": "ordering.orderType",
                     "data-action": "ordering#updateVisibility",
-                    class: "form-control-lg col-lg-6" }
+                    class: "form-control-lg col-lg-6" },
+                    readonly: service.offers.published.size == 0 && service.order_type.present?
     = f.input :internal,
       wrapper_html: { "data-target": "ordering.internalWrapper" },
       input_html: { "data-target": "ordering.internal",

--- a/app/views/backoffice/services/offers/edit.html.haml
+++ b/app/views/backoffice/services/offers/edit.html.haml
@@ -4,7 +4,7 @@
   .mb-4.pb-4.border-header
     %h1= _("Edit offer")
 
-  - if @service.offers.size == 1
+  - if @service.offers.published.size == 1
     = render "one_offer_edit_form",
       offer: @offer,
       service: @service,

--- a/app/views/services/ordering_configuration/offers/edit.html.haml
+++ b/app/views/services/ordering_configuration/offers/edit.html.haml
@@ -5,7 +5,7 @@
     %h1= _("Edit offer")
 
   - from = params[:from] || from
-  - if @service.offers.size == 1
+  - if @service.offers.published.size == 1
     = render "backoffice/services/offers/one_offer_edit_form",
       offer: @offer,
       service: @service,

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -327,6 +327,9 @@ RSpec.feature "Services in backoffice" do
       visit backoffice_service_path(service)
       click_on "Add new offer"
 
+      expect(page).to have_field("Name")
+      expect(page).to have_field("Description")
+
       expect {
         fill_in "Name", with: "new offer 1"
         fill_in "Description", with: "test offer"
@@ -339,6 +342,7 @@ RSpec.feature "Services in backoffice" do
           fill_in "Unit", with: "days"
           select "integer", from: "Value type"
         end
+
         click_on "Create Offer"
       }.to change { service.offers.count }.by(1)
 
@@ -731,6 +735,27 @@ RSpec.feature "Services in backoffice" do
       offer.reload
       expect(offer.primary_oms).to eq(oms2)
       expect(offer.oms_params).to eq({})
+    end
+
+    scenario "I see disabled order type if service has no offers" do
+      service = create(:service)
+
+      visit backoffice_service_path(service)
+
+      click_on "Add new offer"
+
+      expect(page).to have_field("Order type", with: service.order_type, readonly: true)
+    end
+
+    scenario "I see enabled order type field if service has an offer" do
+      service = create(:service)
+      create(:offer, order_type: service.order_type, service: service)
+
+      visit backoffice_service_path(service)
+
+      click_on "Add new offer"
+
+      expect(page).to have_field("Order type", with: service.order_type, readonly: false)
     end
   end
 

--- a/spec/features/ordering_configuration_spec.rb
+++ b/spec/features/ordering_configuration_spec.rb
@@ -56,6 +56,9 @@ RSpec.feature "Services in ordering_configuration panel" do
 
       click_on "Add new offer"
 
+      expect(page).to have_field("Name")
+      expect(page).to have_field("Description")
+
       expect {
         fill_in "Name", with: "new offer 1"
         fill_in "Description", with: "test offer"
@@ -68,6 +71,7 @@ RSpec.feature "Services in ordering_configuration panel" do
           fill_in "Unit", with: "days"
           select "integer", from: "Value type"
         end
+
         click_on "Create Offer"
       }.to change { service.offers.count }.by(1)
 
@@ -91,6 +95,8 @@ RSpec.feature "Services in ordering_configuration panel" do
       expect(page).to have_content("Add new offer")
 
       click_on "Add new offer"
+
+      expect(page).to have_field("Name")
 
       expect {
         fill_in "Name", with: "new offer 1"


### PR DESCRIPTION
Issue cause by unnecessary double saving an offer in `Offer::Create` service.
(first save and then copy order_type from not updated resource)
Removed order_type's update and disabled `order_type` field with the service.order_type value set.
Fixes #2299
