### PR TITLE
Correct owned_resources failing test

### DIFF
--- a/test/system/cypress/integration/regression_tests/backoffice/resources/owned_resources.spec.ts
+++ b/test/system/cypress/integration/regression_tests/backoffice/resources/owned_resources.spec.ts
@@ -81,7 +81,7 @@ describe("Owned resources", () => {
       .click();
     cy.get("div.invalid-feedback")
       .should("be.visible")
-    cy.contains("div.invalid-feedback", "Logo is not a valid file format and The logo format you're trying to attach is not supported")
+    cy.contains("div.invalid-feedback", "Logo is not a valid file format and Logo format you're trying to attach is not supported")
       .should("be.visible")
     cy.contains("div.invalid-feedback", "Email is not a valid email address")
       .should("be.visible") 


### PR DESCRIPTION
The rails/ruby upgrade PR wasn't rebased on the current master, leading
to the test failure.