### PR TITLE
[#2316] Clear query param on tour complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Include resources without offers in statistics in the executive panel (@goreck888)
+- Clear query param on completion for query param activated tours (@jswk)
 
 ### Security
 

--- a/app/javascript/app/tours.js
+++ b/app/javascript/app/tours.js
@@ -21,14 +21,8 @@ function handleCancelFor(data) {
     if (data.activation_strategy === "default") {
         Cookies.set(data.cookies_names.skip, "later", {domain: window.location.hostname});
     } else if (data.activation_strategy === "query_param") {
-        window.location.search = stripTourParam(window.location.search);
+        window.history.pushState(null, "", stripTourParam(window.location));
     }
-}
-
-function stripTourParam(search) {
-    const params = new URLSearchParams(search);
-    params.delete("tour");
-    return params;
 }
 
 function handleCompleteFor(data) {
@@ -59,8 +53,16 @@ function handleCompleteFor(data) {
     }
 
     if (!!data.next_tour_link) {
-        window.location.replace(data.next_tour_link)
+        Turbolinks.visit(data.next_tour_link);
+    } else if (data.activation_strategy === "query_param") {
+        window.history.pushState(null, "", stripTourParam(window.location));
     }
+}
+
+function stripTourParam(location) {
+    const url = new URL(location);
+    url.searchParams.delete("tour");
+    return url;
 }
 
 function handleStartFor(data) {

--- a/spec/features/tours/query_param_spec.rb
+++ b/spec/features/tours/query_param_spec.rb
@@ -67,6 +67,8 @@ RSpec.feature "Query param tour" do
     click_on "Next"
     click_on "Next"
 
+    expect(page).to have_current_path(service_details_path(service))
+
     expect(page).to have_text("Congratulations!")
     expect(page).to have_text("You have completed the resource presentation page tour guide.")
     expect(page).to have_text("Please also leave a comment on how we can improve it")


### PR DESCRIPTION
The `tour` query param wasn't cleared on tour completion for tours with
query param activation strategy.

It was discovered in https://github.com/cyfronet-fid/marketplace/pull/2311#issuecomment-926471672, but was out of the virtual tour scope itself.

# How to test

Go to https://marketplace-13.docker-fid.grid.cyf-kr.edu.pl/services/egi-cloud-compute?tour=query_param_1 and complete both parts of the tour.
After the last step, the `tour` query param should disappear from URL and the feedback modal should be visible.

Fixes: #2316.