### PR TITLE
Remove unused dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ gem "google-api-client", "~> 0.34", require: "google/apis/analyticsreporting_v4"
 gem "redis-rails"
 gem "sidekiq"
 
-gem "custom_error_message", git: "https://github.com/thethanghn/custom-err-msg.git"
 gem "stomp"
 
 gem "split", require: "split/dashboard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/thethanghn/custom-err-msg.git
-  revision: b913309360995472507ea444c6f1a80315b99d28
-  specs:
-    custom_error_message (1.2.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -663,7 +657,6 @@ DEPENDENCIES
   colorize (>= 0.8.1)
   counter_culture (~> 2.0)
   countries
-  custom_error_message!
   database_cleaner
   devise
   dotenv-rails


### PR DESCRIPTION
Removed gem custom_error_message, there were instances in code that started with ^ that changed validation msg from artibute+msg to only msg. There should be no more msg that starts with ^.

Reason:
gem works only for Rails 4. 
Rails 6 should work with custom messages. [[more info](https://www.bigbinary.com/blog/rails-6-allows-to-override-the-activemodel-errors-full_message-format-at-the-model-level-and-at-the-attribute-level)]