### PR TITLE
Move to sentry-ruby from deprecated sentry-raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,9 @@ end
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :production do
-  gem "sentry-raven"
+  gem "sentry-ruby"
+  gem "sentry-rails"
+  gem "sentry-sidekiq"
   gem "faker", require: false
   gem "newrelic_rpm"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,8 +530,19 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.1.2)
+    sentry-rails (4.7.3)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.7.0)
+    sentry-ruby (4.7.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.7.3)
+    sentry-ruby-core (4.7.3)
+      concurrent-ruby
+      faraday
+    sentry-sidekiq (4.7.3)
+      sentry-ruby-core (~> 4.7.0)
+      sidekiq (>= 3.0)
     sexp_processor (4.15.3)
     shoulda-matchers (5.0.0)
       activesupport (>= 5.2.0)
@@ -710,7 +721,9 @@ DEPENDENCIES
   scss_lint
   searchkick
   selenium-webdriver
-  sentry-raven
+  sentry-rails
+  sentry-ruby
+  sentry-sidekiq
   shoulda-matchers
   sidekiq
   simple_form

--- a/app/controllers/concerns/sentryable.rb
+++ b/app/controllers/concerns/sentryable.rb
@@ -4,20 +4,17 @@ module Sentryable
   extend ActiveSupport::Concern
 
   included do
-    before_action :set_raven_context, if: :sentry_enabled?
+    before_action :set_sentry_context, if: :sentry_enabled?
   end
 
   private
-    def set_raven_context
+    def set_sentry_context
       if current_user
-        Raven.user_context(id: current_user.id,
-                          email: current_user.email,
-                          username: current_user.full_name)
+        Sentry.set_user(id: current_user.id, uid: current_user.uid)
       end
-      Raven.extra_context(params: params.permit!.to_h, url: request.url)
     end
 
     def sentry_enabled?
-      Rails.env.production?
+      Rails.env.production? && ENV["SENTRY_DSN"]
     end
 end

--- a/app/controllers/concerns/service/recommendable.rb
+++ b/app/controllers/concerns/service/recommendable.rb
@@ -67,7 +67,7 @@ module Service::Recommendable
       end
 
     rescue
-      Raven.capture_message("Recommendation service, recommendation endpoint response error")
+      Sentry.capture_message("Recommendation service, recommendation endpoint response error")
       []
     end
 

--- a/app/helpers/image_helper.rb
+++ b/app/helpers/image_helper.rb
@@ -83,7 +83,7 @@ module ImageHelper
     extension = "." + metadata[/image\/[a-zA-Z]+/].gsub!(/image\//, "")
     unless ImageHelper.image_ext_permitted?(extension)
       msg = "Conversion of binary image to base64 can't be done on file with extension #{extension}"
-      Raven.capture_message(msg)
+      Sentry.capture_message(msg)
       raise msg
     end
 
@@ -96,7 +96,7 @@ module ImageHelper
       extension = "." + file_name.split(".")[-1]
       unless ImageHelper.image_ext_permitted?(extension)
         msg = "Conversion of binary image to base64 can't be done on file with extension #{extension}"
-        Raven.capture_message(msg)
+        Sentry.capture_message(msg)
         raise msg
       end
 

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "raven"
-
 class Country
   SCHENGEN = ["AT", "BE", "CH", "CZ", "DE", "DK",
               "EE", "GR", "ES", "FI", "FR", "HU",
@@ -86,7 +84,7 @@ class Country
         return searched_country
       end
 
-      Raven.capture_message("Country with alpha2 code: #{value}, couldn't be found")
+      Sentry.capture_message("Country with alpha2 code: #{value}, couldn't be found")
       ISO3166::Country.new("N/E")
     end
 

--- a/app/services/jms/manage_message.rb
+++ b/app/services/jms/manage_message.rb
@@ -46,7 +46,7 @@ class Jms::ManageMessage
     end
   rescue WrongMessageError => e
     warn "[WARN] Message arrived, but the type is unknown: #{body["resourceType"]}, #{e}"
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
   end
 
   private

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -141,26 +141,6 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
-      "fingerprint": "2fbbd766459c796fa13ed38170547a2689999b1648f61869c8d90112ea51af73",
-      "check_name": "MassAssignment",
-      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
-      "file": "app/controllers/concerns/sentryable.rb",
-      "line": 17,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.permit!",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Sentryable",
-        "method": "set_raven_context"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 70,
       "fingerprint": "3aa961f8b2b6468e0677efc995ada5be6554337f13351cf422ccd777714a94b4",
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 if Rails.env.production? && ENV["SENTRY_DSN"]
-  require "raven"
+  require "sentry-ruby"
 
-  Raven.configure do |config|
+  Sentry.init do |config|
     config.dsn = ENV["SENTRY_DSN"]
-    config.environments = [ENV["SENTRY_ENVIRONMENT"] || "production"]
-    config.sanitize_fields =
-      Rails.application.config.filter_parameters.map(&:to_s)
+    config.environment = ENV["SENTRY_ENVIRONMENT"] || "production"
+    config.traces_sample_rate = 0.5
+    config.send_default_pii = true
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -44,7 +44,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 
-require "raven"
+require "sentry-ruby"
 
 before_fork do
   require "puma_worker_killer"
@@ -61,7 +61,7 @@ before_fork do
     config.rolling_restart_frequency = false
 
     config.pre_term = -> (worker) {
-      Raven.capture_message(
+      Sentry.capture_message(
         "Puma worker #{worker.instance_variable_get("@index")} "\
         "(pid: #{worker.instance_variable_get("@pid")}) "\
         "#{worker.instance_variable_get("@stage")}, "\

--- a/lib/jms/subscriber.rb
+++ b/lib/jms/subscriber.rb
@@ -2,14 +2,14 @@
 
 require "stomp"
 require "json"
-require "raven"
+require "sentry-ruby"
 
 module Jms
   class Subscriber
     class ConnectionError < StandardError
       def initialize(msg)
-        Raven.capture_exception(msg)
         super(msg)
+        Sentry.capture_exception(self)
       end
     end
 
@@ -49,7 +49,7 @@ module Jms
       def error_block(msg, e)
         @logger.error("Error occured while processing message:\n #{msg}")
         @logger.error(e)
-        Raven.capture_exception(e)
+        Sentry.capture_exception(e)
         abort(e.full_message)
       end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "import/resources"
-require "raven"
 
 namespace :import do
   desc "Imports services data from external providers"

--- a/spec/features/favourite_spec.rb
+++ b/spec/features/favourite_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "raven"
 
 RSpec.feature "Favourites" do
   include OmniauthHelper

--- a/spec/features/recommended_spec.rb
+++ b/spec/features/recommended_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "raven"
+require "sentry-ruby"
 
 RSpec.feature "Recommended services" do
   include OmniauthHelper
@@ -30,7 +30,7 @@ RSpec.feature "Recommended services" do
     )
 
     allow(Faraday).to receive(:post).and_raise(ArgumentError)
-    allow(Raven).to receive(:capture_message)
+    allow(Sentry).to receive(:capture_message)
 
     services_ids = [1, 2, 3]
     services = services_ids.map { |id| create(:service, id: id) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,7 +18,6 @@ require "rspec/rails"
 require "action_dispatch/system_testing/server"
 ActionDispatch::SystemTesting::Server.silence_puma = true
 require "action_dispatch/system_test_case"
-require "raven"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
The extra_context from Sentryable::set_raven_context should be supplied
by sentry-rails itself, thanks to setting `send_default_pii = true`.
Make sure too, that Sentryable::sentry_enabled? is aligned with the
condition from initializers.

Enable performance monitoring, by setting `traces_sample_rate = 0.5`. It
could be later lowered in case it incurs too much cost.

Sanitization is removed, as with the sentry-ruby transition it is meant
to happen on the server side.