### PR TITLE
[#2333] Set correct OpenAIRE Notebooks URL and add customization

### DIFF
--- a/app/views/services/_about.html.haml
+++ b/app/views/services/_about.html.haml
@@ -3,7 +3,7 @@
     %main.col-12.col-xl-9.pr-5.mb-4{ "data-shepherd-tour-target": "service-about" }
 
       = markdown(service.description)
-      - if service.pid == "egi-fed.notebook"
+      - if service.pid == (ENV["OPENAIRE_NOTEBOOKS__ACTIVATION_PID"] || "egi-fed.notebook")
         = render "notebook_openaire_explore"
       - if policy(service).order? && !offers&.empty?
         = render "services/offers", offers: offers, service: service

--- a/app/views/services/_notebook_openaire_explore.html.haml
+++ b/app/views/services/_notebook_openaire_explore.html.haml
@@ -4,8 +4,9 @@
   .col-12.col-sm-7.col-md-8.vertical-middle
     %p.mb-0
       = _("See Jupyter notebooks compatible with the EGI Notebook service at")
-      %a{ href: "https://explore.openaire.eu/search/advanced/research-outcomes
-          ?f0=resultsubject&fv0=%2522eosc%2520jupyter%2520notebook%2522&resultbestaccessright=%22Open%2520Access%22",
+      %a{ href: ENV["OPENAIRE_NOTEBOOKS__HARDCODED_LINK"] ||
+                "https://beta.explore.openaire.eu/search/advanced/research-outcomes?
+                 f0=resultsubject&fv0=%2522EOSC%2520Jupyter%2520Notebook%2522",
           target: "_blank" }
         OpenAIRE Explore
       = _("(opens in a new window)")


### PR DESCRIPTION
Correct the outgoing URL and make it possible to override the URL and
activation PID in runtime, in case quick corrections are necessary.

## How to test

The integration link should now lead to the actual results.
The customization test would require instance modification. It is a basic code, which shouldn't misbehave.

Closes: #2333.