### PR TITLE
 [#2273] Improve preview functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Project duplication includes scientific domains associated with source (@goreck888)
+- The backoffice resource preview should be displayed identically as resource page - improve user experience (@danielkryska)
 
 ### Security
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -105,7 +105,9 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
     def store_in_session!
       attributes = permitted_attributes(@service || Service)
       logo = attributes.delete(:logo)
-      session[preview_session_key] = { "attributes" => attributes }
+      compact_attributes = attributes.each { |k, v| v.reject!(&:blank?) if v.instance_of? Array }
+                                     .reject { |k, v| v.blank? }
+      session[preview_session_key] = { "attributes" => compact_attributes }
       if logo
         session[preview_session_key]["logo"] = {
           "filename" => logo.original_filename,

--- a/app/helpers/backoffice/services_helper.rb
+++ b/app/helpers/backoffice/services_helper.rb
@@ -28,4 +28,17 @@ module Backoffice::ServicesHelper
   def is_offer_missing(param, param_options)
     param_options["mandatory"] && @offer.errors[:oms_params].present? && @offer.oms_params[param].blank?
   end
+
+  def preview_link_parameters(is_preview)
+    if is_preview
+      {
+        disabled: true,
+        tabindex: -1,
+        class: "disabled",
+        "data-tooltip": "Element disabled in the preview mode"
+      }
+    else
+      {}
+    end
+  end
 end

--- a/app/helpers/image_helper.rb
+++ b/app/helpers/image_helper.rb
@@ -24,10 +24,12 @@ module ImageHelper
   end
 
   def self.to_base_64(path)
-    content_type = MIME::Types.type_for(path).first.content_type
+    content_type = MiniMagick::Image.open(path).mime_type
     File.open(path, "rb") do |img|
       "data:" + content_type + ";base64," + Base64.strict_encode64(img.read)
     end
+    rescue Exception
+      "Not recognized or not permitted file type"
   end
 
   def self.binary_to_blob_stream(file_path)

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -49,12 +49,14 @@ module ServiceHelper
     service.scientific_domains.map { |target| target.name }
   end
 
-  def resource_organisation(service, highlights = nil)
+  def resource_organisation(service, highlights = nil, preview = false)
     target = service.resource_organisation
+    preview_options = preview ? { "data-target": "preview.link" } : {}
     link_to_unless(
       target.deleted?,
       highlighted_for(:resource_organisation_name, service, highlights),
-      provider_path(target)
+      provider_path(target),
+      preview_options
     )
   end
 
@@ -76,16 +78,17 @@ module ServiceHelper
       map { |target| target.name }
   end
 
-  def providers(service, highlights = nil)
+  def providers(service, highlights = nil, preview = false)
     highlighted = highlights.present? ? sanitize(highlights[:provider_names])&.to_str : ""
+    preview_options = preview ? { "data-target": "preview.link" } : {}
     service.providers
            .reject(&:blank?)
            .reject(&:deleted?)
            .reject { |p| p == service.resource_organisation }.uniq.map do |target|
       if highlighted.present? && highlighted.strip == target.name.strip
-        link_to_unless target.deleted?, highlights[:provider_names].html_safe, provider_path(target)
+        link_to_unless target.deleted?, highlights[:provider_names].html_safe, provider_path(target), preview_options
       else
-        link_to_unless target.deleted?, target.name, provider_path(target)
+        link_to_unless target.deleted?, target.name, provider_path(target), preview_options
       end
     end
   end

--- a/app/javascript/app/controllers/preview_controller.js
+++ b/app/javascript/app/controllers/preview_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+    static targets = ["link"];
+
+    initialize() {
+        console.log("Preview connected")
+        this.linkTargets.
+            forEach(link => { link.href = "javascript:;" });
+    }
+}

--- a/app/javascript/app/controllers/preview_controller.js
+++ b/app/javascript/app/controllers/preview_controller.js
@@ -1,11 +1,23 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-    static targets = ["link"];
+    static targets = ["link", "tab", "content", "details"];
 
     initialize() {
-        console.log("Preview connected")
         this.linkTargets.
             forEach(link => { link.href = "javascript:;" });
+    }
+
+    toggle(event) {
+        const tab = document.getElementById(event.currentTarget.dataset.value);
+
+        this.contentTargets.forEach(el => { el.classList.add("d-none") });
+        this.tabTargets.forEach(tab => { tab.classList.remove("active") });
+        if (event.currentTarget.classList.contains("more-details")) {
+            this.detailsTarget.classList.add("active");
+        } else {
+            event.currentTarget.classList.add("active");
+        }
+        tab.classList.remove("d-none");
     }
 }

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -154,7 +154,7 @@
                   [:resource_geographic_locations])),
                   data: { toggle: "collapse", target: "#location" },
                   aria: { expanded: true, controls: "location" } }
-            .card-header.text-left{ id: "contact-header" }
+            .card-header.text-left{ id: "location-header" }
               .row
                 .col-10
                   = _("Location")

--- a/app/views/backoffice/services/preview.html.haml
+++ b/app/views/backoffice/services/preview.html.haml
@@ -24,8 +24,11 @@
       = render "services/tabs", service: @service, preview: true
 
   .tab-content
-    = render "services/about", service: @service, offers: @offers, analytics: @analytics, preview: true
-    = render "taggable/details_section", service: @service, preview: true
+    #about{ "data-target": "preview.content" }
+      = render "services/about", service: @service, offers: @offers, analytics: @analytics, preview: true
+      = render "taggable/details_section", taggable: @service, preview: true
+    #details.d-none{ "data-target": "preview.content" }
+      = render "services/details", service: @service, preview: true
 
   .container.mt-4.pt-4.related-container
     = render "services/related", related_services: @related_services, title: @related_services_title, preview: true

--- a/app/views/backoffice/services/preview.html.haml
+++ b/app/views/backoffice/services/preview.html.haml
@@ -16,15 +16,16 @@
             class: "btn btn-warning"
           = link_to _("Confirm changes"), backoffice_services_path,
             class: "btn btn-success", method: :post
+.container{ "data-controller": "preview" }
+  .container.preview
+    .pt-4.pl-3.pr-3.shadow-sm.rounded.service-box.service-detail
+      = render "services/header", service: @service, preview: true, favourite_services: @favourite_services,
+      comparison_enabled: @comparison_enabled
+      = render "services/tabs", service: @service, preview: true
 
-.container.preview
-  .pt-4.pl-3.pr-3.shadow-sm.rounded.service-box.service-detail
-    = render "services/header", service: @service, preview: true, favourite_services: @favourite_services
-    = render "services/tabs", service: @service, preview: true
+  .tab-content
+    = render "services/about", service: @service, offers: @offers, analytics: @analytics, preview: true
+    = render "taggable/details_section", service: @service, preview: true
 
-.tab-content
-  = render "services/about", service: @service, offers: @offers, analytics: @analytics
-  = render "taggable/details_section", taggable: @service
-
-.container.mt-4.pt-4.related-container
-  = render "services/related", related_services: @related_services, title: @related_services_title
+  .container.mt-4.pt-4.related-container
+    = render "services/related", related_services: @related_services, title: @related_services_title, preview: true

--- a/app/views/services/_about.html.haml
+++ b/app/views/services/_about.html.haml
@@ -6,7 +6,7 @@
       - if service.pid == (ENV["OPENAIRE_NOTEBOOKS__ACTIVATION_PID"] || "egi-fed.notebook")
         = render "notebook_openaire_explore"
       - if policy(service).order? && (policy(service).offers_show? || policy(service).bundles_show?)
-        = render "services/offers", offers: offers, service: service, bundles: bundles
+        = render "services/offers", offers: offers, service: service, bundles: bundles, preview: local_assigns[:preview]
     %sidebar.col-12.col-xl-3{ "data-shepherd-tour-target": "service-classification" }
       - service_sidebar_fields.each do |group|
         - if any_present?(service, *group[:fields])

--- a/app/views/services/_about.html.haml
+++ b/app/views/services/_about.html.haml
@@ -38,9 +38,18 @@
               %span
                 = _("Total orders") + ":"
               %strong.text-dark= service.project_items.order_required.size
-
-      %a.more-details{ href: service_details_path(service), "data-shepherd-tour-target": "service-more-about",
-        "data-probe" => "" }
-        = _("More about")
-        = service.name
-        %i.fas.fa-long-arrow-alt-right
+      - unless local_assigns[:preview]
+        %a.more-details{ href: service_details_path(service),
+                         "data-shepherd-tour-target": "service-more-about",
+                         "data-probe" => "" }
+          = _("More about")
+          = service.name
+          %i.fas.fa-long-arrow-alt-right
+      - else
+        %a.more-details{ href: "javascript:;",
+                         "data-action": "click->preview#toggle",
+                         "data-value": "details",
+                         "data-probe" => "" }
+          = _("More about")
+          = service.name
+          %i.fas.fa-long-arrow-alt-right

--- a/app/views/services/_ask_question.html.haml
+++ b/app/views/services/_ask_question.html.haml
@@ -1,3 +1,3 @@
 = link_to _("Ask a question about this resource?"), new_service_question_path(service),
-  class: "question-link", remote: true, "data-probe": ""
+  class: "question-link", remote: true, "data-probe": "", "data-target": local_assigns[:preview] ? "preview.link" : ""
 

--- a/app/views/services/_categorization.html.haml
+++ b/app/views/services/_categorization.html.haml
@@ -3,8 +3,8 @@
     %span
       = _("Organisation") + ":"
   %dd.x-small
-    %mr-4= resource_organisation(service, highlights)
-- active_providers = safe_join(providers(service, highlights), ", ")
+    %mr-4= resource_organisation(service, highlights, local_assigns[:preview])
+- active_providers = safe_join(providers(service, highlights, local_assigns[:preview]), ", ")
 - if active_providers.present?
   %dl.mb-0
     %dt.x-small

--- a/app/views/services/_details.html.haml
+++ b/app/views/services/_details.html.haml
@@ -19,4 +19,5 @@
                               type: group[:type] || "single",
                               clazz: group[:clazz] || "",
                               nested: group[:nested] || "",
-                              with_desc: group[:with_desc] || false
+                              with_desc: group[:with_desc] || false,
+                              preview: local_assigns[:preview]

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -9,7 +9,7 @@
     .col-12.col-sm-9.service-details-header
       %h2.font-weight-bolder= service.name
       %p.mb-1= service.tagline
-      = render "services/categorization", service: service, highlights: nil
+      = render "services/categorization", service: service, highlights: nil, preview: local_assigns[:preview]
 
       .row.mt-2
         .col
@@ -21,12 +21,12 @@
             - if service.persisted?
               = link_to "#{service.service_opinion_count} reviews", service_opinions_path(service),
               class: "ml-1 default-color"
-          .comparison
-            - unless local_assigns[:preview]
+          %fieldset{ preview_link_parameters(local_assigns[:preview]) }
+            .comparison
               %span.compare
-                %label{ options(service.slug, comparison_enabled) }
+                %label{ local_assigns[:preview] ? {} : options(service.slug, comparison_enabled) }
                   = check_box_tag "comparison", service.slug, checked?(service.slug), id: "comparison-#{service.id}",
-                          class: "form-check-input",
+                          class: local_assigns[:preview] ? "form-check-input disabled" : "form-check-input",
                           disabled: !checked?(service.slug) && comparison_enabled,
                           "data-probe" => "",
                           "data-e2e": "comparison-checkbox",
@@ -34,25 +34,26 @@
                           "data-action": "click->comparison#update"
                   %span.smaller
                     = _("Add to comparison")
-          .comparison
-            %span.compare
-              %label
-                = check_box_tag "favourite", service.slug, favourite?(Array(favourite_services), service.slug),
-                  id: "favourite-#{service.id}",
-                      class: "form-check-input",
-                      "data-target": "favourite.checkbox",
-                      "data-action": "click->favourite#updateFromRes"
-                %span.smaller
-                  = _("Add to favourites")
+            .comparison
+              %span.compare
+                %label
+                  = check_box_tag "favourite", service.slug, favourite?(Array(favourite_services), service.slug),
+                    id: "favourite-#{service.id}",
+                        class: "form-check-input",
+                        "data-target": "favourite.checkbox",
+                        "data-action": "click->favourite#updateFromRes"
+                  %span.smaller
+                    = _("Add to favourites")
   .col-12.col-lg-3.text-center.vertical-center
     .vertical-center-inner.access-type
-      - if policy(service).order?
+      - if policy(service).order? || local_assigns[:preview]
         = link_to _("Access the resource"),
                       service_offers_path(service),
                       class: "btn btn-primary d-block mb-3",
                       "data-e2e": "access-resource-btn",
-                      "data-probe": ""
-      - if user_signed_in? && policy(service).data_administrator?
+                      "data-probe": "",
+                      "data-target": local_assigns[:preview] ? "preview.link" : ""
+      - if user_signed_in? && policy(service).data_administrator? && !local_assigns[:preview]
         %a#dropdown-menu-button.dropdown-toggle.btn.btn-outline-secondary.d-block.mb-3{ "aria-expanded" => "false",
                                                       "aria-haspopup" => "true",
                                                       "data-toggle" => "dropdown",
@@ -89,7 +90,9 @@
           = render "services/sidebar/simple_links",
                       service: service,
                       fields: group[:fields],
-                      nested: group[:nested] || ""
+                      nested: group[:nested] || "",
+                      preview: local_assigns[:preview]
   .col-12.col-sm-3.question-col
-    - if local_assigns[:question] && !service.public_contacts.empty?
-      = render "services/ask_question", service: service, question: question
+    - if !service.public_contacts.empty? && (local_assigns[:question] || local_assigns[:preview])
+      = render "services/ask_question", service: service, question: local_assigns[:question],
+        preview: local_assigns[:preview]

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -20,7 +20,7 @@
               (#{service.rating} /5)
             - if service.persisted?
               = link_to "#{service.service_opinion_count} reviews", service_opinions_path(service),
-              class: "ml-1 default-color"
+              class: "ml-1 default-color", "data-target": local_assigns[:preview] ? "preview.link" : ""
           %fieldset{ preview_link_parameters(local_assigns[:preview]) }
             .comparison
               %span.compare

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -1,5 +1,6 @@
 .col-md-6.d-flex.align-items-stretch{ id: "offer-#{offer.id}" }
   .card.m-0.mb-5
+    = local_assigns[:preview]
     = render "services/offers/description", offer: offer
     = render "services/offers/parameters",
       technical_parameters: filter_technical_parameters(offer.attributes.map(&:to_json))
@@ -9,6 +10,7 @@
     .card-button.text-center
       %label
         = link_to service_offers_path(offer.service, customizable_project_item: { offer_id: offer.iid }),
-        "data-probe": "", "data-e2e": "select-offer-btn", method: :put do
+        "data-probe": "", "data-e2e": "select-offer-btn", "data-target": local_assigns[:preview] ? "preview.link" : "",
+        method: :put do
           %span.btn.btn-primary.font-weight-bold
             = _("Select an offer")

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -1,6 +1,5 @@
 .col-md-6.d-flex.align-items-stretch{ id: "offer-#{offer.id}" }
   .card.m-0.mb-5
-    = local_assigns[:preview]
     = render "services/offers/description", offer: offer
     = render "services/offers/parameters",
       technical_parameters: filter_technical_parameters(offer.attributes.map(&:to_json))

--- a/app/views/services/_offers.html.haml
+++ b/app/views/services/_offers.html.haml
@@ -18,7 +18,7 @@
   %h2.mb-3.mt-5.font-weight-normal
     = _("Resource offers")
   .row
-    = render partial: "services/offer", collection: offers, as: :offer
+    = render partial: "services/offer", collection: offers, as: :offer, locals: { preview: local_assigns[:preview] }
 - if policy(service).bundles_show?
   %h2.mb-4.mt-5.font-weight-normal
     = _("Bundles")

--- a/app/views/services/_related.html.haml
+++ b/app/views/services/_related.html.haml
@@ -4,4 +4,5 @@
   .card-columns
     = render partial: "services/service_box",
             collection: related_services,
-            as: :service
+            as: :service,
+            locals: { preview: local_assigns[:preview] }

--- a/app/views/services/_service_box.html.haml
+++ b/app/views/services/_service_box.html.haml
@@ -1,6 +1,7 @@
 .card.bg-gray-5.border-0
   .card-body
-    %h3.card-title= link_to service.name.truncate(35, separator: " "), service, name: service.name
+    %h3.card-title= link_to service.name.truncate(35, separator: " "), service, name: service.name,
+    "data-target": local_assigns[:preview] ? "preview.link" : ""
     .row.card-description
       .col-4
         = service_logo(service)

--- a/app/views/services/_tabs.haml
+++ b/app/views/services/_tabs.haml
@@ -5,8 +5,17 @@
     %ul#my-tab.nav.nav-tabs.row.pl-3{ role: "tablist" }
       - if local_assigns[:preview]
         %li.nav-item
-          %a.nav-link.active.text-uppercase{ "data-probe" => "" }
+          %a.nav-link.active.text-uppercase{ "data-probe": "",
+                                             "data-target": "preview.tab",
+                                             "data-action": "click->preview#toggle",
+                                             "data-value": "about" }
             = _("About")
+        %li.nav-item
+          %a.nav-link.text-uppercase{ "data-probe": "",
+                                      "data-target": "preview.tab preview.details",
+                                      "data-action": "click->preview#toggle",
+                                      "data-value": "details" }
+            = _("Details")
         %li.nav-item
           %a.nav-link.disabled.text-uppercase{ "data-probe" => "" }
             = _("Reviews (%{ssoc})") % { ssoc: service.service_opinion_count }

--- a/app/views/services/details/_array.html.haml
+++ b/app/views/services/details/_array.html.haml
@@ -12,26 +12,30 @@
       - elsif field == "geographical_availabilities"
         %span
           = safe_join(get_only_regions(service.send(field)).map { |c| link_to c,
-            services_path(geographical_availabilities: c) }.sort, ", ")
+            services_path(geographical_availabilities: c),
+            "data-target": local_assigns[:preview] ? "preview.link" : "" }.sort, ", ")
         - if get_only_countries(service.send(field)).present?
           %span.geographical
             = safe_join(get_only_countries(service.send(field)).map { |c| link_to c,
-            services_path(geographical_availabilities: c) }.sort, ", ")
+            services_path(geographical_availabilities: c),
+            "data-target": local_assigns[:preview] ? "preview.link" : "" }.sort, ", ")
       - else
         - Array(service.send(field)).map.with_index do |element, idx|
           - if nested.present? && nested[field.to_sym].present?
             - if nested[field.to_sym] == "link"
               %li.links
                 %i.fas.fa-arrow-right
-                = link_to field.humanize, element, "data-probe": ""
+                = link_to field.humanize, element, "data-probe": "",
+                "data-target": local_assigns[:preview] ? "preview.link" : ""
             - elsif nested[field.to_sym] == "service"
               %li.links
                 %i.fas.fa-arrow-right
-                = link_to(element.name, service_path(element), "data-probe": "")
+                = link_to(element.name, service_path(element), "data-probe": "",
+                "data-target": local_assigns[:preview] ? "preview.link" : "")
             - elsif nested[field.to_sym] == "tag"
               %span
                 = link_to element, services_path(tag: element), class: "badge badge-light",
-                "data-probe": ""
+                "data-probe": "", "data-target": local_assigns[:preview] ? "preview.link" : ""
             - elsif nested[field.to_sym] == "label"
               %span
                 -# TODO: refactor dynamic translation

--- a/app/views/services/details/_links.html.haml
+++ b/app/views/services/details/_links.html.haml
@@ -5,14 +5,17 @@
         %li.links
           %i.fas.fa-arrow-right
           -# TODO: refactor dynamic translation
-          = link_to(t(".#{field}", idx: idx + 1), link, "data-probe": "")
+          = link_to(t(".#{field}", idx: idx + 1), link, "data-probe": "",
+          "data-target": local_assigns[:preview] ? "preview.link" : "")
     - elsif type == "service"
       - service.send(field).map do |element|
         %li.links
           %i.fas.fa-arrow-right
-          = link_to(element.name, service_path(element), "data-probe": "")
+          = link_to(element.name, service_path(element), "data-probe": "",
+          "data-target": local_assigns[:preview] ? "preview.link" : "")
     - else
       %li.links
         %i.fas.fa-arrow-right
         -# TODO: refactor dynamic translation
-        = link_to(t("services.about.sidebar.fields.#{field}"), service.send(field), "data-probe": "")
+        = link_to(t("services.about.sidebar.fields.#{field}"), service.send(field), "data-probe": "",
+        "data-target": local_assigns[:preview] ? "preview.link" : "")

--- a/app/views/services/details/_object.html.haml
+++ b/app/views/services/details/_object.html.haml
@@ -3,7 +3,12 @@
     - fields.map do |field|
       - if object.send(field).present?
         - if nested[field.to_sym].present? && nested[field.to_sym] == "email"
-          %span= mail_to object.send(field), object.send(field)
+
+          %span
+            - if local_assigns[:preview]
+              = link_to object.send(field), "javascript:;"
+            - else
+              = mail_to object.send(field), object.send(field)
           %br
         - else
           %span= object.send(field)

--- a/app/views/services/sidebar/_simple_links.html.haml
+++ b/app/views/services/sidebar/_simple_links.html.haml
@@ -4,7 +4,9 @@
       %li
         %i.fas.fa-arrow-right
         - if field.end_with? "_url"
-          = link_to(t("services.about.sidebar.fields.#{field}"), service.send(field), "data-probe": "")
+          = link_to(t("services.about.sidebar.fields.#{field}"), service.send(field), "data-probe": "",
+          "data-target": local_assigns[:preview] ? "preview.link" : "")
         - elsif field.end_with? "_email"
-          = mail_to(service.send(field), t("services.about.sidebar.fields.#{field}"), "data-probe": "")
+          = mail_to(service.send(field), t("services.about.sidebar.fields.#{field}"), "data-probe": "",
+          "data-target": local_assigns[:preview] ? "preview.link" : "")
         -# TODO: refactor dynamic translation (above)

--- a/app/views/taggable/_details_section.html.haml
+++ b/app/views/taggable/_details_section.html.haml
@@ -2,4 +2,5 @@
   .container
     = _("Tags") + ":"
     - taggable.tag_list.sort.each do |tag|
-      = link_to tag, services_path(tag: tag), class: "badge badge-light"
+      = link_to tag, services_path(tag: tag), class: "badge badge-light",
+      "data-target": local_assigns[:preview] ? "preview.link" : ""

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -207,6 +207,26 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_content("service name")
     end
 
+    scenario "I cannot do any action on service preview", js: true do
+      service = create(:service, related_services: [create(:service)], tag_list: ["tag"],
+                       public_contacts: [build(:public_contact)], offers: [create(:offer)])
+
+      visit edit_backoffice_service_path(service)
+
+      click_on "Preview"
+
+      expect(page).to have_link(service.resource_organisation.name, href: "javascript:;")
+      expect(page).to have_link(service.providers.first.name, href: "javascript:;")
+      expect(page).to have_link("Webpage", href: "javascript:;")
+      expect(page).to have_link("Manual", href: "javascript:;")
+      expect(page).to have_link("Helpdesk", href: "javascript:;")
+      expect(page).to have_link("Training information", href: "javascript:;")
+      expect(page).to have_link("Ask a question about this resource?", href: "javascript:;")
+      expect(page).to have_link("Access the resource", href: "javascript:;")
+      expect(page).to have_link("tag", href: "javascript:;")
+      expect(page).to have_link(service.related_services.first.name, href: "javascript:;")
+    end
+
     scenario "I cannot create service with wrong logo file" do
       provider = create(:provider)
       scientific_domain = create(:scientific_domain)

--- a/test/system/cypress/support/resources.ts
+++ b/test/system/cypress/support/resources.ts
@@ -112,7 +112,6 @@ Cypress.Commands.add("fillFormCreateResource", (resource: IResources, logo) => {
     .type("{esc}");
 
   cy.get("#contact-header.card-header")
-    .eq(1)
     .click();
 
   if (resource.contactsFirstname) {


### PR DESCRIPTION
Add all hidden buttons and links in preview
and disable them via js controller
Closes #2273

---
- [x] "Access to Resource" button
- [x] Add to comparison (but not clickable)
- [x] Add to favourite (but not clickable)
- [x] Replacemnet logo if there is no logo
- [x] Details - the user is able to see how the details will be displayed (every link in details will be not clickable)
- [x] Reviews - disabled (as it is now)
- [x] Link: Provided by:, Organisation:, More about Resource, Helpdesk, and any other not clickable in preview mode.
- [x] Ask a question about this resource? link should be visible but not clickable
- [x] Tags and other elements that could allow users to exit the "Preview" mode should not be clickable
