### PR TITLE
[#2092] Fix anchor tag persistence on denied permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Include resources without offers in statistics in the executive panel (@goreck888)
+- Fix anchor tag url persistence in redirect after trying to access a forbidden resource (@wujuu)
 
 ### Security
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,8 +21,8 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from Pundit::NotAuthorizedError do |exception|
-    redirect_back fallback_location: root_path,
-                  alert: not_authorized_message(exception)
+    redirect_to root_path(anchor: ""),
+                alert: not_authorized_message(exception)
   end
 
   def tour_disabled

--- a/spec/features/access_denied_spec.rb
+++ b/spec/features/access_denied_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Access denied" do
+  include OmniauthHelper
+
+  context "After trying to enter an unauthorized resource" do
+    let!(:user) { create(:user) }
+
+    before { checkin_sign_in_as(user) }
+
+    scenario "I am being redirected to root_path" do
+      visit backoffice_path
+      expect(page).to have_current_path(root_path(anchor: ""))
+    end
+
+    scenario "with an anchor tag, I am being redirected to root_path without an anchor tag" do
+      visit backoffice_path(anchor: "test")
+      expect(page).to have_current_path(root_path(anchor: ""))
+    end
+  end
+end

--- a/spec/requests/backoffice/services_spec.rb
+++ b/spec/requests/backoffice/services_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Backoffice service" do
       service = create(:service, owners: [user], status: :deleted)
 
       post backoffice_service_publish_path(service)
-      expect(response).to redirect_to root_path
+      expect(response).to redirect_to root_path(anchor: "")
       expect(flash[:alert]).to eq(I18n.t("default", scope: :pundit))
     end
 
@@ -45,7 +45,7 @@ RSpec.describe "Backoffice service" do
       service = create(:service, owners: [user], status: :deleted)
 
       post backoffice_service_draft_path(service)
-      expect(response).to redirect_to root_path
+      expect(response).to redirect_to root_path(anchor: "")
       expect(flash[:alert]).to eq(I18n.t("default", scope: :pundit))
     end
   end


### PR DESCRIPTION
Bug happens due to the behaviour of 302 HTTP Redirect, which persists the anchor tag (#offers in our case) in the url after the redirection (https://stackoverflow.com/questions/5283395/url-hash-is-persisting-between-redirects). Due to losing permission to see the page, the user is being redirected by `pundit` (to the previous page if possible ("referer" header value), or to the root_url if not) - and the anchor persists, causing the bug.

My solution includes replacing the `redirect_back` with `redirect_to root_page(anchor: "")`. This is acceptable, because in MP we have a policy that the users cannot click the links or buttons that they aren't authorized to see (@marcelinna - please check this), thus making the `redirect_back` redundant - the only way to access unauthorized resources is to explicitly input the url, in which case the "referer" header is empty, in which case we are redirected to the root_page anyway (`fallback_url` in `redirect_back`).

Closes #2092 