### PR TITLE
990 breakpoint mobile menu fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Button to query clear in the Backoffice (@goreck888)
 
 ### Changed
+- In mobile view max-width of page is set to 989px (@jarekzet)
 
 ### Deprecated
 
@@ -19,7 +20,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Include resources without offers in statistics in the executive panel (@goreck888)
-- Max width to 989px for mobile view (@jarekzet)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Include resources without offers in statistics in the executive panel (@goreck888)
+- Max width to 989px for mobile view (@jarekzet)
 
 ### Security
 

--- a/app/javascript/stylesheets/_ref_mobile.scss
+++ b/app/javascript/stylesheets/_ref_mobile.scss
@@ -24,7 +24,7 @@
 }
 
 
-@media (max-width: 990px) {
+@media (max-width: 989px) {
 
   .backoffice {
     margin: 0 0 20px;


### PR DESCRIPTION
fix for mobile menu in specific 990px screen size (double navigation in header).

Was
![image](https://user-images.githubusercontent.com/59872096/134332324-d88a38cb-3424-48c6-8b71-ed8b38425e57.png)

Now
![image](https://user-images.githubusercontent.com/59872096/134332432-68e34abf-0430-4272-afb3-a10933e94a12.png)
![image](https://user-images.githubusercontent.com/59872096/134332463-1a7878be-5313-463d-af29-a3039aa57c95.png)

