### PR TITLE
[#2354] Implement providers soft delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Add the tags to a provider page (@danielkryska)
 
 ### Changed
+- Extend providers with soft delete - keep information's for analytics purposes or for data recovery (@danielkryska)
 
 ### Deprecated
 

--- a/app/controllers/backoffice/providers_controller.rb
+++ b/app/controllers/backoffice/providers_controller.rb
@@ -67,9 +67,13 @@ class Backoffice::ProvidersController < Backoffice::ApplicationController
   end
 
   def destroy
-    @provider.destroy!
-    redirect_to backoffice_providers_path,
-                notice: "Provider destroyed"
+    if Provider::Destroy.new(@provider).call
+      redirect_to backoffice_providers_path,
+                  notice: "Provider have been removed"
+    else
+      redirect_to backoffice_providers_path,
+                  alert: "This Provider has resources connected to it, therefore is not possible to remove it."
+    end
   end
 
   private

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -126,9 +126,11 @@ module Service::Searchable
     end
 
     def filter_classes
+      url_path = URI.parse(request.path).path
+      backoffice = url_path.start_with?("/backoffice")
       [
           Filter::ScientificDomain,
-          Filter::Provider,
+          backoffice ? Filter::BackofficeProvider : Filter::Provider,
           Filter::TargetUser,
           Filter::Platform,
           Filter::Rating,

--- a/app/controllers/providers/details_controller.rb
+++ b/app/controllers/providers/details_controller.rb
@@ -5,5 +5,6 @@ class Providers::DetailsController < ApplicationController
     # @service = Service.friendly.find(params[:service_id])
     # @related_services = @service.related_services
     @provider = Provider.with_attached_logo.friendly.find(params[:provider_id])
+    authorize(@provider, :show?)
   end
 end

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -2,11 +2,13 @@
 
 class ProvidersController < ApplicationController
   def index
-    @providers = Provider.all.order(:name)
+    @providers = policy_scope(Provider).order(:name)
   end
 
   def show
     @provider = Provider.with_attached_logo.friendly.find(params[:id])
+    authorize(@provider)
+
     @related_services = @provider.services.order(created_at: :desc).uniq.first(2)
     @question = Provider::Question.new(provider: @provider)
   end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -51,7 +51,11 @@ module ServiceHelper
 
   def resource_organisation(service, highlights = nil)
     target = service.resource_organisation
-    link_to(highlighted_for(:resource_organisation_name, service, highlights), provider_path(target))
+    link_to_unless(
+      target.deleted?,
+      highlighted_for(:resource_organisation_name, service, highlights),
+      provider_path(target)
+    )
   end
 
   def resource_organisation_pid(service)
@@ -63,22 +67,25 @@ module ServiceHelper
   end
 
   def resource_organisation_and_providers(service)
-    service.resource_organisation_and_providers.map { |target| link_to(target.name, provider_path(target)) }
+    service.resource_organisation_and_providers.
+      map { |target| link_to(target.name, provider_path(target)) }
   end
 
   def resource_organisation_and_providers_text(service)
-    service.resource_organisation_and_providers.map { |target| target.name }
+    service.resource_organisation_and_providers.
+      map { |target| target.name }
   end
 
   def providers(service, highlights = nil)
     highlighted = highlights.present? ? sanitize(highlights[:provider_names])&.to_str : ""
     service.providers
            .reject(&:blank?)
+           .reject(&:deleted?)
            .reject { |p| p == service.resource_organisation }.uniq.map do |target|
       if highlighted.present? && highlighted.strip == target.name.strip
-        link_to highlights[:provider_names].html_safe, provider_path(target)
+        link_to_unless target.deleted?, highlights[:provider_names].html_safe, provider_path(target)
       else
-        link_to target.name, provider_path(target)
+        link_to_unless target.deleted?, target.name, provider_path(target)
       end
     end
   end

--- a/app/models/filter/backoffice_provider.rb
+++ b/app/models/filter/backoffice_provider.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Filter::BackofficeProvider < Filter::Multiselect
+  def initialize(params = {})
+    super(params: params.fetch(:params, {}),
+          field_name: "providers",
+          title: "Providers",
+          model: ::Provider,
+          index: "providers",
+          search: true)
+  end
+end

--- a/app/models/filter/multiselect.rb
+++ b/app/models/filter/multiselect.rb
@@ -15,8 +15,8 @@ class Filter::Multiselect < Filter
   protected
     def fetch_options
       @model.distinct
-          .map { |e| { name: e.name, id: e.id, count: @counters[e.id] || 0 } }
-          .sort_by! { |e| [-e[:count], e[:name] ] }
+            .map { |e| { name: e.name, id: e.id, count: @counters[e.id] || 0 } }
+            .sort_by! { |e| [-e[:count], e[:name]] }
     end
 
     def where_constraint

--- a/app/models/filter/provider.rb
+++ b/app/models/filter/provider.rb
@@ -9,4 +9,11 @@ class Filter::Provider < Filter::Multiselect
           index: "providers",
           search: true)
   end
+
+  protected
+    def fetch_options
+      @model.distinct
+            .filter_map { |e| { name: e.name, id: e.id, count: @counters[e.id] || 0 } unless e.deleted? }
+            .sort_by! { |e| [-e[:count], e[:name]] }
+    end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -11,6 +11,13 @@ class Provider < ApplicationRecord
 
   searchkick word_middle: [:provider_name]
 
+  STATUSES = {
+    published: "published",
+    deleted: "deleted"
+  }
+
+  enum status: STATUSES
+
   def search_data
     {
       provider_id: id,
@@ -18,6 +25,8 @@ class Provider < ApplicationRecord
       service_ids: service_ids
     }
   end
+
+  scope :active, -> { where.not(status: :deleted) }
 
   has_one_attached :logo
 
@@ -79,6 +88,7 @@ class Provider < ApplicationRecord
     unless legal_entity
       self.legal_status = nil
     end
+    self.status ||= :published
   end
 
   validates :name, presence: true, uniqueness: true
@@ -93,6 +103,7 @@ class Provider < ApplicationRecord
   validates :provider_life_cycle_statuses, length: { maximum: 1 }
   validates :public_contacts, length: { minimum: 1, message: "are required. Please add at least one" }
   validates :data_administrators, length: { minimum: 1, message: "are required. Please add at least one" }
+  validates :status, presence: true
   validate :logo_variable, on: [:create, :update]
   validate :validate_array_values_uniqueness
 

--- a/app/policies/backoffice/provider_policy.rb
+++ b/app/policies/backoffice/provider_policy.rb
@@ -28,17 +28,21 @@ class Backoffice::ProviderPolicy < ApplicationPolicy
     service_portfolio_manager?
   end
 
+  def edit?
+    service_portfolio_manager? && !record.deleted?
+  end
+
   def update?
-    service_portfolio_manager?
+    service_portfolio_manager? && !record.deleted?
   end
 
   def destroy?
-    service_portfolio_manager?
+    service_portfolio_manager? && !record.deleted?
   end
 
   def permitted_attributes
     attrs = [
-      :name, :abbreviation, :website,
+      :name, :abbreviation, :website, :status,
       :legal_entity, [legal_status_ids: []],
       :legal_status, :esfri_type, :provider_life_cycle_status,
       :description, :logo, [multimedia: []],

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -3,8 +3,14 @@
 class ProviderPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope
+      scope.where(status: [:published, :unverified, :errored])
     end
+  end
+
+  def show?
+    has_permission = !record.deleted?
+    raise ActiveRecord::RecordNotFound unless has_permission
+    true
   end
 
   def data_administrator?

--- a/app/services/provider/destroy.rb
+++ b/app/services/provider/destroy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Provider::Destroy
+  def initialize(provider)
+    @provider = provider
+  end
+
+  def call
+    active_organisation_service = Service.where(resource_organisation_id: @provider.id).where.not(status: :deleted)
+    if active_organisation_service.present?
+      false
+    else
+      @provider.status = :deleted
+      updated = @provider.save(validate: false)
+      @provider.reindex
+      updated
+    end
+  end
+end

--- a/app/views/backoffice/services/_form.html.haml
+++ b/app/views/backoffice/services/_form.html.haml
@@ -54,9 +54,10 @@
             class: ("show" unless collapsed?(service, [:name, :resource_organisation, :providers, :webpage_url])) }
           .card-body
             = f.input :name, disabled: cant_edit(:name)
-            = f.association :resource_organisation, disabled: cant_edit(:resource_organisation_id)
+            = f.association :resource_organisation, disabled: cant_edit(:resource_organisation_id),
+                              collection: Provider.active
             = f.association :providers, multiple: true, input_html: { data: { choice: true } },
-                              disabled: cant_edit([provider_ids: []])
+                              disabled: cant_edit([provider_ids: []]), collection: Provider.active
             = f.input :webpage_url, disabled: cant_edit(:webpage_url)
         .card.shadow-sm.rounded
           %button.btn.btn-link{ type: "button", class: ("collapsed" if collapsed?(service,

--- a/app/views/services/_categorization.html.haml
+++ b/app/views/services/_categorization.html.haml
@@ -4,13 +4,14 @@
       = _("Organisation") + ":"
   %dd.x-small
     %mr-4= resource_organisation(service, highlights)
-- if service.providers?
+- active_providers = safe_join(providers(service, highlights), ", ")
+- if active_providers.present?
   %dl.mb-0
     %dt.x-small
       %span
         = _("Provided by") + ":"
     %dd.x-small
-      %mr-4= safe_join(providers(service, highlights), ", ")
+      %mr-4= active_providers
 %dl.mb-0.research
   %dt.x-small
     %span

--- a/db/data.yml
+++ b/db/data.yml
@@ -1,88 +1,88 @@
 platforms:
 
-    EGI:
-        name: &egiPlatform "EGI"
-    EUDAT:
-        name: &eudatPlatform "EUDAT"
-    WENMR:
-        name: &wenmr "WeNMR Suite"
-    CLARIN:
-        name: &clarinPlatform "CLARIN"
-    D4Science:
-        name: &d4sciencePlatform "D4Science"
-    EOPillar:
-        name: &eopillar "EO Pillar"
-    EC3:
-        name: &ec3 "EC3 Portal"
-    INSTRUCT:
-        name: &instruct "INSTRUCT-ERIC"
-    BIOEXCEL:
-        name: &bioexcel "BIOEXCEL"
-    ECOPOTENTIAL:
-        name: &ecopotential "ECOPOTENTIAL Virtual Laboratory"
-    GEOSS:
-        name: &geossPlatform "Global Earth Observation system of Systems (GEOSS)"
-    Europeana:
-        name: &europeana "Europeana"
-    AoDP:
-        name: &aodp "EGI Applications on Demand"
-    ENES:
-        name: &enesPlatform "IS-ENES"
-    ELIXIR:
-        name: &elixirPlatform "ELIXIR"
-    GBIF:
-        name: &gbif "GBIF"
-    OBIS:
-        name: &obis "OBIS"
-    SeaDataCloud:
-        name: &seaDataCloud "SeaDataCloud"
-    gCube:
-        name: &gCube "gCube System"
-    EOSC PAN:
-        name: &eoscPan "EOSC PaN"
-    GEO:
-        name: &geo "Group on Earth Observation (GEO)"
-    ESA:
-        name: &esaPlatform "European Space Agency (ESA)"
-    GEP:
-        name: &gepPlatform "Geohazards Thematic Exploitation Platform (GEP)"
-    OpenGConsortium:
-        name: &openGC "Open Geospatial Consortium"
-    Copernicus:
-        name: &copernicus "Copernicus"
-    EOSCHub:
-        name: &eoscHub "EOSC-hub project"
-    NIRD:
-        name: &nird "National Infrastructure for Research Data (NIRD)"
+  EGI:
+    name: &egiPlatform "EGI"
+  EUDAT:
+    name: &eudatPlatform "EUDAT"
+  WENMR:
+    name: &wenmr "WeNMR Suite"
+  CLARIN:
+    name: &clarinPlatform "CLARIN"
+  D4Science:
+    name: &d4sciencePlatform "D4Science"
+  EOPillar:
+    name: &eopillar "EO Pillar"
+  EC3:
+    name: &ec3 "EC3 Portal"
+  INSTRUCT:
+    name: &instruct "INSTRUCT-ERIC"
+  BIOEXCEL:
+    name: &bioexcel "BIOEXCEL"
+  ECOPOTENTIAL:
+    name: &ecopotential "ECOPOTENTIAL Virtual Laboratory"
+  GEOSS:
+    name: &geossPlatform "Global Earth Observation system of Systems (GEOSS)"
+  Europeana:
+    name: &europeana "Europeana"
+  AoDP:
+    name: &aodp "EGI Applications on Demand"
+  ENES:
+    name: &enesPlatform "IS-ENES"
+  ELIXIR:
+    name: &elixirPlatform "ELIXIR"
+  GBIF:
+    name: &gbif "GBIF"
+  OBIS:
+    name: &obis "OBIS"
+  SeaDataCloud:
+    name: &seaDataCloud "SeaDataCloud"
+  gCube:
+    name: &gCube "gCube System"
+  EOSC PAN:
+    name: &eoscPan "EOSC PaN"
+  GEO:
+    name: &geo "Group on Earth Observation (GEO)"
+  ESA:
+    name: &esaPlatform "European Space Agency (ESA)"
+  GEP:
+    name: &gepPlatform "Geohazards Thematic Exploitation Platform (GEP)"
+  OpenGConsortium:
+    name: &openGC "Open Geospatial Consortium"
+  Copernicus:
+    name: &copernicus "Copernicus"
+  EOSCHub:
+    name: &eoscHub "EOSC-hub project"
+  NIRD:
+    name: &nird "National Infrastructure for Research Data (NIRD)"
 
 
 
 categories:
 
-    Sharing & Discovery:
-        name: &sharingAndDicoveryParent "Sharing & Discovery"
-        description: Services to search and discover data, publications, tools and other resources useful for your research
-    Processing & Analysis:
-        name: &processingAndAnalysisParent "Processing & Analysis"
-        description: Software, platforms, tools, analytics and end-user applications offered-as-a-service or deployed-on-demand also specialised by discipline or research domain
-    Compute:
-        name: &computeParent "Compute"
-        description: Services to access virtual machines, containers and job processing to support your general computing needs
-    Storage:
-        name: &storageParent "Storage"
-        description: Service to use storage for your data
-    Data management:
-        name: &dataManagementParent "Data management"
-        description: Service to manage your data
-    Networking:
-        name: &networkingParent "Networking"
-        description: Ultra-fast connectivity and ubiquitous access to the eInfrastructures' resources and services you need
-    Training & Support:
-        name: &trainingAndSupportParent "Training & Support"
-        description: Grow your research knowledge and skills with specialised trainings or seek dedicated professional support for a wide range of scientific disciplines and research activities
-    Security & Operations:
-        name: &securityAndOperationsParent "Security & Operations"
-        description: Services to integrate identity management, authorisation and other security services to comply with policies and regulations or access services to support the operations of your infrastructures and services
+  Sharing & Discovery:
+    name: &sharingAndDicoveryParent "Sharing & Discovery"
+    description: Services to search and discover data, publications, tools and other resources useful for your research
+  Processing & Analysis:
+    name: &processingAndAnalysisParent "Processing & Analysis"
+    description: Software, platforms, tools, analytics and end-user applications offered-as-a-service or deployed-on-demand also specialised by discipline or research domain
+  Compute:
+    name: &computeParent "Compute"
+    description: Services to access virtual machines, containers and job processing to support your general computing needs
+  Storage:
+    name: &storageParent "Storage"
+    description: Service to use storage for your data
+  Data management:
+    name: &dataManagementParent "Data management"
+    description: Service to manage your data
+  Networking:
+    name: &networkingParent "Networking"
+    description: Ultra-fast connectivity and ubiquitous access to the eInfrastructures' resources and services you need
+  Training & Support:
+    name: &trainingAndSupportParent "Training & Support"
+    description: Grow your research knowledge and skills with specialised trainings or seek dedicated professional support for a wide range of scientific disciplines and research activities
+  Security & Operations:
+    name: &securityAndOperationsParent "Security & Operations"
+    description: Services to integrate identity management, authorisation and other security services to comply with policies and regulations or access services to support the operations of your infrastructures and services
 #    Data discovery & access:
 #        name: &dataDiscoveryAndAccess Data discovery & access
 #        parent: *sharingAndDicoveryParent
@@ -98,2795 +98,2864 @@ categories:
 
 
 providers:
-    EGI Federation:
-        name: &egi "EGI Federation"
-        abbreviation: "egi-federation"
-        website: "http://egi-federation.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: &provider_default_logo |
-          data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAB4CAYAAABb59j9AAAABGdBTUEAALGPC
-          /xhBQAAB19JREFUeAHtnYlPIlkQxh9egIj36KizJrPZZP//f2eT2R3HWzw4vEBh9n0de1LTAaSRPqr6q8Tw
-          6Lu++nVT/S5LP705GhUwosCcET/oBhUIFCDQBMGUAgTaVDjpDIEmA6YUINCmwklnCDQZMKUAgTYVTjpDoMm
-          AKQUItKlw0hkCTQZMKUCgTYWTzhBoMmBKAQJtKpx0hkCTAVMKEGhT4aQzBJoMmFKAQJsKJ50h0GTAlAIE2l
-          Q46QyBJgOmFCDQpsJJZwg0GTClAIE2FU46Q6DJgCkFCLSpcNIZAk0GTClAoE2Fk84QaDJgSgECbSqcdIZAk
-          wFTChBoU+GkMwSaDJhSgECbCiedIdBkwJQCBNpUOOkMgSYDphQg0KbCSWcWKMHsFHh+7rr2/b3r9nru9fXV
-          //Xdi/8cDAZucWHBzc/PB5/l8pJbqdVcbbnqSqXS7C6AR3Il/lu3j1Hw+PTkmq2269w/uN7LS6yDzc3NebC
-          X3cb6mltdWYm1LzcergCBHq7Lu0vxNL5oNAKQ3914gg3w1N7Z2nLra6sTbM1NRilAoEcpM2I5UoiLq0bwVB
-          6xyYcWVypld7i/7wA4Lb4CBDqGZkgvjk5Og9w4xm6xN0Vevbe747Y21mPvW/QdCPSEBNw2m+7s4sql+Z+kk
-          Vcfftnni+OEMcJmBHoCsZBiNG5uJ9hy9pvUlpfd18MvhHpCaVkP/Y5QN3fNzGDGpT08Prrjs/N3rpKrQwUI
-          dKjEkM92596nGZdD1qS7qNXuBC+i6Z5V59kI9Ii4PXe7uXoyIuVBHk8brwCBHqHP+eVV0MI3YnUmi/FS2u3
-          2Mjm3lpMS6CGRanU67v7hcciabBehhuU0BylQtiqMPzuBjugDaC4uG5Gl+fmKl0TccLThChDoiC63zVbsPh
-          mRQyT+tXH9exVimnXjiTv3wROwt11EwDsPdN7t6fnZfT8+cb3eS3DzhUCjN9/S4qJbrlaDTk+r9eJ1eGLDi
-          qAX3T7/+fafWKK7CMDRfP5pa9OhZ18RjECLKF82rt3V9Y1YYqO44Ptif9n77OorNRsOjfGiGLftGAHkKnTO
-          t2gYbIAUxeLNGo0XgRaKWK/jxS/Q0fFpqh2shLypFAn0m8zIn8OXq1SUz+gk+BVCA41VI9BvkUWNQVEMTeg
-          YNmbRWG33FtV+v+/KS+mNEsH4wyx/EdDiWK1WUvU5jRuItRxpqDzkHOj89O/RscONlJVhcC5qPywZU46Mol
-          kpl13WDR9oRIo7Uj0juSY+LYGeWKrZb/gSc9qD2V+BM5dLM4dOgpIRx8TUB4OfA587O9dqt3PRow+DB3a2t
-          0Zcsb7FZoDGC9bx6Xkwc1GWL1sYsY3BrX8c7P0aB4jr+fb9h0MfjLwZcnk0vKA10YKZSTlQDYVulVnCDCBw
-          flyHrBbrPDzkEuYQ4Cf/y2HFzACd54AsLSzm+fJcHnL5WQlk43fGq4EptDC/HFrCsnxKhymHnNILsyEd7O2
-          6u2Y7yKHjBm/QHyRaG9H3k0laMdZDK4kkblZ0MErCMEvT9uZGEodO/ZhMOVKXfLoTousnOu4nYZjq14oRaE
-          WRTKpV0UoNB0Jp59aMgIk8+sfpmcNkMdMYWvEOD36fVw7HRNUgai3qfsJyWTWHc6D6a+C3mbUhh8YMTugRm
-          ISl2YclieuXxzQLNJp1p4UZAmFfVL2hv0NoYdUgvqNqrt6q/Vp/cn7hX/ryPx4x9CX8rFYqvg56Pvyq/tNs
-          ypHmGDo0TmiEGfRaG5ZlFui11bpbq9enfuIg5ZBVbzgQvuOYuFnwGa7HYFStFvqg9fqj181qu6giU36/9Tn
-          u9e2d6w+m7Q5aCnLwKU8/1W6bfkT4wefdqfbN604EOkeRQVdOjPlDCpO0oQHo77/+DP4rV9LnSvP4ZlOONE
-          Wc1bkwSQzm0EjD9n1jiqX651AzAh0qkZNP/E/DpG1zfd0h3bBoZqvtZh0s1EEn3UcEvd6SnjsDL7PoV2LVC
-          gF02CAyruNS2Kko2liCJyb+81Uep9eNCyU68u9+2o67m6rtC5FyhA0i456wWBftx4xI3vnGFe0wIzfHf9Oy
-          DjPiVYgnNBwtouGlb9u/ZGLCRvwCFcEKATQaD9CUjT4Yo57SYcoRbWjY9E3f977r5rh98wAKGncAMJqx0Ss
-          PDUNo1i6asR66aBE37m8hcmjjMaR7QgECLcRgUb8CBFp/DOmBUIBACzFY1K8AgdYfQ3ogFCDQQgwW9StAoP
-          XHkB4IBQi0EINF/QoQaP0xpAdCAQItxGBRvwIEWn8M6YFQgEALMVjUrwCB1h9DeiAUINBCDBb1K0Cg9ceQH
-          ggFCLQQg0X9ChBo/TGkB0IBAi3EYFG/AgRafwzpgVCAQAsxWNSvAIHWH0N6IBQg0EIMFvUrQKD1x5AeCAUI
-          tBCDRf0KEGj9MaQHQgECLcRgUb8CBFp/DOmBUIBACzFY1K8AgdYfQ3ogFCDQQgwW9StAoPXHkB4IBQi0EIN
-          F/QoQaP0xpAdCAQItxGBRvwIEWn8M6YFQ4H/g4U11p2PhtgAAAABJRU5ErkJggg==
-    EUDAT:
-        name: &eudat "EUDAT"
-        abbreviation: "eudat"
-        website: "http://eudat.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    JSC:
-        name: &jsc "JSC"
-        abbreviation: "jsc"
-        website: "http://jsc.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    Deutsches Klimarechenzentrum (DKRZ):
-        name: &dkrz "Deutsches Klimarechenzentrum (DKRZ)"
-        abbreviation: "dkrz"
-        website: "http://dkrz.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    GRNET:
-        name: &grnet "GRNET"
-        abbreviation: "grnet"
-        website: "http://grnet.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    SURFsara:
-        name: &surfsara "SURFsara"
-        abbreviation: "surfsara"
-        website: "http://surfsara.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    CERM:
-        name: &cerm "Magnetic Resonance Center of the University of Florence - CERM"
-        abbreviation: "CERM"
-        website: "http://cerm.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    BSC:
-        name: &bsc "BSC"
-        abbreviation: "bsc"
-        website: "http://bsc.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    All generic CDI Level 1 providers:
-        name: &all "all generic CDI Level 1 providers"
-        abbreviation: "cdi-1"
-        website: "http://cdi1.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    CSC:
-        name: &csc "CSC"
-        abbreviation: "csc"
-        website: "http://csc.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    CLARIN ERIC:
-        name: &clarin "CLARIN ERIC"
-        abbreviation: "clarin-eric"
-        website: "http://egi-federation.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    Euro-Mediterranean Center on Climate Change (CMCC):
-        name: &ccmc "Euro-Mediterranean Center on Climate Change (CMCC)"
-        abbreviation: "cmcc"
-        website: "http://cmcc.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    RASDAMAN:
-        name: &rasdaman "RASDAMAN"
-        abbreviation: "rasdaman"
-        website: "http://rasdaman.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    EODC:
-        name: &eodc "Earth Observation Data Centre for Water Resources Monitoring GmbH (EODC)"
-        abbreviation: "eodc"
-        website: "http://eodc.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    Sinergise:
-        name: &sinergise "Sinergise"
-        abbreviation: "sinergise"
-        website: "http://sinergise.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    ASTRON:
-        name: &astron "ASTRON, the Netherlands Institute for Radio Astronomy."
-        abbreviation: "astron"
-        website: "http://astron.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    RUG:
-        name: &rug "RUG"
-        abbreviation: "rug"
-        website: "http://rug.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    FZJ:
-        name: &fzj "FZJ"
-        abbreviation: "fzj"
-        website: "http://fzj.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    PSNC:
-        name: &psnc "PSNC"
-        abbreviation: "psnc"
-        website: "http://psnc.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    SmartSMEAR:
-        name: &smartSmear "SmartSMEAR"
-        abbreviation: "smart-smear"
-        website: "http://smart-smear.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    RECAS-BARI:
-        name: &recas "RECAS-BARI"
-        abbreviation: "recas-bari"
-        website: "http://recas-bari.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    CYFRONET-LCG2:
-        name: &cyfro "CYFRONET-LCG2"
-        abbreviation: "cyfronet-lcg2"
-        website: "http://cyfronet-lcg2.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    BEgrid-ULV-VUB:
-        name: &begrid "BEgrid-ULV-VUB"
-        abbreviation: "be-grid-ulv-vub"
-        website: "http://be-grid-ulv-vub.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    CESGA:
-        name: &cesga "CESGA"
-        abbreviation: "cesga"
-        website: "http://cesga.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    Ruder Boškovic Institute:
-        name: &rbi "Ruder Boškovic Institute"
-        abbreviation: "rbi"
-        website: "http://rbi.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    INFN:
-        name: &infn "Italian National Institute of Nuclear Physics (INFN)"
-        abbreviation: "infn"
-        website: "http://infn.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    INFN-CATANIA-STACK:
-        name: &ics "INFN-CATANIA-STACK"
-        abbreviation: "infn-catania-stack"
-        website: "http://infn-catania-stack.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    INFN-Catania:
-        name: &infnc "INFN-Catania"
-        abbreviation: "infn-catania"
-        website: "http://infn-catania.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    INFN-Bari:
-        name: &infnb "INFN-Bari"
-        abbreviation: "infn-bari"
-        website: "http://infn-bari.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    D4Science:
-        name: &d4science "D4Science.org infrastructure"
-        abbreviation: "d4-science"
-        website: "http://d4-science.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    LifeWatch ERIC:
-        name: &lifewatch "LifeWatch ERIC"
-        abbreviation: "life-watch-eric"
-        website: "http://life-watch-eric.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    Terradue:
-        name: &terradue "Terradue Srl"
-        abbreviation: "terradue-srl"
-        website: "http://terradue-srl.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    MEEO:
-        name: &meeo "MEEO"
-        abbreviation: "meeo"
-        website: "http://meeo.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    CloudFerro:
-        name: &cloudFerro "CloudFerro"
-        abbreviation: "cloud-ferro"
-        website: "http://cloud-ferro.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    PNCEL:
-        name: &pncel "Portuguese National Civil Engineering Laboratory"
-        abbreviation: "pncel"
-        website: "http://pncel.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    University of Utrecht:
-        name: &uou "Bijvoet Center, Utrecht University"
-        abbreviation: "bc-uu"
-        website: "http://bc-uu.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-#    University of Florence:
-#        name: &uof "University of Florence"
-    CIRMMP:
-        name: &cirmmp "Interuniversity consortium CIRMMP"
-        abbreviation: "cirmmp"
-        website: "http://cirmmp.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    CESNET:
-        name: &cesnet "CESNET"
-        abbreviation: "cesnet"
-        website: "http://cesnet.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    EIDA:
-        name: &eida "EIDA"
-        abbreviation: "eida"
-        website: "http://eida.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    ESA:
-        name: &esa "European Space Agency (ESA)"
-        abbreviation: "esa"
-        website: "http://esa.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    DESY:
-        name: &desyProvider "Deutsches Elektronen-Synchrotron DESY"
-        abbreviation: "desy"
-        website: "http://desy.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    CNR-IIA:
-        name: &cnr "Institute of Atmospheric Pollution - National Research Council of Italy (CNR-IIA)"
-        abbreviation: "cnr-iia"
-        website: "http://cnr-iia.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    GryCAP-I3M-UPV:
-        name: &grycap "GryCAP-I3M-UPV"
-        abbreviation: "gry-cap-i3m-upv"
-        website: "http://gry-cap-i3m-upv.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    MTA SZTAKI Laboratory of Parallel and Distributed Systems:
-        name: &mtaSztaki "MTA SZTAKI Laboratory of Parallel and Distributed Systems"
-        abbreviation: "mta-sztaki"
-        website: "http://mta-sztaki.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    University of Oslo (UiO):
-        name: &uioProider "University of Oslo (UiO)"
-        abbreviation: "uio"
-        website: "http://uio.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
-    Not specified:
-        name: &not "not specified yet"
-        abbreviation: "not-specified-yet"
-        website: "http://not-specified-yet.com"
-        legal_entity: true
-        description: |
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
-          Sed luctus tristique est, nec sollicitudin magna blandit ac.
-          Fusce vulputate erat leo, sed commodo nisl sagittis nec.
-          Morbi fermentum ex dui, interdum pharetra justo gravida quis.
-          Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
-          Sed maximus odio neque, sed ullamcorper purus tristique a.
-          Ut gravida venenatis nunc placerat cursus.
-        street_name_and_number: "Malcolm St. 4"
-        postal_code: "332-332"
-        city: "Test City"
-        country_alpha2: "PL"
-        image_base_64: *provider_default_logo
+  EGI Federation:
+    status: "published"
+    name: &egi "EGI Federation"
+    abbreviation: "egi-federation"
+    website: "http://egi-federation.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: &provider_default_logo |
+      data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAB4CAYAAABb59j9AAAABGdBTUEAALGPC
+      /xhBQAAB19JREFUeAHtnYlPIlkQxh9egIj36KizJrPZZP//f2eT2R3HWzw4vEBh9n0de1LTAaSRPqr6q8Tw
+      6Lu++nVT/S5LP705GhUwosCcET/oBhUIFCDQBMGUAgTaVDjpDIEmA6YUINCmwklnCDQZMKUAgTYVTjpDoMm
+      AKQUItKlw0hkCTQZMKUCgTYWTzhBoMmBKAQJtKpx0hkCTAVMKEGhT4aQzBJoMmFKAQJsKJ50h0GTAlAIE2l
+      Q46QyBJgOmFCDQpsJJZwg0GTClAIE2FU46Q6DJgCkFCLSpcNIZAk0GTClAoE2Fk84QaDJgSgECbSqcdIZAk
+      wFTChBoU+GkMwSaDJhSgECbCiedIdBkwJQCBNpUOOkMgSYDphQg0KbCSWcWKMHsFHh+7rr2/b3r9nru9fXV
+      //Xdi/8cDAZucWHBzc/PB5/l8pJbqdVcbbnqSqXS7C6AR3Il/lu3j1Hw+PTkmq2269w/uN7LS6yDzc3NebC
+      X3cb6mltdWYm1LzcergCBHq7Lu0vxNL5oNAKQ3914gg3w1N7Z2nLra6sTbM1NRilAoEcpM2I5UoiLq0bwVB
+      6xyYcWVypld7i/7wA4Lb4CBDqGZkgvjk5Og9w4xm6xN0Vevbe747Y21mPvW/QdCPSEBNw2m+7s4sql+Z+kk
+      Vcfftnni+OEMcJmBHoCsZBiNG5uJ9hy9pvUlpfd18MvhHpCaVkP/Y5QN3fNzGDGpT08Prrjs/N3rpKrQwUI
+      dKjEkM92596nGZdD1qS7qNXuBC+i6Z5V59kI9Ii4PXe7uXoyIuVBHk8brwCBHqHP+eVV0MI3YnUmi/FS2u3
+      2Mjm3lpMS6CGRanU67v7hcciabBehhuU0BylQtiqMPzuBjugDaC4uG5Gl+fmKl0TccLThChDoiC63zVbsPh
+      mRQyT+tXH9exVimnXjiTv3wROwt11EwDsPdN7t6fnZfT8+cb3eS3DzhUCjN9/S4qJbrlaDTk+r9eJ1eGLDi
+      qAX3T7/+fafWKK7CMDRfP5pa9OhZ18RjECLKF82rt3V9Y1YYqO44Ptif9n77OorNRsOjfGiGLftGAHkKnTO
+      t2gYbIAUxeLNGo0XgRaKWK/jxS/Q0fFpqh2shLypFAn0m8zIn8OXq1SUz+gk+BVCA41VI9BvkUWNQVEMTeg
+      YNmbRWG33FtV+v+/KS+mNEsH4wyx/EdDiWK1WUvU5jRuItRxpqDzkHOj89O/RscONlJVhcC5qPywZU46Mol
+      kpl13WDR9oRIo7Uj0juSY+LYGeWKrZb/gSc9qD2V+BM5dLM4dOgpIRx8TUB4OfA587O9dqt3PRow+DB3a2t
+      0Zcsb7FZoDGC9bx6Xkwc1GWL1sYsY3BrX8c7P0aB4jr+fb9h0MfjLwZcnk0vKA10YKZSTlQDYVulVnCDCBw
+      flyHrBbrPDzkEuYQ4Cf/y2HFzACd54AsLSzm+fJcHnL5WQlk43fGq4EptDC/HFrCsnxKhymHnNILsyEd7O2
+      6u2Y7yKHjBm/QHyRaG9H3k0laMdZDK4kkblZ0MErCMEvT9uZGEodO/ZhMOVKXfLoTousnOu4nYZjq14oRaE
+      WRTKpV0UoNB0Jp59aMgIk8+sfpmcNkMdMYWvEOD36fVw7HRNUgai3qfsJyWTWHc6D6a+C3mbUhh8YMTugRm
+      ISl2YclieuXxzQLNJp1p4UZAmFfVL2hv0NoYdUgvqNqrt6q/Vp/cn7hX/ryPx4x9CX8rFYqvg56Pvyq/tNs
+      ypHmGDo0TmiEGfRaG5ZlFui11bpbq9enfuIg5ZBVbzgQvuOYuFnwGa7HYFStFvqg9fqj181qu6giU36/9Tn
+      u9e2d6w+m7Q5aCnLwKU8/1W6bfkT4wefdqfbN604EOkeRQVdOjPlDCpO0oQHo77/+DP4rV9LnSvP4ZlOONE
+      Wc1bkwSQzm0EjD9n1jiqX651AzAh0qkZNP/E/DpG1zfd0h3bBoZqvtZh0s1EEn3UcEvd6SnjsDL7PoV2LVC
+      gF02CAyruNS2Kko2liCJyb+81Uep9eNCyU68u9+2o67m6rtC5FyhA0i456wWBftx4xI3vnGFe0wIzfHf9Oy
+      DjPiVYgnNBwtouGlb9u/ZGLCRvwCFcEKATQaD9CUjT4Yo57SYcoRbWjY9E3f977r5rh98wAKGncAMJqx0Ss
+      PDUNo1i6asR66aBE37m8hcmjjMaR7QgECLcRgUb8CBFp/DOmBUIBACzFY1K8AgdYfQ3ogFCDQQgwW9StAoP
+      XHkB4IBQi0EINF/QoQaP0xpAdCAQItxGBRvwIEWn8M6YFQgEALMVjUrwCB1h9DeiAUINBCDBb1K0Cg9ceQH
+      ggFCLQQg0X9ChBo/TGkB0IBAi3EYFG/AgRafwzpgVCAQAsxWNSvAIHWH0N6IBQg0EIMFvUrQKD1x5AeCAUI
+      tBCDRf0KEGj9MaQHQgECLcRgUb8CBFp/DOmBUIBACzFY1K8AgdYfQ3ogFCDQQgwW9StAoPXHkB4IBQi0EIN
+      F/QoQaP0xpAdCAQItxGBRvwIEWn8M6YFQ4H/g4U11p2PhtgAAAABJRU5ErkJggg==
+  EUDAT:
+    status: "published"
+    name: &eudat "EUDAT"
+    abbreviation: "eudat"
+    website: "http://eudat.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  JSC:
+    status: "published"
+    name: &jsc "JSC"
+    abbreviation: "jsc"
+    website: "http://jsc.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  Deutsches Klimarechenzentrum (DKRZ):
+    name: &dkrz "Deutsches Klimarechenzentrum (DKRZ)"
+    abbreviation: "dkrz"
+    website: "http://dkrz.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  GRNET:
+    status: "published"
+    name: &grnet "GRNET"
+    abbreviation: "grnet"
+    website: "http://grnet.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  SURFsara:
+    status: "published"
+    name: &surfsara "SURFsara"
+    abbreviation: "surfsara"
+    website: "http://surfsara.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  CERM:
+    status: "published"
+    name: &cerm "Magnetic Resonance Center of the University of Florence - CERM"
+    abbreviation: "CERM"
+    website: "http://cerm.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  BSC:
+    status: "published"
+    name: &bsc "BSC"
+    abbreviation: "bsc"
+    website: "http://bsc.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  All generic CDI Level 1 providers:
+    status: "published"
+    name: &all "all generic CDI Level 1 providers"
+    abbreviation: "cdi-1"
+    website: "http://cdi1.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  CSC:
+    status: "published"
+    name: &csc "CSC"
+    abbreviation: "csc"
+    website: "http://csc.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  CLARIN ERIC:
+    status: "published"
+    name: &clarin "CLARIN ERIC"
+    abbreviation: "clarin-eric"
+    website: "http://egi-federation.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  Euro-Mediterranean Center on Climate Change (CMCC):
+    status: "published"
+    name: &ccmc "Euro-Mediterranean Center on Climate Change (CMCC)"
+    abbreviation: "cmcc"
+    website: "http://cmcc.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  RASDAMAN:
+    status: "published"
+    name: &rasdaman "RASDAMAN"
+    abbreviation: "rasdaman"
+    website: "http://rasdaman.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  EODC:
+    status: "published"
+    name: &eodc "Earth Observation Data Centre for Water Resources Monitoring GmbH (EODC)"
+    abbreviation: "eodc"
+    website: "http://eodc.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  Sinergise:
+    status: "published"
+    name: &sinergise "Sinergise"
+    abbreviation: "sinergise"
+    website: "http://sinergise.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  ASTRON:
+    status: "published"
+    name: &astron "ASTRON, the Netherlands Institute for Radio Astronomy."
+    abbreviation: "astron"
+    website: "http://astron.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  RUG:
+    status: "published"
+    name: &rug "RUG"
+    abbreviation: "rug"
+    website: "http://rug.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  FZJ:
+    status: "published"
+    name: &fzj "FZJ"
+    abbreviation: "fzj"
+    website: "http://fzj.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  PSNC:
+    status: "published"
+    name: &psnc "PSNC"
+    abbreviation: "psnc"
+    website: "http://psnc.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  SmartSMEAR:
+    status: "published"
+    name: &smartSmear "SmartSMEAR"
+    abbreviation: "smart-smear"
+    website: "http://smart-smear.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  RECAS-BARI:
+    status: "published"
+    name: &recas "RECAS-BARI"
+    abbreviation: "recas-bari"
+    website: "http://recas-bari.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  CYFRONET-LCG2:
+    status: "published"
+    name: &cyfro "CYFRONET-LCG2"
+    abbreviation: "cyfronet-lcg2"
+    website: "http://cyfronet-lcg2.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  BEgrid-ULV-VUB:
+    status: "published"
+    name: &begrid "BEgrid-ULV-VUB"
+    abbreviation: "be-grid-ulv-vub"
+    website: "http://be-grid-ulv-vub.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  CESGA:
+    status: "published"
+    name: &cesga "CESGA"
+    abbreviation: "cesga"
+    website: "http://cesga.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  Ruder Boškovic Institute:
+    status: "published"
+    name: &rbi "Ruder Boškovic Institute"
+    abbreviation: "rbi"
+    website: "http://rbi.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  INFN:
+    status: "published"
+    name: &infn "Italian National Institute of Nuclear Physics (INFN)"
+    abbreviation: "infn"
+    website: "http://infn.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  INFN-CATANIA-STACK:
+    status: "published"
+    name: &ics "INFN-CATANIA-STACK"
+    abbreviation: "infn-catania-stack"
+    website: "http://infn-catania-stack.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  INFN-Catania:
+    status: "published"
+    name: &infnc "INFN-Catania"
+    abbreviation: "infn-catania"
+    website: "http://infn-catania.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  INFN-Bari:
+    status: "published"
+    name: &infnb "INFN-Bari"
+    abbreviation: "infn-bari"
+    website: "http://infn-bari.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  D4Science:
+    status: "published"
+    name: &d4science "D4Science.org infrastructure"
+    abbreviation: "d4-science"
+    website: "http://d4-science.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  LifeWatch ERIC:
+    status: "published"
+    name: &lifewatch "LifeWatch ERIC"
+    abbreviation: "life-watch-eric"
+    website: "http://life-watch-eric.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  Terradue:
+    status: "published"
+    name: &terradue "Terradue Srl"
+    abbreviation: "terradue-srl"
+    website: "http://terradue-srl.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  MEEO:
+    status: "published"
+    name: &meeo "MEEO"
+    abbreviation: "meeo"
+    website: "http://meeo.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  CloudFerro:
+    status: "published"
+    name: &cloudFerro "CloudFerro"
+    abbreviation: "cloud-ferro"
+    website: "http://cloud-ferro.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  PNCEL:
+    status: "published"
+    name: &pncel "Portuguese National Civil Engineering Laboratory"
+    abbreviation: "pncel"
+    website: "http://pncel.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  University of Utrecht:
+    status: "published"
+    name: &uou "Bijvoet Center, Utrecht University"
+    abbreviation: "bc-uu"
+    website: "http://bc-uu.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  #    University of Florence:
+  #        name: &uof "University of Florence"
+  CIRMMP:
+    status: "published"
+    name: &cirmmp "Interuniversity consortium CIRMMP"
+    abbreviation: "cirmmp"
+    website: "http://cirmmp.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  CESNET:
+    status: "published"
+    name: &cesnet "CESNET"
+    abbreviation: "cesnet"
+    website: "http://cesnet.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  EIDA:
+    status: "published"
+    name: &eida "EIDA"
+    abbreviation: "eida"
+    website: "http://eida.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  ESA:
+    status: "published"
+    name: &esa "European Space Agency (ESA)"
+    abbreviation: "esa"
+    website: "http://esa.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  DESY:
+    status: "published"
+    name: &desyProvider "Deutsches Elektronen-Synchrotron DESY"
+    abbreviation: "desy"
+    website: "http://desy.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  CNR-IIA:
+    status: "published"
+    name: &cnr "Institute of Atmospheric Pollution - National Research Council of Italy (CNR-IIA)"
+    abbreviation: "cnr-iia"
+    website: "http://cnr-iia.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  GryCAP-I3M-UPV:
+    status: "published"
+    name: &grycap "GryCAP-I3M-UPV"
+    abbreviation: "gry-cap-i3m-upv"
+    website: "http://gry-cap-i3m-upv.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  MTA SZTAKI Laboratory of Parallel and Distributed Systems:
+    status: "published"
+    name: &mtaSztaki "MTA SZTAKI Laboratory of Parallel and Distributed Systems"
+    abbreviation: "mta-sztaki"
+    website: "http://mta-sztaki.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  University of Oslo (UiO):
+    status: "published"
+    name: &uioProider "University of Oslo (UiO)"
+    abbreviation: "uio"
+    website: "http://uio.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
+  Not specified:
+    status: "published"
+    name: &not "not specified yet"
+    abbreviation: "not-specified-yet"
+    website: "http://not-specified-yet.com"
+    legal_entity: true
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Duis venenatis purus ut augue efficitur, eu gravida libero aliquet.
+      Sed luctus tristique est, nec sollicitudin magna blandit ac.
+      Fusce vulputate erat leo, sed commodo nisl sagittis nec.
+      Morbi fermentum ex dui, interdum pharetra justo gravida quis.
+      Mauris mollis suscipit tincidunt. Integer fringilla at magna ut euismod.
+      Sed maximus odio neque, sed ullamcorper purus tristique a.
+      Ut gravida venenatis nunc placerat cursus.
+    street_name_and_number: "Malcolm St. 4"
+    postal_code: "332-332"
+    city: "Test City"
+    country_alpha2: "PL"
+    image_base_64: *provider_default_logo
 
 domain:
-    Humanities:
-        name: &humanities "Humanities"
-    OtherHumanities:
-      name: &otherHumanities "Other Humanities"
-      parent: *humanities
-    Philosophy:
-        name: &philosophy "Philosophy, Ethics & Religion"
-        parent: *humanities
-    Arts:
-        name: &arts "Arts"
-        parent: *humanities
-    SocialScience:
-        name: &socialSciences "Social Sciences"
-    OtherSocialScienes:
-      name: &otherSocialSciences "Other Social Sciences"
-      parent: *socialSciences
-    Political:
-        name: &political "Political Sciences"
-        parent: *socialSciences
-    Psychology:
-        name: &psychology "Psychology"
-        parent: *socialSciences
-    engineering:
-        name: &engineering "Engineering & Technology"
-    electrical:
-        name: &electrical "Electrical, Electronic & Information Engineering"
-        parent: *engineering
-    environmental:
-        name: &environmental "Environmental Engineering"
-        parent: *engineering
-    agricultural:
-        name: &agricultural "Agricultural Sciences"
-    medical:
-        name: &medical "Medical & Health Sciences"
-    natural:
-        name: &natural "Natural Sciences"
-    EnvironmentalScience:
-        name: &earthAndEnvironmentalScience "Earth & Related Environmental Sciences"
-        parent: *natural
-    BiologicalSciences:
-        name: &biologicalSciences "Biological Sciences"
-        parent: *natural
-    PhysicalSciences:
-        name: &physicalSciences "Physical Sciences"
-        parent: *engineering
-    Other:
-        name: &other "Other"
-    OtherOther:
-        name: &otherOther "Other"
-        parent: *other
+  Humanities:
+    name: &humanities "Humanities"
+  OtherHumanities:
+    name: &otherHumanities "Other Humanities"
+    parent: *humanities
+  Philosophy:
+    name: &philosophy "Philosophy, Ethics & Religion"
+    parent: *humanities
+  Arts:
+    name: &arts "Arts"
+    parent: *humanities
+  SocialScience:
+    name: &socialSciences "Social Sciences"
+  OtherSocialScienes:
+    name: &otherSocialSciences "Other Social Sciences"
+    parent: *socialSciences
+  Political:
+    name: &political "Political Sciences"
+    parent: *socialSciences
+  Psychology:
+    name: &psychology "Psychology"
+    parent: *socialSciences
+  engineering:
+    name: &engineering "Engineering & Technology"
+  electrical:
+    name: &electrical "Electrical, Electronic & Information Engineering"
+    parent: *engineering
+  environmental:
+    name: &environmental "Environmental Engineering"
+    parent: *engineering
+  agricultural:
+    name: &agricultural "Agricultural Sciences"
+  medical:
+    name: &medical "Medical & Health Sciences"
+  natural:
+    name: &natural "Natural Sciences"
+  EnvironmentalScience:
+    name: &earthAndEnvironmentalScience "Earth & Related Environmental Sciences"
+    parent: *natural
+  BiologicalSciences:
+    name: &biologicalSciences "Biological Sciences"
+    parent: *natural
+  PhysicalSciences:
+    name: &physicalSciences "Physical Sciences"
+    parent: *engineering
+  Other:
+    name: &other "Other"
+  OtherOther:
+    name: &otherOther "Other"
+    parent: *other
 
 
 
 target_users:
 
-    Researchers:
-        name: &researchers "Researchers"
-        description: "Someone who conducts scientific research, i.e., an organized and systematic investigation by using scientific methods."
-        eid: "target_user-researchers"
-    Research organisations:
-        name: &research_organisations "Research organisations"
-        description: "A public or private legal entity (e.g. academia, business, industry, public services, etc.) representing the User."
-        eid: "target_user-research_organisations"
-    Businesses:
-        name: &business "Businesses"
-        description: "An organization or economic system where goods and services are exchanged for one another or for money. Businesses can be privately owned, not-for-profit or state-owned."
-        eid: "target_user-businesses"
-    Research group:
-        name: &research_groups "Research groups"
-        description: "A research group is a group of researchers working together on a particular issue or topic. Research groups may be composed of researchers all from the same subject/discipline or from different subjects/disciplines."
-        eid: "target_user-research_groups"
-    Providers:
-        name: &providers "Providers"
-        description: "A Provider is an organisation that provides different kind of solutions and/or services or other Resources to end users and other organizations. This broad term incorporates all businesses and organisations that provide products and solutions that are offered for free, on-demand, pay per use or a hybrid delivery model."
-        eid: "target_user-providers"
-    Research communities:
-        name: &research_communities "Research communities"
-        description: "Research communities provide an infrastructure through which scientists of discipline-specific scientific areas are able to advance their research goals, reaching out to other researchers."
-        eid: "target_user-research_communities"
-    Research projects:
-        name: &research_projects "Research projects"
-        description: "A privately or publicly funded project on a research topic."
-        eid: "target_user-research_projects"
-    Research networks:
-        name: &research_network "Research networks"
-        desctiption: "Research networks aim to stimulate interaction between researchers and promote information exchange."
-        eid: "target_user-research_networks"
-    Research managers:
-        name: &research_manager "Research managers"
-        description: "Someone in an organization whose job is to manage a research initiative aiming to the development of new scientific results, products or ideas."
-        eid: "target_user-research_managers"
-    Students:
-        name: &students "Students"
-        desctiption: "A person who is studying at a university or other place of higher education."
-        eid: "target_user-students"
-    Innowators:
-        name: &innowators "Innovators"
-        description: "The group or individual which is the first to try new ideas, processes, goods and services. Innovators are followed by early adopters, early majority, late majority, and laggards, in that order."
-        eid: "target_user-innovators"
-    Funders:
-        name: &funders "Funders"
-        description: "Individual or organization financing a part or all of a project's cost as a grant, investment, or loan."
-        eid: "target_user-funders"
-    Policy Makers:
-        name: &policy_makers "Policy Makers"
-        description: "Individuals (usually members of the board of directors) who have the authority to set the policy framework of an organization."
-        eid: "target_user-policy_makers"
-    Research Infrastructure Managers:
-        name: &research_infrastructure_managers "Research Infrastructure Managers"
-        description: "A RI Manager is a type of Project Coordinator who specializes in research infrastructures. They are responsible for things like managing researchers, making sure costs are on budget and serving as a liaison between reserach staff and project stakeholders."
-        eid: "target_user-research_infrastructure_managers"
-    Provider Managers:
-        name: &provider_managers "Provider Managers"
-        description: "A Provider Manager is an individual within an organisation that is responsible for the quality of the Resources provided and monitors the delivery of the Resource."
-        eid: "target_user-provider_managers"
-    Resource Managers:
-        name: &resource_manager "Resource Managers"
-        description: "Resource Managers are typically responsible for managing Service level agreements with customers and external Providers."
-        eid: "target_user-resource_managers"
-    Other:
-        name: &other "Other"
-        description: ""
-        eid: "target_user-other"
+  Researchers:
+    name: &researchers "Researchers"
+    description: "Someone who conducts scientific research, i.e., an organized and systematic investigation by using scientific methods."
+    eid: "target_user-researchers"
+  Research organisations:
+    name: &research_organisations "Research organisations"
+    description: "A public or private legal entity (e.g. academia, business, industry, public services, etc.) representing the User."
+    eid: "target_user-research_organisations"
+  Businesses:
+    name: &business "Businesses"
+    description: "An organization or economic system where goods and services are exchanged for one another or for money. Businesses can be privately owned, not-for-profit or state-owned."
+    eid: "target_user-businesses"
+  Research group:
+    name: &research_groups "Research groups"
+    description: "A research group is a group of researchers working together on a particular issue or topic. Research groups may be composed of researchers all from the same subject/discipline or from different subjects/disciplines."
+    eid: "target_user-research_groups"
+  Providers:
+    name: &providers "Providers"
+    description: "A Provider is an organisation that provides different kind of solutions and/or services or other Resources to end users and other organizations. This broad term incorporates all businesses and organisations that provide products and solutions that are offered for free, on-demand, pay per use or a hybrid delivery model."
+    eid: "target_user-providers"
+  Research communities:
+    name: &research_communities "Research communities"
+    description: "Research communities provide an infrastructure through which scientists of discipline-specific scientific areas are able to advance their research goals, reaching out to other researchers."
+    eid: "target_user-research_communities"
+  Research projects:
+    name: &research_projects "Research projects"
+    description: "A privately or publicly funded project on a research topic."
+    eid: "target_user-research_projects"
+  Research networks:
+    name: &research_network "Research networks"
+    desctiption: "Research networks aim to stimulate interaction between researchers and promote information exchange."
+    eid: "target_user-research_networks"
+  Research managers:
+    name: &research_manager "Research managers"
+    description: "Someone in an organization whose job is to manage a research initiative aiming to the development of new scientific results, products or ideas."
+    eid: "target_user-research_managers"
+  Students:
+    name: &students "Students"
+    desctiption: "A person who is studying at a university or other place of higher education."
+    eid: "target_user-students"
+  Innowators:
+    name: &innowators "Innovators"
+    description: "The group or individual which is the first to try new ideas, processes, goods and services. Innovators are followed by early adopters, early majority, late majority, and laggards, in that order."
+    eid: "target_user-innovators"
+  Funders:
+    name: &funders "Funders"
+    description: "Individual or organization financing a part or all of a project's cost as a grant, investment, or loan."
+    eid: "target_user-funders"
+  Policy Makers:
+    name: &policy_makers "Policy Makers"
+    description: "Individuals (usually members of the board of directors) who have the authority to set the policy framework of an organization."
+    eid: "target_user-policy_makers"
+  Research Infrastructure Managers:
+    name: &research_infrastructure_managers "Research Infrastructure Managers"
+    description: "A RI Manager is a type of Project Coordinator who specializes in research infrastructures. They are responsible for things like managing researchers, making sure costs are on budget and serving as a liaison between reserach staff and project stakeholders."
+    eid: "target_user-research_infrastructure_managers"
+  Provider Managers:
+    name: &provider_managers "Provider Managers"
+    description: "A Provider Manager is an individual within an organisation that is responsible for the quality of the Resources provided and monitors the delivery of the Resource."
+    eid: "target_user-provider_managers"
+  Resource Managers:
+    name: &resource_manager "Resource Managers"
+    description: "Resource Managers are typically responsible for managing Service level agreements with customers and external Providers."
+    eid: "target_user-resource_managers"
+  Other:
+    name: &other "Other"
+    description: ""
+    eid: "target_user-other"
 
 services:
 
-    Cloud compute:
-        name: &egiCloud EGI Cloud compute
-        parents: *computeParent
-        providers: [*egi]
-        logo: cloud-compute.png
-        open_access: false
-        webpage_url: https://www.egi.eu/services/cloud-compute/
-        manual_url: https://wiki.egi.eu/wiki/Federated_Cloud_user_support
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url: https://documents.egi.eu/document/2733
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        language_availability: &english EN
-        geographical_availabilities: &poland PL
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-        restrictions: &notSpecified not yet specified
-        funding_bodies: ["funding_body-innoviris","funding_body-ec"]
-        funding_programs: ["funding_program-icfs", "funding_program-insc2020", "funding_program-isf"]
-        trl: &trl_9 ["trl-9"]
-        life_cycle_status: &prod ["life_cycle_status-production"]
-        tagline: Run virtual machines on-demand with complete control over computing resources
-        platforms: [*egiPlatform]
+  Cloud compute:
+    name: &egiCloud EGI Cloud compute
+    parents: *computeParent
+    providers: [ *egi ]
+    logo: cloud-compute.png
+    open_access: false
+    webpage_url: https://www.egi.eu/services/cloud-compute/
+    manual_url: https://wiki.egi.eu/wiki/Federated_Cloud_user_support
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url: https://documents.egi.eu/document/2733
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    language_availability: &english EN
+    geographical_availabilities: &poland PL
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    restrictions: &notSpecified not yet specified
+    funding_bodies: [ "funding_body-innoviris","funding_body-ec" ]
+    funding_programs: [ "funding_program-icfs", "funding_program-insc2020", "funding_program-isf" ]
+    trl: &trl_9 [ "trl-9" ]
+    life_cycle_status: &prod [ "life_cycle_status-production" ]
+    tagline: Run virtual machines on-demand with complete control over computing resources
+    platforms: [ *egiPlatform ]
+    description: |
+      With Cloud Compute you can deploy and scale virtual machines
+      on­demand. Cloud Compute offers guaranteed computational resources in
+      a secure and isolated environment with standard API
+      access, without the overhead of managing physical servers.
+      Cloud Compute offers the possibility to select pre­configured virtual
+      appliances (e.g. CPU, memory, disk, operating system or software)
+      from a catalogue replicated across all EGI cloud providers.
+
+      ### To access the service you need to:
+
+       1. Request access selecting one of the service options below.
+       2. Set the relevant parameters and add the service to the cart.
+       3. Go to the cart and submit your order.
+       4. You will receive an email summarising your order.
+       5. You will be contacted by the EGI support team.
+
+      ### Featured use cases:
+
+
+      [How to predict social media trends?][1] how Cloud Compute helps to
+      test new ways to detect trends on social networks
+
+      [The genetics of Salmonella infections:][2] how Cloud Compute
+      helped scientists to understand what happens during when a human cell meets Salmonella
+
+
+      [1]: https://www.egi.eu/use-cases/research-stories/how-to-predict-social-media-trends/
+
+
+      [2]: https://www.egi.eu/use-cases/research-stories/the-genetics-of-salmonella-infections/
+
+    offers: &cloudComputeOffers
+      1:
+        name: General purpose
         description: |
-          With Cloud Compute you can deploy and scale virtual machines
-          on­demand. Cloud Compute offers guaranteed computational resources in
-          a secure and isolated environment with standard API
-          access, without the overhead of managing physical servers.
-          Cloud Compute offers the possibility to select pre­configured virtual
-          appliances (e.g. CPU, memory, disk, operating system or software)
-          from a catalogue replicated across all EGI cloud providers.
-
-          ### To access the service you need to:
-
-           1. Request access selecting one of the service options below.
-           2. Set the relevant parameters and add the service to the cart.
-           3. Go to the cart and submit your order.
-           4. You will receive an email summarising your order.
-           5. You will be contacted by the EGI support team.
-
-          ### Featured use cases:
-
-
-          [How to predict social media trends?][1] how Cloud Compute helps to
-          test new ways to detect trends on social networks
-
-          [The genetics of Salmonella infections:][2] how Cloud Compute
-          helped scientists to understand what happens during when a human cell meets Salmonella
-
-
-          [1]: https://www.egi.eu/use-cases/research-stories/how-to-predict-social-media-trends/
-
-
-          [2]: https://www.egi.eu/use-cases/research-stories/the-genetics-of-salmonella-infections/
-
-        offers: &cloudComputeOffers
-          1:
-            name: General purpose
-            description: |
-              Base preformance instance type. Features:
-              Accessible in opportunistic or reserved ways, CPU cores could be overcommitted.
-              Ideal for: Web services, Micro-services, Development environtments,
-              Building server, Small database, Test environments.
-            parameters:
-              - id: "id1"
-                label: "Number of CPU Cores"
-                description: "Select number of cores you want"
-                type: "select"
-                value_type: "integer"
-                config:
-                  mode: "buttons"
-                  values: [1, 2, 4, 8]
-              - id: "id2"
-                label: "Amount of RAM per CPU core"
-                description:  "Select amount of RAM per core"
-                type:  "select"
-                value_type:  "integer"
-                unit: "GB"
-                config:
-                  mode:  "buttons"
-                  values:  [1, 2, 4]
-              - id:  "id3"
-                label:  "Local disk"
-                description:  "Amount of local disk space"
-                type:  "select"
-                value_type:  "integer"
-                unit: "GB"
-                config:
-                  mode:  "buttons"
-                  values:  [10, 20, 40]
-              - id:  "id4"
-                label:  "Number of VM instances"
-                description:  "Type number of VM instances from 1-50"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 50
-              - id: "id5"
-                label: "Access type"
-                description:  "Choose access type"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode:  "buttons"
-                  values:  ["opportunistic", "reserved"]
-              - id:  "id6"
-                label:  "Start of service"
-                description:  "Please choose start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id7"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 730
-          2:
-            name: Compute-intensive
-            description: |
-              Optimised instance for computing tasks. Feattures: High perfromance CPU cores,
-              Until 64 CPU cores, Real CPU cors (non-overcommitted), Low latency network, Reserved instances.
-              Ideal for: Batch computing, High-perfromance applications and web services,
-              Distributed analysis. Video encoding.
-            parameters:
-              - id:  "id1"
-                label:  "Number of CPU Cores"
-                description:  "Select number of cores you want"
-                type:  "select"
-                value_type:  "integer"
-                config:
-                  mode:  "buttons"
-                  values:  [8, 12, 16, 20, 24, 28, 32, 64]
-              - id:  "id2"
-                label:  "Amount of RAM per CPU core"
-                description:  "Select amount of RAM per core"
-                type:  "select"
-                value_type:  "integer"
-                unit: "GB"
-                config:
-                  mode:  "buttons"
-                  values:  [2, 4, 8]
-              - id:  "id3"
-                label:  "Local disk"
-                description:  "Amount of local disk space"
-                type:  "select"
-                value_type:  "integer"
-                unit: "GB"
-                config:
-                  mode:  "buttons"
-                  values:  [10, 20, 40]
-              - id:  "id4"
-                label:  "Number of VM instances"
-                description:  "Type number of VM instances from 1-50"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 50
-              - id: "id5"
-                label: "Access type"
-                description:  "Access type for this offer is constant"
-                type:  "attribute"
-                value_type:  "string"
-                value: "reserved"
-              - id:  "id6"
-                label:  "Start of service"
-                description:  "Please choose start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id7"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 730
-          3:
-            name: High-memory
-            description: |
-              Optimised instances for tasks that require more memory relative to virtual CPUs.
-              Features: High amout od RAM per CPU core, Up to 240 GB of  RAm in total, Reserved instances.
-              Ideal for: Running in-memory database, Running in-memory stores (e.g. redis, memcached),
-              In-memory big data processing engines (e.g. Apache Spark)
-            parameters:
-              - id:  "id1"
-                label:  "Number of CPU Cores"
-                description:  "Select number of cores you want"
-                type:  "select"
-                value_type:  "integer"
-                config:
-                  mode:  "buttons"
-                  values:  [2, 4, 8, 12, 16]
-              - id:  "id2"
-                label:  "Amount of RAM per CPU core"
-                description:  "Select amount of RAM per core"
-                type:  "select"
-                value_type:  "integer"
-                unit: "GB"
-                config:
-                  mode:  "buttons"
-                  values:  [16, 32, 48, 64, 80, 96, 112, 120]
-              - id:  "id3"
-                label:  "Local disk"
-                description:  "Amount of local disk space"
-                type:  "select"
-                value_type:  "integer"
-                unit: "GB"
-                config:
-                  mode:  "buttons"
-                  values:  [10, 20, 40]
-              - id:  "id4"
-                label:  "Number of VM instances"
-                description:  "Type number of VM instances from 1-50"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 50
-              - id: "id5"
-                label: "Access type"
-                description:  "Access type for this offer is constant"
-                type:  "attribute"
-                value_type:  "string"
-                value: "reserved"
-              - id:  "id6"
-                label:  "Start of service"
-                description:  "Please choose start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id7"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 730
-          4:
-            name: GPU
-            description: |
-              GPU-enabled instances. Features: 1 or 2 GPU cores, 9 CPU cores for each GPU core, large memory.
-              Ideal for: Graphics and general purpose GPu compute applications.
-            parameters:
-              - id:  "id1"
-                label:  "Number of GPU cores"
-                description:  "Select number of GPU cores you want"
-                type:  "select"
-                value_type:  "integer"
-                config:
-                  mode:  "buttons"
-                  values:  [1, 2]
-              - id:  "id2"
-                label:  "Number of CPU Cores"
-                description:  "For GPU instance number of CPU cores is constant"
-                type:  "attribute"
-                value_type:  "integer"
-                value: 8
-              - id:  "id3"
-                label:  "Amount of RAM"
-                description:  "Select amount of RAM per core"
-                type:  "select"
-                value_type:  "integer"
-                unit: "GB"
-                config:
-                  mode:  "buttons"
-                  values:  [24, 50]
-              - id:  "id4"
-                label:  "Local disk"
-                description:  "Amount of local disk space is constant"
-                type:  "attribute"
-                value_type:  "integer"
-                value: 280
-                unit: "GB"
-              - id:  "id5"
-                label:  "Number of VM instances"
-                description:  "Type number of VM instances from 1-50"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 50
-              - id: "id6"
-                label: "Access type"
-                description:  "Access type for this offer is constant"
-                type:  "attribute"
-                value_type:  "string"
-                value: "reserved"
-              - id:  "id7"
-                label:  "Start of service"
-                description:  "Please choose start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id8"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 730
-    High-Throughput compute:
-        name: &egiHTC EGI High-Throughput compute
-        parents: *computeParent
-        providers: [*egi]
-        logo: high-throughput-compute.png
-        open_access: false
-        webpage_url: https://www.egi.eu/services/high-throughput-compute/
-        manual_url: https://wiki.egi.eu/wiki/Federated_Cloud_user_support
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url: https://documents.egi.eu/document/2733
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Execute thousands of computational tasks to analyse large datasets
-        platforms: [*egiPlatform]
+          Base preformance instance type. Features:
+          Accessible in opportunistic or reserved ways, CPU cores could be overcommitted.
+          Ideal for: Web services, Micro-services, Development environtments,
+          Building server, Small database, Test environments.
+        parameters:
+          - id: "id1"
+            label: "Number of CPU Cores"
+            description: "Select number of cores you want"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 1, 2, 4, 8 ]
+          - id: "id2"
+            label: "Amount of RAM per CPU core"
+            description: "Select amount of RAM per core"
+            type: "select"
+            value_type: "integer"
+            unit: "GB"
+            config:
+              mode: "buttons"
+              values: [ 1, 2, 4 ]
+          - id: "id3"
+            label: "Local disk"
+            description: "Amount of local disk space"
+            type: "select"
+            value_type: "integer"
+            unit: "GB"
+            config:
+              mode: "buttons"
+              values: [ 10, 20, 40 ]
+          - id: "id4"
+            label: "Number of VM instances"
+            description: "Type number of VM instances from 1-50"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 50
+          - id: "id5"
+            label: "Access type"
+            description: "Choose access type"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "opportunistic", "reserved" ]
+          - id: "id6"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id7"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 730
+      2:
+        name: Compute-intensive
         description: |
-          With High-Throughput Compute you can run computational jobs at scale on the EGI infrastructure. It allows you to analyse large datasets and execute thousands of parallel computing tasks.
-
-          EGI offers more than 650,000 cores of installed capacity, supporting about 1.6 million computing jobs per day.
-
-          ### To access the service you need to:
-
-            1. Request access selecting one of the service options below.
-            2. Set the relevant parameters and add the service to the cart.
-            3. Go to the cart and submit your order.
-            4. You will receive an email summarising your order.
-            5. You will be contacted by the EGI support team.
-
-          ### Featured use cases:
-
-          [What happens when molecules collide?][1] How High-Throughput Compute helps researchers to simulate chemical reactions. <br>
-          [Small settlements coalesce into larger cities][2]: how the OpenMOLE platform and High-Throughput Compute helped to validate a long-held theory in geography
-
-          [1]: https://www.egi.eu/use-cases/research-stories/what-happens-when-molecules-collide/
-
-          [2]: https://www.egi.eu/use-cases/research-stories/cities/
-        offers:
-          1:
-            name: Base
-            description: |
-              It allows the execution of large numbers of independent or loosely coupled computing tasks.
-              Limited parallel and multi-thread computing can be supported as well.
-            parameters:
-              - id:  "id1"
-                label:  "Number of CPU hours"
-                description:  "Choose number of hours"
-                type:  "range"
-                value_type:  "integer"
-                unit: "h"
-                config:
-                  minimum: 1
-                  maximum: 10000000
-              - id:  "id2"
-                label:  "Guaranteed number of CPU cores"
-                description:  "Choose number of cores between 1 and 32"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 32
-              - id:  "id3"
-                label:  "Amount of RAM per CPU core"
-                description:  "Choose amount of RAM"
-                unit: "GB"
-                type:  "select"
-                value_type:  "integer"
-                config:
-                  mode:  "buttons"
-                  values: [4, 8]
-              - id: "id4"
-                label: "Access type"
-                description:  "Choose access type"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode:  "buttons"
-                  values:  ["opportunistic", "reserved"]
-              - id:  "id5"
-                label:  "Other technical requirements"
-                description:  "Type other requirements"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id6"
-                label:  "Start of service"
-                description:  "Please choose start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id7"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 730
-          2:
-            name: MPI
-            description: |
-              It allows parallel computing, with support of MPI protocol and libraries.
-            parameters:
-              - id:  "id1"
-                label:  "Number of CPU hours"
-                description:  "Choose number of hours"
-                type:  "range"
-                value_type:  "integer"
-                unit: "h"
-                config:
-                  minimum: 1
-                  maximum: 10000000
-              - id:  "id2"
-                label:  "Guaranteed number of CPU cores"
-                description:  "Choose number of cores between 1 and 32"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 32
-              - id:  "id3"
-                label:  "Amount of RAM per CPU core"
-                description:  "Choose amount of RAM"
-                unit: "GB"
-                type:  "select"
-                value_type:  "integer"
-                config:
-                  mode:  "buttons"
-                  values: [4, 8]
-              - id:  "id4"
-                label:  "Parallelism (Threads)"
-                description:  "Choose number of threads from 8 to 24"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 8
-                  maximum: 24
-              - id: "id5"
-                label: "Access type"
-                description:  "Choose access type"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode:  "buttons"
-                  values:  ["opportunistic", "reserved"]
-              - id:  "id6"
-                label:  "Other technical requirements"
-                description:  "Type other requirements"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id7"
-                label:  "Start of service"
-                description:  "Please choose start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id8"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "range"
-                value_type:  "integer"
-                config:
-                  minimum: 1
-                  maximum: 730
-    Cloud container compute:
-        name: EGI Cloud container compute BETA
-        parents: *computeParent
-        providers: [*egi]
-        logo: cloud-container-compute.png
-        open_access: false
-        webpage_url: https://www.egi.eu/services/cloud-compute/
-        manual_url: https://wiki.egi.eu/wiki/Federated_Cloud_user_support
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-container-compute-training-material
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url: https://documents.egi.eu/document/2733
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Run Docker containers in a lightweight virtualised environment
-        platforms: [*egiPlatform]
+          Optimised instance for computing tasks. Feattures: High perfromance CPU cores,
+          Until 64 CPU cores, Real CPU cors (non-overcommitted), Low latency network, Reserved instances.
+          Ideal for: Batch computing, High-perfromance applications and web services,
+          Distributed analysis. Video encoding.
+        parameters:
+          - id: "id1"
+            label: "Number of CPU Cores"
+            description: "Select number of cores you want"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 8, 12, 16, 20, 24, 28, 32, 64 ]
+          - id: "id2"
+            label: "Amount of RAM per CPU core"
+            description: "Select amount of RAM per core"
+            type: "select"
+            value_type: "integer"
+            unit: "GB"
+            config:
+              mode: "buttons"
+              values: [ 2, 4, 8 ]
+          - id: "id3"
+            label: "Local disk"
+            description: "Amount of local disk space"
+            type: "select"
+            value_type: "integer"
+            unit: "GB"
+            config:
+              mode: "buttons"
+              values: [ 10, 20, 40 ]
+          - id: "id4"
+            label: "Number of VM instances"
+            description: "Type number of VM instances from 1-50"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 50
+          - id: "id5"
+            label: "Access type"
+            description: "Access type for this offer is constant"
+            type: "attribute"
+            value_type: "string"
+            value: "reserved"
+          - id: "id6"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id7"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 730
+      3:
+        name: High-memory
         description: |
-          With Cloud Container Compute you can deploy and scale Docker containers on-demand. It offers guaranteed computational resources in a secure and isolated environment with standard API access, without the overhead of managing the operating system.
-
-          The result is improved performance, ideal for development.
-
-          ### To access the service you need to:
-
-            1. Request access selecting one of the service options below.
-            2. Set the relevant parameters and add the service to the cart.
-            3. Go to the cart and submit your order.
-            4. You will receive an email summarising your order.
-            5. You will be contacted by the EGI support team.
-        offers: *cloudComputeOffers
-    B2DROP:
-        name: &b2drop B2DROP
-        parents: [*storageParent, *sharingAndDicoveryParent]
-        providers: [*eudat, *jsc]
-        logo: b2drop.png
-        open_access: false
-        webpage_url: https://b2drop.eudat.eu
-        manual_url: https://eudat.eu/services/userdoc/b2drop
-        helpdesk_url: https://www.eudat.eu/support-request?service=B2DROP
-        training_information_url: https://eudat.eu/services/userdoc/b2drop
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://eudat.eu/policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Secure and trusted data exchange service for researchers
-        platforms: [*eudatPlatform]
+          Optimised instances for tasks that require more memory relative to virtual CPUs.
+          Features: High amout od RAM per CPU core, Up to 240 GB of  RAm in total, Reserved instances.
+          Ideal for: Running in-memory database, Running in-memory stores (e.g. redis, memcached),
+          In-memory big data processing engines (e.g. Apache Spark)
+        parameters:
+          - id: "id1"
+            label: "Number of CPU Cores"
+            description: "Select number of cores you want"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 2, 4, 8, 12, 16 ]
+          - id: "id2"
+            label: "Amount of RAM per CPU core"
+            description: "Select amount of RAM per core"
+            type: "select"
+            value_type: "integer"
+            unit: "GB"
+            config:
+              mode: "buttons"
+              values: [ 16, 32, 48, 64, 80, 96, 112, 120 ]
+          - id: "id3"
+            label: "Local disk"
+            description: "Amount of local disk space"
+            type: "select"
+            value_type: "integer"
+            unit: "GB"
+            config:
+              mode: "buttons"
+              values: [ 10, 20, 40 ]
+          - id: "id4"
+            label: "Number of VM instances"
+            description: "Type number of VM instances from 1-50"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 50
+          - id: "id5"
+            label: "Access type"
+            description: "Access type for this offer is constant"
+            type: "attribute"
+            value_type: "string"
+            value: "reserved"
+          - id: "id6"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id7"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 730
+      4:
+        name: GPU
         description: |
-          B2DROP is a secure and trusted data exchange service for researchers and scientists to keep their research data synchronized and up-to-date and to exchange with other researchers. B2DROP is an ideal solution to store and exchange data with colleagues and team members, synchronise multiple versions of data, ensure automatic desktop synchronisation of large files.
+          GPU-enabled instances. Features: 1 or 2 GPU cores, 9 CPU cores for each GPU core, large memory.
+          Ideal for: Graphics and general purpose GPu compute applications.
+        parameters:
+          - id: "id1"
+            label: "Number of GPU cores"
+            description: "Select number of GPU cores you want"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 1, 2 ]
+          - id: "id2"
+            label: "Number of CPU Cores"
+            description: "For GPU instance number of CPU cores is constant"
+            type: "attribute"
+            value_type: "integer"
+            value: 8
+          - id: "id3"
+            label: "Amount of RAM"
+            description: "Select amount of RAM per core"
+            type: "select"
+            value_type: "integer"
+            unit: "GB"
+            config:
+              mode: "buttons"
+              values: [ 24, 50 ]
+          - id: "id4"
+            label: "Local disk"
+            description: "Amount of local disk space is constant"
+            type: "attribute"
+            value_type: "integer"
+            value: 280
+            unit: "GB"
+          - id: "id5"
+            label: "Number of VM instances"
+            description: "Type number of VM instances from 1-50"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 50
+          - id: "id6"
+            label: "Access type"
+            description: "Access type for this offer is constant"
+            type: "attribute"
+            value_type: "string"
+            value: "reserved"
+          - id: "id7"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id8"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 730
+  High-Throughput compute:
+    name: &egiHTC EGI High-Throughput compute
+    parents: *computeParent
+    providers: [ *egi ]
+    logo: high-throughput-compute.png
+    open_access: false
+    webpage_url: https://www.egi.eu/services/high-throughput-compute/
+    manual_url: https://wiki.egi.eu/wiki/Federated_Cloud_user_support
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url: https://documents.egi.eu/document/2733
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Execute thousands of computational tasks to analyse large datasets
+    platforms: [ *egiPlatform ]
+    description: |
+      With High-Throughput Compute you can run computational jobs at scale on the EGI infrastructure. It allows you to analyse large datasets and execute thousands of parallel computing tasks.
 
-          For the individuals researchers who need to synchronise and exchange data with one or multiple users, B2DROP Service is a customer-facing solution to store and exchange data with colleagues and team members.
+      EGI offers more than 650,000 cores of installed capacity, supporting about 1.6 million computing jobs per day.
 
-          ### Uses cases:
+      ### To access the service you need to:
 
-            - define with whom to exchange data, for how long and how
-            - are offered up to 20GB of storage space for research data
-            - access and manage permissions to files from any device and any location
+        1. Request access selecting one of the service options below.
+        2. Set the relevant parameters and add the service to the cart.
+        3. Go to the cart and submit your order.
+        4. You will receive an email summarising your order.
+        5. You will be contacted by the EGI support team.
 
-          ### To access the service you need to:
+      ### Featured use cases:
 
-          1.  The EUDAT public B2DROP service (https://b2drop.eudat.eu) is offered as a fairshare free-to-use service, users can register themselves via the B2DROP service. Users get a default quota of 20GB.
-          2.  Requests for higher quotas or a dedicated instance can by selecting one of the service options below.
-          3.  Set the relevant parameters and add the service to the cart.
-          4.  Go to the cart and submit your order.
-          5.  You will receive an email summarising your order.
-          6.  You will be contacted by the EUDAT support team.
+      [What happens when molecules collide?][1] How High-Throughput Compute helps researchers to simulate chemical reactions. <br>
+      [Small settlements coalesce into larger cities][2]: how the OpenMOLE platform and High-Throughput Compute helped to validate a long-held theory in geography
 
-          ### Service provided by
+      [1]: https://www.egi.eu/use-cases/research-stories/what-happens-when-molecules-collide/
 
-          EUDAT and JSC.
-        offers:
-          1:
-            name: B2DROP For Researchers
-            description: |
-              B2DROP is a secure and trusted data exchange service for researchers and scientists to keep their
-              research data synchronized and up-to-date and to exchange with other researchers.
-              B2DROP is an ideal solution to store and exchange data with colleagues and team members,
-              synchronise multiple versions of data, ensure automatic desktop synchronisation of large files.
-              Features: Public service, Self registering, Quota 20GB, Web access, Sharing files with local users,
-              Sharing files across other B2DROP and ownCloud/Nextcloud instances, Desktop synchronisation,
-              Support for WebDAV mounts, Publish data to B2SHARE.
-              Ideal for: Researchers seeking a central place to dtorage and ahre research data.
-            parameters:
-              - id:  "id1"
-                label:  "Start of service"
-                description:  "Please choose start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-          2:
-            name: B2DROP For Data Managers
-            description: |
-              The public B2DROP service has a per user quota limit of 20GB. Communities, organisations
-              or PI's which have a need for higher quota’s, higher storage capacity, specific requirements
-              and/or (Nextcloud) applications enabled can submit support request. Depending on the requirements
-              and/or requested storage capacity the B2DROP service is offered as a paid service.
-              Features: Public service, Self registering, Higher quota's as default, Web access,
-              Sharing files with local users, Sharing files across other B2DROP and ownCloud/Nextcloud instances,
-              Desktop synchronisation, Support for WebDAV mounts, Publish data to B2SHARE.
-              Ideal for: Data managers with higher quota, storage and/or any specific requirements.
-            parameters: &b2dropParameters
-              - id:  "id1"
-                label:  "Requested storage capacity"
-                description:  "Please choose storage capacity"
-                type:  "select"
-                value_type:  "integer"
-                unit: "TB"
-                config:
-                  mode:  "buttons"
-                  values:  [0.5, 1, 5, 10]
-              - id:  "id2"
-                label:  "Requested quota per user"
-                description:  "Choose quota per user"
-                type:  "select"
-                value_type:  "integer"
-                unit: "GB"
-                config:
-                  mode:  "buttons"
-                  values:  [100, 200, 500]
-              - id:  "id3"
-                label:  "Access type"
-                description:  "Choose number of days"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode:  "buttons"
-                  values:  ["opportunistic", "reserved"]
-              - id:  "id4"
-                label:  "Start of service"
-                description:  "Please choose start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id5"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-              - id:  "id6"
-                label: "Special requirements"
-                description:  "Write about special requirements"
-                type:  "input"
-                value_type:  "string"
-          3:
-            name: B2DROP For Communities And Organisations
-            description: |
-              The public B2DROP service is provided on a fair-share basis.
-              Communities and/or organisations with specific requirements which can not be support via
-              the public fair-share service or or need higher level of security or access control can request
-              consultancy in setting up and deploying a local B2DROP instance or can request
-              a B2DROP instance which is hosted at one of the EUDAT partners.
-              Features: dedicated B2DROP instace, Requirements are negotiable.
-              Ideal for: Community/organisational data managers.
-            parameters: *b2dropParameters
-
-    B2FIND:
-        name: &b2find B2FIND
-        parents: [*sharingAndDicoveryParent, *dataManagementParent]
-        providers: [*eudat, *dkrz]
-        logo: b2find.png
-        open_access: false
-        webpage_url: http://b2find.eudat.eu/
-        manual_url: http://eudat.eu/services/userdoc/b2find
-        helpdesk_url: http://www.egi.eu/more-information/
-        training_information_url: http://eudat.eu/services/userdoc/b2find
-        terms_of_use_url: http://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: http://eudat.eu/policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *providers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Metadata based data-discovery
-        platforms: [*eudatPlatform]
-        funding_bodies: ["funding_body-fapesp","funding_body-rpf"]
-        funding_programs: ["funding_program-icfs", "funding_program-insc2020", "funding_program-iter"]
+      [2]: https://www.egi.eu/use-cases/research-stories/cities/
+    offers:
+      1:
+        name: Base
         description: |
-          B2FIND is the EUDAT metadata service and provides a discovery portal which allows users
-          to find data collections within an international and inter-disciplinary scope.
-          It is based on a comprehensive metadata catalogue of research data collections stored
-          in EUDAT data centres and other repositories. Harmonization of the metadata descriptions collected
-          from heterogeneous sources enables not only the presentation in a consistent form but as well
-          the faceted search across scientific domain boundaries.
-
-          B2FIND is for communities and other providers of research data who need to publish and give visibility
-          to their metadata and individual researchers who need to search data from everywhere,
-          and see data in the context with an accross community approach.
-
-          ### Features:
-
-             - based on a comprehensive joint catalogue of EUDAT services and external metadata
-             - metadata is mapped onto standardized facets
-             - supports faceted, geospatial and temporal metadata searches
-             - allows users to search and browse datasets via keyword searches
-             - results displayed in user-friendly format and listed in order of relevance
-             - access to the scientific data objects is given through references provided in the metadata
-             - available for communities in the EUDAT registered domain of data
-
-          ### Uses cases:
-
-             - define with whom to exchange data, for how long and how
-             - are offered up to 20GB of storage space for research data
-             - access and manage permissions to files from any device and any location
-
-
-          ### To access the service you need to:
-
-             1. The EUDAT public B2FIND [service][1]  is offered as a fairshare free-to-use service,
-             no registration is required to search through the B2FIND service.
-             2. Request for metadata data harvesting of an existing data repository select the service option below.
-             3. Provide URL to data repository
-             4. Provide URL endpoint for harvesting, see B2FIND [guidelines][2] for harvesting
-             5. Go to the cart and submit your order.
-             6. You will receive an email summarising your order.
-             7. You will be contacted by the EUDAT support team
-
-          ### Service provided by
-
-          EUDAT and Deutsches Klimarechenzentrum (DKRZ)
-
-          [1]: https://b2find.eudat.eu/
-          [2]: http://b2find.eudat.eu/guidelines/harvesting.html
-        offers:
-          1:
-            name: B2FIND For Researchers
-            description: |
-              B2FIND is a discovery service based on metadata steadily harvested from research data collections
-              from EUDAT data centres and other community repositories. The service offers faceted browsing
-              and it allows in particular to discover data that is stored through the B2SAFE and B2SHARE services.
-              Features: Public service supporting cross disciplinary research, No registration required.
-              Ideal for: Researchers seeking interesting datasets.
-          2:
-            name: B2FIND For Data Providers
-            description: |
-              To enlarge the discovery of existing datasets, data repository owners can make their research
-              data collections stored in existing data repositories harvestable and discoverable
-              via public B2FIND service. To ease the process of harvesting data repository owners can assess the
-              B2FIND guidelines for data providers.
-              Features: Comprehensive joint catalogue of EUDAT services and external metadata,
-              Metadata is mapped onto standardized facets, Supports faceted, geospatial and temporal metadata searches,
-              Allows suse to search and browse datasets via keyword searches,
-              user-friendly format and listed in order of relevance,
-              Access to the scintific data objects is given through references provided in the metadata.
-              Ideal for: Data providers.
-            parameters:
-              - id:  "id1"
-                label:  "Data repository name"
-                description:  "Type data repository name"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Harvesting method"
-                description:  "Choose harvesting method"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode:  "buttons"
-                  values:  ["OAI-PMH", "JSON-API", "CSW 2.0", "Other"]
-              - id:  "id3"
-                label:  "Harvesting endpoint"
-                description:  "Type harvesting endpoint"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id4"
-                label:  "Reference to md schema"
-                description:  "Reference to md schema"
-                type:  "input"
-                value_type:  "string"
-          3:
-            name: B2FIND For Communities And Organisations
-            description: |
-              A way to deploy a local instance use the B2FIND technology.
-              Community data managers can adapt this local instance to support community specific facets.
-              The community and/or organisation local B2FIND instances can again be made harvestable
-              by the public B2FIND service. To explore the feasibility of B2FIND as data discovery service,
-              community data managers can assess the B2FIND training module on Github.
-              Features: Comprehensive joint catalogue of EUDAT services and external metadata,
-              Metadata in mapped onto standardized facetes, Supports faceted search,
-              facets can be adapted to domain specific facets, Geospatial and temporal metadata searches,
-              Allows users to search and browse datasets via keyword searches, user-friendly format and listed
-              in order of relevance, Access to the scientifc data objects in given through references provided
-              in the metadata, Local B2FIND instace. Ideal for: Community/organisational data managers.
-    B2HANDLE:
-        name: &b2handle B2HANDLE
-        parents: [*dataManagementParent, *sharingAndDicoveryParent]
-        providers: [*eudat, *surfsara, *grnet]
-        logo: b2handle.png
-        open_access: false
-        webpage_url: https://www.eudat.eu/services/b2handle
-        manual_url: https://eudat.eu/services/userdoc/b2handle
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://eudat.eu/services/userdoc/b2handle
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://eudat.eu/policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Secure and trusted data exchange service for researchers
-        platforms: [*eudatPlatform]
+          It allows the execution of large numbers of independent or loosely coupled computing tasks.
+          Limited parallel and multi-thread computing can be supported as well.
+        parameters:
+          - id: "id1"
+            label: "Number of CPU hours"
+            description: "Choose number of hours"
+            type: "range"
+            value_type: "integer"
+            unit: "h"
+            config:
+              minimum: 1
+              maximum: 10000000
+          - id: "id2"
+            label: "Guaranteed number of CPU cores"
+            description: "Choose number of cores between 1 and 32"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 32
+          - id: "id3"
+            label: "Amount of RAM per CPU core"
+            description: "Choose amount of RAM"
+            unit: "GB"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 4, 8 ]
+          - id: "id4"
+            label: "Access type"
+            description: "Choose access type"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "opportunistic", "reserved" ]
+          - id: "id5"
+            label: "Other technical requirements"
+            description: "Type other requirements"
+            type: "input"
+            value_type: "string"
+          - id: "id6"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id7"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 730
+      2:
+        name: MPI
         description: |
-          B2HANDLE is the distributed service for minting, storing, managing and accessing persistent identifiers (PIDs) and essential metadata (PID records) as well as managing PID namespaces. The implementation of the service relies on the DONA/Handle persistent identifier solution.
+          It allows parallel computing, with support of MPI protocol and libraries.
+        parameters:
+          - id: "id1"
+            label: "Number of CPU hours"
+            description: "Choose number of hours"
+            type: "range"
+            value_type: "integer"
+            unit: "h"
+            config:
+              minimum: 1
+              maximum: 10000000
+          - id: "id2"
+            label: "Guaranteed number of CPU cores"
+            description: "Choose number of cores between 1 and 32"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 32
+          - id: "id3"
+            label: "Amount of RAM per CPU core"
+            description: "Choose amount of RAM"
+            unit: "GB"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 4, 8 ]
+          - id: "id4"
+            label: "Parallelism (Threads)"
+            description: "Choose number of threads from 8 to 24"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 8
+              maximum: 24
+          - id: "id5"
+            label: "Access type"
+            description: "Choose access type"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "opportunistic", "reserved" ]
+          - id: "id6"
+            label: "Other technical requirements"
+            description: "Type other requirements"
+            type: "input"
+            value_type: "string"
+          - id: "id7"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id8"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 730
+  Cloud container compute:
+    name: EGI Cloud container compute BETA
+    parents: *computeParent
+    providers: [ *egi ]
+    logo: cloud-container-compute.png
+    open_access: false
+    webpage_url: https://www.egi.eu/services/cloud-compute/
+    manual_url: https://wiki.egi.eu/wiki/Federated_Cloud_user_support
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-container-compute-training-material
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url: https://documents.egi.eu/document/2733
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Run Docker containers in a lightweight virtualised environment
+    platforms: [ *egiPlatform ]
+    description: |
+      With Cloud Container Compute you can deploy and scale Docker containers on-demand. It offers guaranteed computational resources in a secure and isolated environment with standard API access, without the overhead of managing the operating system.
 
-          B2HANDLE can be used by middleware applications, end-user tools and other service to reliably identify data objects over longer timespans and through changes in object location or ownership. The B2HANDLE service encompasses management of identifier namespaces (Handle prefixes), establishment of policies and business workflows, operation of Handle servers and technical services, and a user-friendly Python library for general interaction with Handle servers and EUDAT-specific extensions. B2HANDLE is mostly transparents to end-users, shielding them from the complexity of infrastructure details. In the background, B2HANDLE operates as a federation and based on policies that aim to ensure high availability of Handle resolution by cross-site mirroring of Handles. B2HANDLE supports a dedicated Handle record structure (a PID profile) for the safe data management within an infrastructure with a given topology. By relying on features of the PID profile, end-users can, for instance, ensure authenticity of objects with checksums and timestamps and account for replicated objects across multiple locations.
+      The result is improved performance, ideal for development.
 
-          ### Note:
+      ### To access the service you need to:
 
-          To mint PIDs a prefix is required.
+        1. Request access selecting one of the service options below.
+        2. Set the relevant parameters and add the service to the cart.
+        3. Go to the cart and submit your order.
+        4. You will receive an email summarising your order.
+        5. You will be contacted by the EGI support team.
+    offers: *cloudComputeOffers
+  B2DROP:
+    name: &b2drop B2DROP
+    parents: [ *storageParent, *sharingAndDicoveryParent ]
+    providers: [ *eudat, *jsc ]
+    logo: b2drop.png
+    open_access: false
+    webpage_url: https://b2drop.eudat.eu
+    manual_url: https://eudat.eu/services/userdoc/b2drop
+    helpdesk_url: https://www.eudat.eu/support-request?service=B2DROP
+    training_information_url: https://eudat.eu/services/userdoc/b2drop
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://eudat.eu/policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Secure and trusted data exchange service for researchers
+    platforms: [ *eudatPlatform ]
+    description: |
+      B2DROP is a secure and trusted data exchange service for researchers and scientists to keep their research data synchronized and up-to-date and to exchange with other researchers. B2DROP is an ideal solution to store and exchange data with colleagues and team members, synchronise multiple versions of data, ensure automatic desktop synchronisation of large files.
 
+      For the individuals researchers who need to synchronise and exchange data with one or multiple users, B2DROP Service is a customer-facing solution to store and exchange data with colleagues and team members.
 
-          ### To access the service you need to:
+      ### Uses cases:
 
-             1. Requests access to PID service or namespace (Prefix) select one of service options below.
-             2. Set the relevant parameters and add the service to the cart.
-             3. Go to the cart and submit your order.
-             4. You will receive an email summarising your order.
-             5. You will be contacted by the EUDAT support team.
+        - define with whom to exchange data, for how long and how
+        - are offered up to 20GB of storage space for research data
+        - access and manage permissions to files from any device and any location
 
-          ### Service provided by
+      ### To access the service you need to:
 
-          EUDAT and SURFsara, GRNET
-        offers:
-          1:
-            name: B2HANDLE For Researchers
-            description: |
-              B2HANDLE is the distributed service for minting, storing, managing and accessing persistent
-              identifiers (PIDs) and essential metadata (PID records) as well as managing PID namespaces.
-              PID are used to create persistent reference which can be used to identify and access data collections
-              and objects over long periods of time. PIDs are normally automatically minted at and
-              within data management and data repository systems.
-              Features: Unique and persistent reference which are globally resolvable,
-              Network of service providers for high available PIDs and PID services,
-              Sustainability framework to sustain PIDs over long periods of time.
-              Ideal for: Data Providers
-            parameters:
-              - id:  "id1"
-                label:  "Access type"
-                description:  "Access type is constant"
-                type:  "attribute"
-                value_type:  "string"
-                value: "reserved"
-              - id:  "id2"
-                label:  "Start of service"
-                description:  "Choose start of the service"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id3"
-                label:  "Number of days"
-                description:  "Type number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-          2:
-            name: B2HANDLE For Data Managers, Communities and/or Organisations
-            description: |
-              B2HANDLE is the distributed service for minting, storing, managing and accessing persistent
-              identifiers (PIDs) and essential metadata (PID records) as well as managing PID namespaces.
-              The implementation of the service relies on the DONA/Handle persistent identifier solution.
-              Features: Unique and persistent reference which are globally resolvable,
-              Network of service providers for high PIDs and PID services, Sustainability framework to sustain PIDs
-              over long periods of time, Unified technical interface for access, registration and modification
-              of PIDs and PID records, Operational management of PID namespaces (prefixes) transparent
-              to user communities, including replication. Local reverse-lookups to retrive Handles base
-              on target location or other fields, Client0side application support through a Python library.
-              Compatible with common standards and practices (e.g. RDA).
-              Ideal for: Data Providers
-            parameters:
-              - id:  "id1"
-                label:  "Access type"
-                description:  "Access type is constant"
-                type:  "attribute"
-                value_type:  "string"
-                value: "reserved"
-              - id:  "id2"
-                label:  "Prefix"
-                description:  "Prefix"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode: "buttons"
-                  values: ["yes", "no"]
-              - id:  "id3"
-                label:  "Prefered service provider"
-                description:  "Choose preferred service provider"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode: "buttons"
-                  values: ["SURFsara", "GRNET"]
-              - id:  "id4"
-                label:  "Start of service"
-                description:  "Choose start of the service"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id5"
-                label:  "Number of days"
-                description:  "Type number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-    B2NOTE:
-        name: &b2note B2NOTE
-        parents: [*sharingAndDicoveryParent, *dataManagementParent]
-        providers: [*eudat, *bsc]
-        logo: b2note.png
-        open_access: false
-        webpage_url: https://www.eudat.eu/catalogue/B2NOTE
-        manual_url:
-        helpdesk_url: https://www.eudat.eu/contact-support-request?service=B2NOTE
-        training_information_url:
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://eudat.eu/policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Data annotation service to create annotations on research data
-        platforms: [*eudatPlatform]
+      1.  The EUDAT public B2DROP service (https://b2drop.eudat.eu) is offered as a fairshare free-to-use service, users can register themselves via the B2DROP service. Users get a default quota of 20GB.
+      2.  Requests for higher quotas or a dedicated instance can by selecting one of the service options below.
+      3.  Set the relevant parameters and add the service to the cart.
+      4.  Go to the cart and submit your order.
+      5.  You will receive an email summarising your order.
+      6.  You will be contacted by the EUDAT support team.
+
+      ### Service provided by
+
+      EUDAT and JSC.
+    offers:
+      1:
+        name: B2DROP For Researchers
         description: |
-          B2Note allows to easily create, search and manage annotations. An annotation is a keyword or commentary attached to a dete object (data collection, file) that explains or classifies it. B2NOTE is a standalone service for annotating data content hosted within the EUDAT CDI.
-
-          There exist 3 types of annotations in B2Note
-
-             - the semantic tag, a keyword from an ontology (a semantic tag coming from identified ontology repositories - currently only Bioportal
-             - the free-text keyword, to be created and used when a specific semantic term is not found
-             - the comment, a more comprehensive annotation
-
-          Perfect for service providers who want to extend the (web based) service with annotation functionality
-
-          ### Relevant:
-
-          User must register to create and maintain annotations, additional access registration can be applied on the service which enabled annotation functionality via B2NOTE. Service providers willing to enable annotation via B2NOTE on an existing service can request consultancy and support.
-
-          ### To access the service you need to:
-
-             1. The EUDAT public B2NOTE service (https://b2note.eudat.eu) is offered as a fairshare free-to-use service, no registration is required to search through the B2NOTE, registration is needed to store and manage annotations.
-             2. Request for integraton within existing services select the service option below.
-             3. Provide URL to service
-             4. Go to the cart and submit your order.
-             5. You will receive an email summarising your order.
-             6. You will be contacted by the EUDAT support team
-
-          ### Service provided by
-
-          EUDAT and BSC
-        offers:
-          1:
-            name: B2NOTE
-            description: |
-              B2NOTE is a service that allows you to easily and intuitively create annotations on research data
-              hosted in the EUDAT Collaborative Data Infrastructure. These annotations are created and stored
-              in a computer-readable format (using the W3C Web Annotation model) and therefore are searchable
-              (which is not the case for hand-written counter-parts). The search results can be visualized
-              in the User Interface and refined before being exported either as JSON-LD for reuse
-              with your analysis workflow/script/software. B2NOTE also allows users to export all the annotations
-              about a file as JSON-LD for your own purpose. This first release of B2NOTE is
-              a crowdsourcing annotation service meaning that all annotations will be publicly available.
-              To preserve the anonymity of the user, you should register and create an annotator pseudonym.
-            parameters:
-              - id:  "id1"
-                label:  "Access type"
-                description:  "Access type is constant"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode: "buttons"
-                  values: ["opportunistic", "reserved"]
-              - id:  "id2"
-                label:  "Amount of data"
-                description:  "Prefix"
-                type:  "input"
-                value_type:  "integer"
-                unit: "TB"
-              - id:  "id3"
-                label:  "Start of service"
-                description:  "Choose start of the service"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id4"
-                label:  "Number of days"
-                description:  "Type number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-    B2SAFE:
-        name: &b2safe B2SAFE
-        parents: [*dataManagementParent, *storageParent]
-        providers: [*eudat, *all]
-        logo: b2safe.png
-        open_access: false
-        webpage_url: https://www.eudat.eu/services/b2safe
-        manual_url: https://eudat.eu/services/userdoc/configure-b2safe
-        helpdesk_url: https://eudat.eu/contact-support-request
-        training_information_url:
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://eudat.eu/policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Distribute and store large volumes of data based on data policies
-        platforms: [*eudatPlatform]
+          B2DROP is a secure and trusted data exchange service for researchers and scientists to keep their
+          research data synchronized and up-to-date and to exchange with other researchers.
+          B2DROP is an ideal solution to store and exchange data with colleagues and team members,
+          synchronise multiple versions of data, ensure automatic desktop synchronisation of large files.
+          Features: Public service, Self registering, Quota 20GB, Web access, Sharing files with local users,
+          Sharing files across other B2DROP and ownCloud/Nextcloud instances, Desktop synchronisation,
+          Support for WebDAV mounts, Publish data to B2SHARE.
+          Ideal for: Researchers seeking a central place to dtorage and ahre research data.
+        parameters:
+          - id: "id1"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id2"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+      2:
+        name: B2DROP For Data Managers
         description: |
-          B2SAFE is a robust, safe and highly available service which allows community
-          and departmental repositories to implement data management policies on their research data across
-          multiple administrative domains in a trustworthy manner. The service provides an abstraction layer
-          of large scale, heterogeneous data storages and guards against data loss in long-term archiving.
-          It allows to optimize access for users (e.g. from different regions) and brings data closer to facilities
-          for compute-intensive analysis.
-
-
-          ### To access the service you need to:
-
-             1. Request access selecting one of the service options below.
-             2. Set the relevant parameters and add the service to the cart.
-             3. Go to the cart and submit your order.
-             4. You will receive an email summarising your order..
-             5. You will be contacted by the EUDAT support team.
-
-          ### Service provided by
-
-          EUDAT and all generic CDI Level 1 providers
-        offers:
-          1:
-            name: B2SAFE
-            description: |
-              For the communities who need to guard against data loss; a customer facing service that allows
-              data replication and policy-driven data management using different storage services provided
-              by geographicallydistributed centres in the EUDAT CDI. Features: based on the execution of auditable
-              data policy rules and the use of persistent identifiers (PIDs), respects the rights of the data owners
-              to define teh access rights for their data and to decide how and when it is made publicly referenceable,
-              able to aggregate data from different disciplines into a storage system of thrustworthy and capable data
-              service providers, support for DSPACE repository packages and a lightweight HTTP-based solution,
-              integration between B2ACCSS and B2SAFE to provide federated authentication
-              (expected in the next stable release).
-    B2SHARE:
-        name: &b2share B2SHARE
-        parents: [*sharingAndDicoveryParent, *dataManagementParent]
-        providers: [*eudat, *csc]
-        logo: b2share.png
-        open_access: false
-        webpage_url: https://www.eudat.eu/services/b2share
-        manual_url: https://eudat.eu/services/userdoc/b2share
-        helpdesk_url: https://eudat.eu/contact-support-request
-        training_information_url:
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://eudat.eu/policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *providers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Store and publish research data
-        platforms: [*eudatPlatform]
+          The public B2DROP service has a per user quota limit of 20GB. Communities, organisations
+          or PI's which have a need for higher quota’s, higher storage capacity, specific requirements
+          and/or (Nextcloud) applications enabled can submit support request. Depending on the requirements
+          and/or requested storage capacity the B2DROP service is offered as a paid service.
+          Features: Public service, Self registering, Higher quota's as default, Web access,
+          Sharing files with local users, Sharing files across other B2DROP and ownCloud/Nextcloud instances,
+          Desktop synchronisation, Support for WebDAV mounts, Publish data to B2SHARE.
+          Ideal for: Data managers with higher quota, storage and/or any specific requirements.
+        parameters: &b2dropParameters
+          - id: "id1"
+            label: "Requested storage capacity"
+            description: "Please choose storage capacity"
+            type: "select"
+            value_type: "integer"
+            unit: "TB"
+            config:
+              mode: "buttons"
+              values: [ 0.5, 1, 5, 10 ]
+          - id: "id2"
+            label: "Requested quota per user"
+            description: "Choose quota per user"
+            type: "select"
+            value_type: "integer"
+            unit: "GB"
+            config:
+              mode: "buttons"
+              values: [ 100, 200, 500 ]
+          - id: "id3"
+            label: "Access type"
+            description: "Choose number of days"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "opportunistic", "reserved" ]
+          - id: "id4"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id5"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+          - id: "id6"
+            label: "Special requirements"
+            description: "Write about special requirements"
+            type: "input"
+            value_type: "string"
+      3:
+        name: B2DROP For Communities And Organisations
         description: |
-          B2SHARE is a user-friendly, reliable and trustworthy way for researchers,
-          scientific communities and citizen scientists to store and publish small-scale
-          research data from diverse contexts. B2SHARE is a solution that facilitates research data storage,
-          guarantees long-term persistence of data and allows data, results or ideas to be shared worldwide.
+          The public B2DROP service is provided on a fair-share basis.
+          Communities and/or organisations with specific requirements which can not be support via
+          the public fair-share service or or need higher level of security or access control can request
+          consultancy in setting up and deploying a local B2DROP instance or can request
+          a B2DROP instance which is hosted at one of the EUDAT partners.
+          Features: dedicated B2DROP instace, Requirements are negotiable.
+          Ideal for: Community/organisational data managers.
+        parameters: *b2dropParameters
 
-             - The basic production service comprises the following features:
-             - self-service registration for any scientists and researchers,
-             - free upload and registration of stable research data,
-             - data access policy is defined by the data owner,
-             - metadata is openly accessible and harvestable,
-             - customised metadata handling and customized user interfaces (e.g. for metadata acquisition),
-             - data integrity is ensured by checksums which are calculated during data ingest,
-             - the data is kept online, the storage usage base on the principle of fair share.
+  B2FIND:
+    name: &b2find B2FIND
+    parents: [ *sharingAndDicoveryParent, *dataManagementParent ]
+    providers: [ *eudat, *dkrz ]
+    logo: b2find.png
+    open_access: false
+    webpage_url: http://b2find.eudat.eu/
+    manual_url: http://eudat.eu/services/userdoc/b2find
+    helpdesk_url: http://www.egi.eu/more-information/
+    training_information_url: http://eudat.eu/services/userdoc/b2find
+    terms_of_use_url: http://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: http://eudat.eu/policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *providers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Metadata based data-discovery
+    platforms: [ *eudatPlatform ]
+    funding_bodies: [ "funding_body-fapesp","funding_body-rpf" ]
+    funding_programs: [ "funding_program-icfs", "funding_program-insc2020", "funding_program-iter" ]
+    description: |
+      B2FIND is the EUDAT metadata service and provides a discovery portal which allows users
+      to find data collections within an international and inter-disciplinary scope.
+      It is based on a comprehensive metadata catalogue of research data collections stored
+      in EUDAT data centres and other repositories. Harmonization of the metadata descriptions collected
+      from heterogeneous sources enables not only the presentation in a consistent form but as well
+      the faceted search across scientific domain boundaries.
 
-          Perfect for the individuals researchers who do not have adequate facilities for storing,
-          preserving and sharing data, B2SHARE Service is a customer-facing service which provides
-          a safe repository for scientific data and a easy way to share it in the research community.
+      B2FIND is for communities and other providers of research data who need to publish and give visibility
+      to their metadata and individual researchers who need to search data from everywhere,
+      and see data in the context with an accross community approach.
+
+      ### Features:
+
+         - based on a comprehensive joint catalogue of EUDAT services and external metadata
+         - metadata is mapped onto standardized facets
+         - supports faceted, geospatial and temporal metadata searches
+         - allows users to search and browse datasets via keyword searches
+         - results displayed in user-friendly format and listed in order of relevance
+         - access to the scientific data objects is given through references provided in the metadata
+         - available for communities in the EUDAT registered domain of data
+
+      ### Uses cases:
+
+         - define with whom to exchange data, for how long and how
+         - are offered up to 20GB of storage space for research data
+         - access and manage permissions to files from any device and any location
 
 
-          ### To access the service you need to:
+      ### To access the service you need to:
 
-             1. The EUDAT public B2SHARE service (https://b2share.eudat.eu) is offered as a fairshare free-to-use service, users can register themselves via the B2SHARE service.
-             2. Requests for a specific community domain and metadata template or a dedicated instance can by selecting one of the service options below.
-             3. Set the relevant parameters and add the service to the cart.
-             4. Go to the cart and submit your order.
-             5. You will receive an email summarising your order.
-             6. You will be contacted by the EUDAT support team.
+         1. The EUDAT public B2FIND [service][1]  is offered as a fairshare free-to-use service,
+         no registration is required to search through the B2FIND service.
+         2. Request for metadata data harvesting of an existing data repository select the service option below.
+         3. Provide URL to data repository
+         4. Provide URL endpoint for harvesting, see B2FIND [guidelines][2] for harvesting
+         5. Go to the cart and submit your order.
+         6. You will receive an email summarising your order.
+         7. You will be contacted by the EUDAT support team
 
-          ### Service provided by
+      ### Service provided by
 
-          EUDAT and CSC
-        offers:
-          1:
-            name: B2SHARE For Researchers
-            description: |
-              B2SHARE is a user-friendly, reliable and trustworthy way for researchers, scientific communities
-              and citizen scientists to store and publish small-scale research data from diverse contexts.
-              Features: Public service supporting cross disciplinary research,
-              Self-service registration for any scientists and researchers,
-              Free upload and registration of stable research data, Data access policy is defined by the data owner,
-              Community metadata schema's available, Metadata in openly accessible and harvestable (e.g. OAI-PMH),
-              metadata is made discoverable via B2FIND, Direct uploads from B2DROP, Data integrity is ensured
-              by checksums which are calculated during data ingest, The data is kept online,
-              the storage usage base on the principle of fair share.
-              Ideal for: Researchers who what to publish datasets.
-            parameters:
-              - id:  "id1"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-          2:
-            name: B2SHARE For Data Providers
-            description: |
-              To enlarge the discovery of existing datasets, data repository owners can make their research
-              data collections stored in existing data repositories harvestable and discoverable
-              via public B2FIND service. To ease the process of harvesting data repository owners can assess
-              the B2FIND guidelines for data providers. Features: Comprehensive joint catalogue
-              of EUDAT services and external metadata, Metadata is mapped onto standardized facets,
-              Supports faceted, geospatial and temporal metadata searches,  Allows users to search
-              and browse datasets via keyword searches, User-friendly format and listed in order of relevance,
-              Access to the scientific data objects is given through references provided in the metadata.
-              Ideal for: Data providers.
-            parameters:
-              - id:  "id1"
-                label:  "Data repository name"
-                description:  "Please choose storage capacity"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Harvesting method"
-                description:  "Choose harvesting method"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode:  "buttons"
-                  values:  ["OAI-PMH", "JSON-API", "CSW 2.0", "Other"]
-              - id:  "id3"
-                label:  "Harvesting endpoint"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id4"
-                label:  "Reference to md schema"
-                description:  "Reference to md schema"
-                type:  "input"
-                value_type:  "string"
-          3:
-            name: B2SHARE For Communities And Organisations
-            description: |
-              A way to deploy a local instance use the B2FIND technology.
-              Community data managers can adapt this local instance to support community specific facets.
-              The community and/or organisation local B2FIND instances can again be made harvestable
-              by the public B2FIND service. To explore the feasibility of B2FIND as data discovery service,
-              community data managers can assess the B2FIND training module on Github.
-              Features: Comprehensive joint catalogue of EUDAT services and external metadata,
-              Metadata in mapped onto standardized facetes, Supports faceted search, facets can be adapted
-              to domain specific facets, Geospatial and temporal metadata searches, Allows users to search
-              and browse datasets via keyword searches, user-friendly format and listed in order of relevance,
-              Access to the scientifc data objects in given through references provided in the metadata,
-              Local B2FIND instace. Ideal for: Community/organisational data managers.
-    B2STAGE:
-        name: &b2stage B2STAGE
-        parents: *storageParent
-        providers: [*eudat, *all]
-        logo: b2stage.png
-        open_access: false
-        webpage_url: https://www.eudat.eu/services/b2stage
-        manual_url: https://eudat.eu/services/userdoc/b2stage
-        helpdesk_url: https://eudat.eu/contact-support-request
-        training_information_url:
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://eudat.eu/policy
-        language_availability: *english
-        domain: *otherOther
-        geographical_availabilities: *poland
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Transfer of data between data resources and external computational facilities
-        platforms: [*eudatPlatform]
+      EUDAT and Deutsches Klimarechenzentrum (DKRZ)
+
+      [1]: https://b2find.eudat.eu/
+      [2]: http://b2find.eudat.eu/guidelines/harvesting.html
+    offers:
+      1:
+        name: B2FIND For Researchers
         description: |
-          B2STAGE is for communities who need to transfert large data collection from EUDAT CDI to HPC.
-          B2STAGE service is a customer-facing service that allow high performance transfers
-          in a reliable, fast, easy to use environment.
-
-          The service allows users to:
-
-             - transfer large data collections from EUDAT storage facilities to external HPC facilities for processing
-             - ingest computation results onto the EUDAT infrastructure
-             - access stored data sets through associated PIDs
-             - in conjunction with B2SAFE, replicate community data sets, ingesting them onto
-             EUDAT storage resources for long-term preservation.
-
-          ### Service provided by
-
-          EUDAT and all generic EUDAT CDI Level 1 providers.
-        offers:
-          1:
-            name: B2STAGE
-            description: |
-              B2STAGE is a reliable, efficient, light-weight and easy-to-use service to transfer research data sets
-              between EUDAT storage resources and high-performance computing (HPC) workspaces.
-            parameters:
-              - id:  "id1"
-                label:  "Tool"
-                description:  "Choose the tool"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode: "buttons"
-                  values: ["FTS3", "globus online"]
-              - id:  "id2"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id3"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-    B2ACCESS:
-        name: &b2access B2ACCESS
-        parents: *securityAndOperationsParent
-        providers: [*eudat, *all]
-        logo: b2access.png
-        open_access: false
-        webpage_url: https://b2access.eudat.eu
-        manual_url: https://eudat.eu/services/userdoc/b2stage
-        helpdesk_url: https://eudat.eu/contact-support-request
-        training_information_url:
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url: http://hdl.handle.net/11304/e43b2e3f-83c5-4e3f-b8b7-18d38d37a6cd
-        access_policies_url: https://eudat.eu/policy
-        language_availability: *english
-        domain: *otherOther
-        geographical_availabilities: *poland
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: AAI platform for federated authentication to EUDAT services
-        platforms: [*eudatPlatform]
+          B2FIND is a discovery service based on metadata steadily harvested from research data collections
+          from EUDAT data centres and other community repositories. The service offers faceted browsing
+          and it allows in particular to discover data that is stored through the B2SAFE and B2SHARE services.
+          Features: Public service supporting cross disciplinary research, No registration required.
+          Ideal for: Researchers seeking interesting datasets.
+      2:
+        name: B2FIND For Data Providers
         description: |
-          The B2ACCESS AAI proxy service is arbitrating access to registered Service Providers via different protocols.
-          Integrated Service Providers consume Attribute assertions from the B2ACCESS service when the End User
-          accesses them. B2ACCESS allows EUDAT users to authenticate themselves using a variety of other Identity
-          Providers or credentials.
+          To enlarge the discovery of existing datasets, data repository owners can make their research
+          data collections stored in existing data repositories harvestable and discoverable
+          via public B2FIND service. To ease the process of harvesting data repository owners can assess the
+          B2FIND guidelines for data providers.
+          Features: Comprehensive joint catalogue of EUDAT services and external metadata,
+          Metadata is mapped onto standardized facets, Supports faceted, geospatial and temporal metadata searches,
+          Allows suse to search and browse datasets via keyword searches,
+          user-friendly format and listed in order of relevance,
+          Access to the scintific data objects is given through references provided in the metadata.
+          Ideal for: Data providers.
+        parameters:
+          - id: "id1"
+            label: "Data repository name"
+            description: "Type data repository name"
+            type: "input"
+            value_type: "string"
+          - id: "id2"
+            label: "Harvesting method"
+            description: "Choose harvesting method"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "OAI-PMH", "JSON-API", "CSW 2.0", "Other" ]
+          - id: "id3"
+            label: "Harvesting endpoint"
+            description: "Type harvesting endpoint"
+            type: "input"
+            value_type: "string"
+          - id: "id4"
+            label: "Reference to md schema"
+            description: "Reference to md schema"
+            type: "input"
+            value_type: "string"
+      3:
+        name: B2FIND For Communities And Organisations
+        description: |
+          A way to deploy a local instance use the B2FIND technology.
+          Community data managers can adapt this local instance to support community specific facets.
+          The community and/or organisation local B2FIND instances can again be made harvestable
+          by the public B2FIND service. To explore the feasibility of B2FIND as data discovery service,
+          community data managers can assess the B2FIND training module on Github.
+          Features: Comprehensive joint catalogue of EUDAT services and external metadata,
+          Metadata in mapped onto standardized facetes, Supports faceted search,
+          facets can be adapted to domain specific facets, Geospatial and temporal metadata searches,
+          Allows users to search and browse datasets via keyword searches, user-friendly format and listed
+          in order of relevance, Access to the scientifc data objects in given through references provided
+          in the metadata, Local B2FIND instace. Ideal for: Community/organisational data managers.
+  B2HANDLE:
+    name: &b2handle B2HANDLE
+    parents: [ *dataManagementParent, *sharingAndDicoveryParent ]
+    providers: [ *eudat, *surfsara, *grnet ]
+    logo: b2handle.png
+    open_access: false
+    webpage_url: https://www.eudat.eu/services/b2handle
+    manual_url: https://eudat.eu/services/userdoc/b2handle
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://eudat.eu/services/userdoc/b2handle
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://eudat.eu/policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Secure and trusted data exchange service for researchers
+    platforms: [ *eudatPlatform ]
+    description: |
+      B2HANDLE is the distributed service for minting, storing, managing and accessing persistent identifiers (PIDs) and essential metadata (PID records) as well as managing PID namespaces. The implementation of the service relies on the DONA/Handle persistent identifier solution.
 
-          ### The features of B2ACCESS:
+      B2HANDLE can be used by middleware applications, end-user tools and other service to reliably identify data objects over longer timespans and through changes in object location or ownership. The B2HANDLE service encompasses management of identifier namespaces (Handle prefixes), establishment of policies and business workflows, operation of Handle servers and technical services, and a user-friendly Python library for general interaction with Handle servers and EUDAT-specific extensions. B2HANDLE is mostly transparents to end-users, shielding them from the complexity of infrastructure details. In the background, B2HANDLE operates as a federation and based on policies that aim to ensure high availability of Handle resolution by cross-site mirroring of Handles. B2HANDLE supports a dedicated Handle record structure (a PID profile) for the safe data management within an infrastructure with a given topology. By relying on features of the PID profile, end-users can, for instance, ensure authenticity of objects with checksums and timestamps and account for replicated objects across multiple locations.
 
-            - supports several methods of authentication via the users' primary identity providers (OpenID, SAML, x.509)
-            - can be used as primary identity provider, if necessary
-            - can be integrated with any service of the CDI service provider federation
-            - is integrated with EduGain and supports identities from theoretically hundreds of Universities
-              and Research institutions worldwide.
-            - provides unique and persistent EUDAT-wide meaningful identifiers.
+      ### Note:
 
-        offers:
-          1:
-            name: b2accessDemo
-            description: |
-              Demo
+      To mint PIDs a prefix is required.
 
 
-    EGI Archive storage:
+      ### To access the service you need to:
+
+         1. Requests access to PID service or namespace (Prefix) select one of service options below.
+         2. Set the relevant parameters and add the service to the cart.
+         3. Go to the cart and submit your order.
+         4. You will receive an email summarising your order.
+         5. You will be contacted by the EUDAT support team.
+
+      ### Service provided by
+
+      EUDAT and SURFsara, GRNET
+    offers:
+      1:
+        name: B2HANDLE For Researchers
+        description: |
+          B2HANDLE is the distributed service for minting, storing, managing and accessing persistent
+          identifiers (PIDs) and essential metadata (PID records) as well as managing PID namespaces.
+          PID are used to create persistent reference which can be used to identify and access data collections
+          and objects over long periods of time. PIDs are normally automatically minted at and
+          within data management and data repository systems.
+          Features: Unique and persistent reference which are globally resolvable,
+          Network of service providers for high available PIDs and PID services,
+          Sustainability framework to sustain PIDs over long periods of time.
+          Ideal for: Data Providers
+        parameters:
+          - id: "id1"
+            label: "Access type"
+            description: "Access type is constant"
+            type: "attribute"
+            value_type: "string"
+            value: "reserved"
+          - id: "id2"
+            label: "Start of service"
+            description: "Choose start of the service"
+            type: "date"
+            value_type: "string"
+          - id: "id3"
+            label: "Number of days"
+            description: "Type number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+      2:
+        name: B2HANDLE For Data Managers, Communities and/or Organisations
+        description: |
+          B2HANDLE is the distributed service for minting, storing, managing and accessing persistent
+          identifiers (PIDs) and essential metadata (PID records) as well as managing PID namespaces.
+          The implementation of the service relies on the DONA/Handle persistent identifier solution.
+          Features: Unique and persistent reference which are globally resolvable,
+          Network of service providers for high PIDs and PID services, Sustainability framework to sustain PIDs
+          over long periods of time, Unified technical interface for access, registration and modification
+          of PIDs and PID records, Operational management of PID namespaces (prefixes) transparent
+          to user communities, including replication. Local reverse-lookups to retrive Handles base
+          on target location or other fields, Client0side application support through a Python library.
+          Compatible with common standards and practices (e.g. RDA).
+          Ideal for: Data Providers
+        parameters:
+          - id: "id1"
+            label: "Access type"
+            description: "Access type is constant"
+            type: "attribute"
+            value_type: "string"
+            value: "reserved"
+          - id: "id2"
+            label: "Prefix"
+            description: "Prefix"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "yes", "no" ]
+          - id: "id3"
+            label: "Prefered service provider"
+            description: "Choose preferred service provider"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "SURFsara", "GRNET" ]
+          - id: "id4"
+            label: "Start of service"
+            description: "Choose start of the service"
+            type: "date"
+            value_type: "string"
+          - id: "id5"
+            label: "Number of days"
+            description: "Type number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  B2NOTE:
+    name: &b2note B2NOTE
+    parents: [ *sharingAndDicoveryParent, *dataManagementParent ]
+    providers: [ *eudat, *bsc ]
+    logo: b2note.png
+    open_access: false
+    webpage_url: https://www.eudat.eu/catalogue/B2NOTE
+    manual_url:
+    helpdesk_url: https://www.eudat.eu/contact-support-request?service=B2NOTE
+    training_information_url:
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://eudat.eu/policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Data annotation service to create annotations on research data
+    platforms: [ *eudatPlatform ]
+    description: |
+      B2Note allows to easily create, search and manage annotations. An annotation is a keyword or commentary attached to a dete object (data collection, file) that explains or classifies it. B2NOTE is a standalone service for annotating data content hosted within the EUDAT CDI.
+
+      There exist 3 types of annotations in B2Note
+
+         - the semantic tag, a keyword from an ontology (a semantic tag coming from identified ontology repositories - currently only Bioportal
+         - the free-text keyword, to be created and used when a specific semantic term is not found
+         - the comment, a more comprehensive annotation
+
+      Perfect for service providers who want to extend the (web based) service with annotation functionality
+
+      ### Relevant:
+
+      User must register to create and maintain annotations, additional access registration can be applied on the service which enabled annotation functionality via B2NOTE. Service providers willing to enable annotation via B2NOTE on an existing service can request consultancy and support.
+
+      ### To access the service you need to:
+
+         1. The EUDAT public B2NOTE service (https://b2note.eudat.eu) is offered as a fairshare free-to-use service, no registration is required to search through the B2NOTE, registration is needed to store and manage annotations.
+         2. Request for integraton within existing services select the service option below.
+         3. Provide URL to service
+         4. Go to the cart and submit your order.
+         5. You will receive an email summarising your order.
+         6. You will be contacted by the EUDAT support team
+
+      ### Service provided by
+
+      EUDAT and BSC
+    offers:
+      1:
+        name: B2NOTE
+        description: |
+          B2NOTE is a service that allows you to easily and intuitively create annotations on research data
+          hosted in the EUDAT Collaborative Data Infrastructure. These annotations are created and stored
+          in a computer-readable format (using the W3C Web Annotation model) and therefore are searchable
+          (which is not the case for hand-written counter-parts). The search results can be visualized
+          in the User Interface and refined before being exported either as JSON-LD for reuse
+          with your analysis workflow/script/software. B2NOTE also allows users to export all the annotations
+          about a file as JSON-LD for your own purpose. This first release of B2NOTE is
+          a crowdsourcing annotation service meaning that all annotations will be publicly available.
+          To preserve the anonymity of the user, you should register and create an annotator pseudonym.
+        parameters:
+          - id: "id1"
+            label: "Access type"
+            description: "Access type is constant"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "opportunistic", "reserved" ]
+          - id: "id2"
+            label: "Amount of data"
+            description: "Prefix"
+            type: "input"
+            value_type: "integer"
+            unit: "TB"
+          - id: "id3"
+            label: "Start of service"
+            description: "Choose start of the service"
+            type: "date"
+            value_type: "string"
+          - id: "id4"
+            label: "Number of days"
+            description: "Type number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  B2SAFE:
+    name: &b2safe B2SAFE
+    parents: [ *dataManagementParent, *storageParent ]
+    providers: [ *eudat, *all ]
+    logo: b2safe.png
+    open_access: false
+    webpage_url: https://www.eudat.eu/services/b2safe
+    manual_url: https://eudat.eu/services/userdoc/configure-b2safe
+    helpdesk_url: https://eudat.eu/contact-support-request
+    training_information_url:
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://eudat.eu/policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Distribute and store large volumes of data based on data policies
+    platforms: [ *eudatPlatform ]
+    description: |
+      B2SAFE is a robust, safe and highly available service which allows community
+      and departmental repositories to implement data management policies on their research data across
+      multiple administrative domains in a trustworthy manner. The service provides an abstraction layer
+      of large scale, heterogeneous data storages and guards against data loss in long-term archiving.
+      It allows to optimize access for users (e.g. from different regions) and brings data closer to facilities
+      for compute-intensive analysis.
+
+
+      ### To access the service you need to:
+
+         1. Request access selecting one of the service options below.
+         2. Set the relevant parameters and add the service to the cart.
+         3. Go to the cart and submit your order.
+         4. You will receive an email summarising your order..
+         5. You will be contacted by the EUDAT support team.
+
+      ### Service provided by
+
+      EUDAT and all generic CDI Level 1 providers
+    offers:
+      1:
+        name: B2SAFE
+        description: |
+          For the communities who need to guard against data loss; a customer facing service that allows
+          data replication and policy-driven data management using different storage services provided
+          by geographicallydistributed centres in the EUDAT CDI. Features: based on the execution of auditable
+          data policy rules and the use of persistent identifiers (PIDs), respects the rights of the data owners
+          to define teh access rights for their data and to decide how and when it is made publicly referenceable,
+          able to aggregate data from different disciplines into a storage system of thrustworthy and capable data
+          service providers, support for DSPACE repository packages and a lightweight HTTP-based solution,
+          integration between B2ACCSS and B2SAFE to provide federated authentication
+          (expected in the next stable release).
+  B2SHARE:
+    name: &b2share B2SHARE
+    parents: [ *sharingAndDicoveryParent, *dataManagementParent ]
+    providers: [ *eudat, *csc ]
+    logo: b2share.png
+    open_access: false
+    webpage_url: https://www.eudat.eu/services/b2share
+    manual_url: https://eudat.eu/services/userdoc/b2share
+    helpdesk_url: https://eudat.eu/contact-support-request
+    training_information_url:
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://eudat.eu/policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *providers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Store and publish research data
+    platforms: [ *eudatPlatform ]
+    description: |
+      B2SHARE is a user-friendly, reliable and trustworthy way for researchers,
+      scientific communities and citizen scientists to store and publish small-scale
+      research data from diverse contexts. B2SHARE is a solution that facilitates research data storage,
+      guarantees long-term persistence of data and allows data, results or ideas to be shared worldwide.
+
+         - The basic production service comprises the following features:
+         - self-service registration for any scientists and researchers,
+         - free upload and registration of stable research data,
+         - data access policy is defined by the data owner,
+         - metadata is openly accessible and harvestable,
+         - customised metadata handling and customized user interfaces (e.g. for metadata acquisition),
+         - data integrity is ensured by checksums which are calculated during data ingest,
+         - the data is kept online, the storage usage base on the principle of fair share.
+
+      Perfect for the individuals researchers who do not have adequate facilities for storing,
+      preserving and sharing data, B2SHARE Service is a customer-facing service which provides
+      a safe repository for scientific data and a easy way to share it in the research community.
+
+
+      ### To access the service you need to:
+
+         1. The EUDAT public B2SHARE service (https://b2share.eudat.eu) is offered as a fairshare free-to-use service, users can register themselves via the B2SHARE service.
+         2. Requests for a specific community domain and metadata template or a dedicated instance can by selecting one of the service options below.
+         3. Set the relevant parameters and add the service to the cart.
+         4. Go to the cart and submit your order.
+         5. You will receive an email summarising your order.
+         6. You will be contacted by the EUDAT support team.
+
+      ### Service provided by
+
+      EUDAT and CSC
+    offers:
+      1:
+        name: B2SHARE For Researchers
+        description: |
+          B2SHARE is a user-friendly, reliable and trustworthy way for researchers, scientific communities
+          and citizen scientists to store and publish small-scale research data from diverse contexts.
+          Features: Public service supporting cross disciplinary research,
+          Self-service registration for any scientists and researchers,
+          Free upload and registration of stable research data, Data access policy is defined by the data owner,
+          Community metadata schema's available, Metadata in openly accessible and harvestable (e.g. OAI-PMH),
+          metadata is made discoverable via B2FIND, Direct uploads from B2DROP, Data integrity is ensured
+          by checksums which are calculated during data ingest, The data is kept online,
+          the storage usage base on the principle of fair share.
+          Ideal for: Researchers who what to publish datasets.
+        parameters:
+          - id: "id1"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id2"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+      2:
+        name: B2SHARE For Data Providers
+        description: |
+          To enlarge the discovery of existing datasets, data repository owners can make their research
+          data collections stored in existing data repositories harvestable and discoverable
+          via public B2FIND service. To ease the process of harvesting data repository owners can assess
+          the B2FIND guidelines for data providers. Features: Comprehensive joint catalogue
+          of EUDAT services and external metadata, Metadata is mapped onto standardized facets,
+          Supports faceted, geospatial and temporal metadata searches,  Allows users to search
+          and browse datasets via keyword searches, User-friendly format and listed in order of relevance,
+          Access to the scientific data objects is given through references provided in the metadata.
+          Ideal for: Data providers.
+        parameters:
+          - id: "id1"
+            label: "Data repository name"
+            description: "Please choose storage capacity"
+            type: "input"
+            value_type: "string"
+          - id: "id2"
+            label: "Harvesting method"
+            description: "Choose harvesting method"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "OAI-PMH", "JSON-API", "CSW 2.0", "Other" ]
+          - id: "id3"
+            label: "Harvesting endpoint"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "string"
+          - id: "id4"
+            label: "Reference to md schema"
+            description: "Reference to md schema"
+            type: "input"
+            value_type: "string"
+      3:
+        name: B2SHARE For Communities And Organisations
+        description: |
+          A way to deploy a local instance use the B2FIND technology.
+          Community data managers can adapt this local instance to support community specific facets.
+          The community and/or organisation local B2FIND instances can again be made harvestable
+          by the public B2FIND service. To explore the feasibility of B2FIND as data discovery service,
+          community data managers can assess the B2FIND training module on Github.
+          Features: Comprehensive joint catalogue of EUDAT services and external metadata,
+          Metadata in mapped onto standardized facetes, Supports faceted search, facets can be adapted
+          to domain specific facets, Geospatial and temporal metadata searches, Allows users to search
+          and browse datasets via keyword searches, user-friendly format and listed in order of relevance,
+          Access to the scientifc data objects in given through references provided in the metadata,
+          Local B2FIND instace. Ideal for: Community/organisational data managers.
+  B2STAGE:
+    name: &b2stage B2STAGE
+    parents: *storageParent
+    providers: [ *eudat, *all ]
+    logo: b2stage.png
+    open_access: false
+    webpage_url: https://www.eudat.eu/services/b2stage
+    manual_url: https://eudat.eu/services/userdoc/b2stage
+    helpdesk_url: https://eudat.eu/contact-support-request
+    training_information_url:
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://eudat.eu/policy
+    language_availability: *english
+    domain: *otherOther
+    geographical_availabilities: *poland
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Transfer of data between data resources and external computational facilities
+    platforms: [ *eudatPlatform ]
+    description: |
+      B2STAGE is for communities who need to transfert large data collection from EUDAT CDI to HPC.
+      B2STAGE service is a customer-facing service that allow high performance transfers
+      in a reliable, fast, easy to use environment.
+
+      The service allows users to:
+
+         - transfer large data collections from EUDAT storage facilities to external HPC facilities for processing
+         - ingest computation results onto the EUDAT infrastructure
+         - access stored data sets through associated PIDs
+         - in conjunction with B2SAFE, replicate community data sets, ingesting them onto
+         EUDAT storage resources for long-term preservation.
+
+      ### Service provided by
+
+      EUDAT and all generic EUDAT CDI Level 1 providers.
+    offers:
+      1:
+        name: B2STAGE
+        description: |
+          B2STAGE is a reliable, efficient, light-weight and easy-to-use service to transfer research data sets
+          between EUDAT storage resources and high-performance computing (HPC) workspaces.
+        parameters:
+          - id: "id1"
+            label: "Tool"
+            description: "Choose the tool"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "FTS3", "globus online" ]
+          - id: "id2"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id3"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  B2ACCESS:
+    name: &b2access B2ACCESS
+    parents: *securityAndOperationsParent
+    providers: [ *eudat, *all ]
+    logo: b2access.png
+    open_access: false
+    webpage_url: https://b2access.eudat.eu
+    manual_url: https://eudat.eu/services/userdoc/b2stage
+    helpdesk_url: https://eudat.eu/contact-support-request
+    training_information_url:
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url: http://hdl.handle.net/11304/e43b2e3f-83c5-4e3f-b8b7-18d38d37a6cd
+    access_policies_url: https://eudat.eu/policy
+    language_availability: *english
+    domain: *otherOther
+    geographical_availabilities: *poland
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: AAI platform for federated authentication to EUDAT services
+    platforms: [ *eudatPlatform ]
+    description: |
+      The B2ACCESS AAI proxy service is arbitrating access to registered Service Providers via different protocols.
+      Integrated Service Providers consume Attribute assertions from the B2ACCESS service when the End User
+      accesses them. B2ACCESS allows EUDAT users to authenticate themselves using a variety of other Identity
+      Providers or credentials.
+
+      ### The features of B2ACCESS:
+
+        - supports several methods of authentication via the users' primary identity providers (OpenID, SAML, x.509)
+        - can be used as primary identity provider, if necessary
+        - can be integrated with any service of the CDI service provider federation
+        - is integrated with EduGain and supports identities from theoretically hundreds of Universities
+          and Research institutions worldwide.
+        - provides unique and persistent EUDAT-wide meaningful identifiers.
+
+    offers:
+      1:
+        name: b2accessDemo
+        description: |
+          Demo
+
+
+  EGI Archive storage:
+    name: EGI Archive storage
+    parents: *storageParent
+    providers: [ *egi ]
+    logo: archive-storage.png
+    open_access: false
+    webpage_url: https://www.egi.eu/services/archive-storage/
+    manual_url: https://wiki.egi.eu/wiki/Online_Storage
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://wiki.egi.eu/wiki/Online_Storage
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://eudat.eu/policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Back-up your data for the long term and future use in a secure environment.
+    platforms: [ *egiPlatform ]
+    description: |
+      Archive Storage allows you to store large amounts of data in a secure environment freeing up
+      your usual file storage resources. Access to the archive can be given at an individual,
+      small group or large collaboration level.
+
+      All the files in Archive Storage are easily located and retrieved to and from different types of platforms.
+
+      The data on Archive Storage can be replicated across several storage sites,
+      thanks to the adoption of interoperable open standards.
+      More copies of your archives mean fewer opportunities for disaster.
+
+
+      ### To access the service you need to:
+
+         1. Request access selecting one of the service options below.
+         2. Set the relevant parameters and add the service to the cart.
+         3. Go to the cart and submit your order.
+         4. You will receive an email summarising your order.
+         5. You will be contacted by the EGI support team.
+    offers:
+      1:
         name: EGI Archive storage
-        parents: *storageParent
-        providers: [*egi]
-        logo: archive-storage.png
-        open_access: false
-        webpage_url: https://www.egi.eu/services/archive-storage/
-        manual_url: https://wiki.egi.eu/wiki/Online_Storage
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://wiki.egi.eu/wiki/Online_Storage
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://eudat.eu/policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Back-up your data for the long term and future use in a secure environment.
-        platforms: [*egiPlatform]
         description: |
           Archive Storage allows you to store large amounts of data in a secure environment freeing up
-          your usual file storage resources. Access to the archive can be given at an individual,
-          small group or large collaboration level.
+          your usual online storage resources.The data on the Archive Storage can be replicated
+          across several storage sites, thanks to the adoption of interoperable open standards.
+          The service is optimised for infrequent access.
+          Main characteristics: Store data for long-term retention,
+          Store large amount of data, Free up your online storage.
+        parameters:
+          - id: "id1"
+            label: "Amount of data"
+            description: "Type amount of data"
+            type: "input"
+            unit: "TB"
+            value_type: "integer"
+          - id: "id2"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id3"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  EGI Online Storage:
+    name: &egiOnlineStorage EGI Online Storage
+    parents: *storageParent
+    providers: [ *egi ]
+    logo: archive-storage.png
+    open_access: false
+    webpage_url: https://www.egi.eu/services/online-storage/
+    manual_url: https://wiki.egi.eu/wiki/Online_Storage
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://wiki.egi.eu/wiki/Online_Storage
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherOther
+    target_users: [ *researchers, *research_organisations ]
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Store, share and access your files and their metadata on a global scale.
+    platforms: [ *egiPlatform ]
+    description: |
+      Store, share and access your files and their metadata on a global scale.
 
-          All the files in Archive Storage are easily located and retrieved to and from different types of platforms.
+      Online Storage allows you to store data in a reliable and high-­quality environment and share it
+      across distributed teams. Your data can be accessed through different standard protocols and can be
+      replicated across different providers to increase fault­-tolerance.
 
-          The data on Archive Storage can be replicated across several storage sites,
-          thanks to the adoption of interoperable open standards.
-          More copies of your archives mean fewer opportunities for disaster.
+      Online Storage gives you complete control over the data you share and with whom.
 
 
-          ### To access the service you need to:
+      ### To access the service you need to:
 
-             1. Request access selecting one of the service options below.
-             2. Set the relevant parameters and add the service to the cart.
-             3. Go to the cart and submit your order.
-             4. You will receive an email summarising your order.
-             5. You will be contacted by the EGI support team.
-        offers:
-          1:
-            name: EGI Archive storage
-            description: |
-              Archive Storage allows you to store large amounts of data in a secure environment freeing up
-              your usual online storage resources.The data on the Archive Storage can be replicated
-              across several storage sites, thanks to the adoption of interoperable open standards.
-              The service is optimised for infrequent access.
-              Main characteristics: Store data for long-term retention,
-              Store large amount of data, Free up your online storage.
-            parameters:
-              - id:  "id1"
-                label:  "Amount of data"
-                description:  "Type amount of data"
-                type:  "input"
-                unit: "TB"
-                value_type:  "integer"
-              - id:  "id2"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id3"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-    EGI Online Storage:
-        name: &egiOnlineStorage EGI Online Storage
-        parents: *storageParent
-        providers: [*egi]
-        logo: archive-storage.png
-        open_access: false
-        webpage_url: https://www.egi.eu/services/online-storage/
-        manual_url: https://wiki.egi.eu/wiki/Online_Storage
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://wiki.egi.eu/wiki/Online_Storage
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherOther
-        target_users: [*researchers, *research_organisations]
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Store, share and access your files and their metadata on a global scale.
-        platforms: [*egiPlatform]
+        1. Request access selecting one of the service options below.
+        2. Set the relevant parameters and add the service to the cart.
+        3. Go to the cart and submit your order.
+        4. You will receive an email summarising your order.
+        5. You will be contacted by the EGI support team.
+    offers:
+      1:
+        name: EGI Block storage
         description: |
-          Store, share and access your files and their metadata on a global scale.
-
-          Online Storage allows you to store data in a reliable and high-­quality environment and share it
-          across distributed teams. Your data can be accessed through different standard protocols and can be
-          replicated across different providers to increase fault­-tolerance.
-
-          Online Storage gives you complete control over the data you share and with whom.
-
-
-          ### To access the service you need to:
-
-            1. Request access selecting one of the service options below.
-            2. Set the relevant parameters and add the service to the cart.
-            3. Go to the cart and submit your order.
-            4. You will receive an email summarising your order.
-            5. You will be contacted by the EGI support team.
-        offers:
-          1:
-            name: EGI Block storage
-            description: |
-              Block Storage is a block-level storage solution that allows you to expand the storage capacity
-              of your instances in the EGI Federated Cloud. This means you can increase your storage
-              without increasing the size or capacity of your instance or by provisioning new ones.
-              Once you mount and format your drive, you can use it just like a regular hard drive
-              attached to your server. Or you can detach your block storage volume from one server
-              and attach it to another. Or you can delete your server, keeping your data intact
-              and ready for the next time you need it.
-            parameters:
-              - id:  "id1"
-                label:  "Storage capacity"
-                description:  "Type amount of data"
-                type:  "input"
-                unit: "GB"
-                value_type:  "integer"
-              - id:  "id2"
-                label:  "Access type"
-                description:  "Choose access type"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode: "buttons"
-                  values: ["opportunistic", "reserved"]
-              - id:  "id3"
-                label:  "Special requirements"
-                description:  "Type special requirements"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id4"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id5"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-          2:
-            name: EGI Object storage
-            description: |
-              Object storage manages data as objects. Each object includes the data itself,
-              a variable amount of metadata, and a globally unique identifier.
-              Cloud object storage allows relatively inexpensive, scalable
-              and self-healing retention of massive amounts of unstructured data.
-            parameters:
-              - id:  "id1"
-                label:  "Storage capacity"
-                description:  "Type amount of data"
-                type:  "input"
-                unit: "GB"
-                value_type:  "integer"
-              - id:  "id2"
-                label:  "Interfaces"
-                description:  "Choose interfaces"
-                type:  "multiselect"
-                value_type:  "string"
-                config:
-                  minItems: 1
-                  values: ["CDMI", "POSIX", "SWIFT", "Others"]
-              - id:  "id3"
-                label:  "Access type"
-                description:  "Choose access type"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode: "buttons"
-                  values: ["opportunistic", "reserved"]
-              - id:  "id4"
-                label:  "Special requirements"
-                description:  "Type special requirements"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id5"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id6"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-          3:
-            name: EGI File storage
-            description: |
-              Highly scalable storage system accessible from anywhere allowing
-              to easily share data through different standard interfaces.
-              It assigns global identifiers to files and allows to organise your data
-              using a flexible hierarchical structure.
-            parameters:
-              - id:  "id1"
-                label:  "Storage capacity"
-                description:  "Type amount of data"
-                type:  "input"
-                unit: "GB"
-                value_type:  "integer"
-              - id:  "id2"
-                label:  "Technology"
-                description:  "Choose technology"
-                type:  "multiselect"
-                value_type:  "string"
-                config:
-                  minItems: 1
-                  values: ["DPM", "DCache", "Storm",  "Others"]
-              - id:  "id3"
-                label:  "Access type"
-                description:  "Choose access type"
-                type:  "select"
-                value_type:  "string"
-                config:
-                  mode: "buttons"
-                  values: ["opportunistic", "reserved"]
-              - id:  "id4"
-                label:  "Special requirements"
-                description:  "Type special requirements"
-                type:  "input"
-                value_type:  "string"
-              - id:  "id5"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id6"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-#    Argo:
-#        name: Argo
-#        parents: *sharingAndDicoveryParent
-#        providers: [*not] #TODO: not specified
-#        logo: argo-data.png
-#        open_access: false
-#        webpage_url: http://www.euro-argo.eu/Activities/Data-Management
-#        manual_url: http://www.argo.ucsd.edu/Argo_date_guide.html
-#        helpdesk_url: https://www.egi.eu/more-information/
-#        training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
-#        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-#        sla_url:
-#        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-#        geographical_availabilities: *poland
-#        dedicated_for: ["Researchers"] #TODO: but not specified
-#        language_availability: *english
-#        domain: *earthAndEnvironmentalScience
-##        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Store, share and access your files and their metadata on a global scale.
-#        platforms: [*egiPlatform]
-#        description: |
-#          The data are available as downloadable netCDF files from Argo's
-#          two Global Data Assembly Centers (GDACS) and there are various data products too
-#          which can be accessed through various data viewers.
-#          Data from individual floats are also available from a certain region or time.
-    GEOSS Portal:
-        name: &geossPortal GEOSS Web Portal
-        parents: *sharingAndDicoveryParent
-        providers: [*esa]
-        logo: geoss-portal.png
-        external: true
-        webpage_url: http://geosspublish.uat.esaportal.eu/knowledge-producer
-        manual_url:
-        helpdesk_url:
-        training_information_url:
-        terms_of_use_url: http://geosspublish.uat.esaportal.eu/community/guest/terms-conditions
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers] #TODO: but not specified
-        domain: *earthAndEnvironmentalScience
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Access to resources from the Global Earth Observation System of Systems
-        platforms: [*ecopotential, *geossPlatform]
+          Block Storage is a block-level storage solution that allows you to expand the storage capacity
+          of your instances in the EGI Federated Cloud. This means you can increase your storage
+          without increasing the size or capacity of your instance or by provisioning new ones.
+          Once you mount and format your drive, you can use it just like a regular hard drive
+          attached to your server. Or you can detach your block storage volume from one server
+          and attach it to another. Or you can delete your server, keeping your data intact
+          and ready for the next time you need it.
+        parameters:
+          - id: "id1"
+            label: "Storage capacity"
+            description: "Type amount of data"
+            type: "input"
+            unit: "GB"
+            value_type: "integer"
+          - id: "id2"
+            label: "Access type"
+            description: "Choose access type"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "opportunistic", "reserved" ]
+          - id: "id3"
+            label: "Special requirements"
+            description: "Type special requirements"
+            type: "input"
+            value_type: "string"
+          - id: "id4"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id5"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+      2:
+        name: EGI Object storage
         description: |
-          The GEOSS (Global Earth Observation System of Systems) Web Portal is the main entry point
-          for discovering and accessing GEOSS data. GEOSS Platform interconnects more than 170 data systems globally,
-          providing discoverability of more than 400M datasets.
-          This version of the GEOSS Web Portal is connected also to the ECOPotential Virtual Laboratory,
-          allowing users to execute available models utilizing GEOSS data as inputs.
-        offers:
-          1:
-            name: GEOSS Portal
-            description: *notSpecified
-            order_url: http://geosspublish.uat.esaportal.eu/knowledge-producer
-    GEO DAB:
-        name: &geossDab GEO DAB
-        parents: *sharingAndDicoveryParent
-        providers: [*cnr]
-        logo: geo-dab.jpg
-        open_access: true
-        webpage_url: http://www.geodab.net
-        manual_url: http://api.geodab.eu/index.html
-        helpdesk_url: http://api.geodab.eu/index.html
-        training_information_url: http://eosc.geodab.eu/gi-cat-StP/
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_groups, *research_organisations]
-        domain: [*earthAndEnvironmentalScience, *otherOther]
-        restrictions:
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Multi-disciplinary discovery, access, and use of resources from the Global Earth Observation System of Systems
-        platforms: [*geo, *geossPlatform]
+          Object storage manages data as objects. Each object includes the data itself,
+          a variable amount of metadata, and a globally unique identifier.
+          Cloud object storage allows relatively inexpensive, scalable
+          and self-healing retention of massive amounts of unstructured data.
+        parameters:
+          - id: "id1"
+            label: "Storage capacity"
+            description: "Type amount of data"
+            type: "input"
+            unit: "GB"
+            value_type: "integer"
+          - id: "id2"
+            label: "Interfaces"
+            description: "Choose interfaces"
+            type: "multiselect"
+            value_type: "string"
+            config:
+              minItems: 1
+              values: [ "CDMI", "POSIX", "SWIFT", "Others" ]
+          - id: "id3"
+            label: "Access type"
+            description: "Choose access type"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "opportunistic", "reserved" ]
+          - id: "id4"
+            label: "Special requirements"
+            description: "Type special requirements"
+            type: "input"
+            value_type: "string"
+          - id: "id5"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id6"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+      3:
+        name: EGI File storage
         description: |
+          Highly scalable storage system accessible from anywhere allowing
+          to easily share data through different standard interfaces.
+          It assigns global identifiers to files and allows to organise your data
+          using a flexible hierarchical structure.
+        parameters:
+          - id: "id1"
+            label: "Storage capacity"
+            description: "Type amount of data"
+            type: "input"
+            unit: "GB"
+            value_type: "integer"
+          - id: "id2"
+            label: "Technology"
+            description: "Choose technology"
+            type: "multiselect"
+            value_type: "string"
+            config:
+              minItems: 1
+              values: [ "DPM", "DCache", "Storm",  "Others" ]
+          - id: "id3"
+            label: "Access type"
+            description: "Choose access type"
+            type: "select"
+            value_type: "string"
+            config:
+              mode: "buttons"
+              values: [ "opportunistic", "reserved" ]
+          - id: "id4"
+            label: "Special requirements"
+            description: "Type special requirements"
+            type: "input"
+            value_type: "string"
+          - id: "id5"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id6"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  #    Argo:
+  #        name: Argo
+  #        parents: *sharingAndDicoveryParent
+  #        providers: [*not] #TODO: not specified
+  #        logo: argo-data.png
+  #        open_access: false
+  #        webpage_url: http://www.euro-argo.eu/Activities/Data-Management
+  #        manual_url: http://www.argo.ucsd.edu/Argo_date_guide.html
+  #        helpdesk_url: https://www.egi.eu/more-information/
+  #        training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
+  #        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+  #        sla_url:
+  #        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+  #        geographical_availabilities: *poland
+  #        dedicated_for: ["Researchers"] #TODO: but not specified
+  #        language_availability: *english
+  #        domain: *earthAndEnvironmentalScience
+  ##        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Store, share and access your files and their metadata on a global scale.
+  #        platforms: [*egiPlatform]
+  #        description: |
+  #          The data are available as downloadable netCDF files from Argo's
+  #          two Global Data Assembly Centers (GDACS) and there are various data products too
+  #          which can be accessed through various data viewers.
+  #          Data from individual floats are also available from a certain region or time.
+  GEOSS Portal:
+    name: &geossPortal GEOSS Web Portal
+    parents: *sharingAndDicoveryParent
+    providers: [ *esa ]
+    logo: geoss-portal.png
+    external: true
+    webpage_url: http://geosspublish.uat.esaportal.eu/knowledge-producer
+    manual_url:
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url: http://geosspublish.uat.esaportal.eu/community/guest/terms-conditions
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ] #TODO: but not specified
+    domain: *earthAndEnvironmentalScience
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Access to resources from the Global Earth Observation System of Systems
+    platforms: [ *ecopotential, *geossPlatform ]
+    description: |
+      The GEOSS (Global Earth Observation System of Systems) Web Portal is the main entry point
+      for discovering and accessing GEOSS data. GEOSS Platform interconnects more than 170 data systems globally,
+      providing discoverability of more than 400M datasets.
+      This version of the GEOSS Web Portal is connected also to the ECOPotential Virtual Laboratory,
+      allowing users to execute available models utilizing GEOSS data as inputs.
+    offers:
+      1:
+        name: GEOSS Portal
+        description: *notSpecified
+        order_url: http://geosspublish.uat.esaportal.eu/knowledge-producer
+  GEO DAB:
+    name: &geossDab GEO DAB
+    parents: *sharingAndDicoveryParent
+    providers: [ *cnr ]
+    logo: geo-dab.jpg
+    open_access: true
+    webpage_url: http://www.geodab.net
+    manual_url: http://api.geodab.eu/index.html
+    helpdesk_url: http://api.geodab.eu/index.html
+    training_information_url: http://eosc.geodab.eu/gi-cat-StP/
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_groups, *research_organisations ]
+    domain: [ *earthAndEnvironmentalScience, *otherOther ]
+    restrictions:
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Multi-disciplinary discovery, access, and use of resources from the Global Earth Observation System of Systems
+    platforms: [ *geo, *geossPlatform ]
+    description: |
 
-            GEO Discovery and Access Broker (GEO DAB) is a key component of the GEOSS Platform,
-            transparently connecting GEOSS User’s requests to the resources shared by the GEOSS Providers.
+      GEO Discovery and Access Broker (GEO DAB) is a key component of the GEOSS Platform,
+      transparently connecting GEOSS User’s requests to the resources shared by the GEOSS Providers.
 
-            GEO DAB scope is to simplify cross and multi-disciplinary discovery, access, and use (or reuse)
-            of disparate data and information.
+      GEO DAB scope is to simplify cross and multi-disciplinary discovery, access, and use (or reuse)
+      of disparate data and information.
 
-            GEO DAB is a brokering framework that interconnects hundreds of heterogeneous and autonomous
-            supply systems (the enterprise systems constituting the GEO metasystem) by providing mediation,
-            harmonization, transformation, and QoS capabilities.
+      GEO DAB is a brokering framework that interconnects hundreds of heterogeneous and autonomous
+      supply systems (the enterprise systems constituting the GEO metasystem) by providing mediation,
+      harmonization, transformation, and QoS capabilities.
 
-            GEO DAB can be accessed using several web service interfaces, available at [link][1].
+      GEO DAB can be accessed using several web service interfaces, available at [link][1].
 
-            [1]: http://eosc.geodab.eu/gi-cat-StP/
-        offers:
-          1:
-            name: GEOSS DAB
-            description: *notSpecified
-            order_url: http://www.geodab.net
-    VLO:
-        name: &vloService Virtual Language Observatory
-        parents: *sharingAndDicoveryParent
-        providers: [*clarin]
-        logo: vlo-logo.png #component-metadata-infrastructure.png
-        open_access: false
-        webpage_url: https://vlo.clarin.eu
-        manual_url: https://vlo.clarin.eu/help
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        language_availability: *english
-        domain: [*otherSocialSciences, *otherHumanities]
-        geographical_availabilities: *poland
-        target_users: [*researchers] #TODO: but not specified
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: A facet browser for fast navigation and searching in huge amounts of metadata.
-        platforms: [*clarinPlatform, *eudatPlatform, *europeana]
+      [1]: http://eosc.geodab.eu/gi-cat-StP/
+    offers:
+      1:
+        name: GEOSS DAB
+        description: *notSpecified
+        order_url: http://www.geodab.net
+  VLO:
+    name: &vloService Virtual Language Observatory
+    parents: *sharingAndDicoveryParent
+    providers: [ *clarin ]
+    logo: vlo-logo.png #component-metadata-infrastructure.png
+    open_access: false
+    webpage_url: https://vlo.clarin.eu
+    manual_url: https://vlo.clarin.eu/help
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    language_availability: *english
+    domain: [ *otherSocialSciences, *otherHumanities ]
+    geographical_availabilities: *poland
+    target_users: [ *researchers ] #TODO: but not specified
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: A facet browser for fast navigation and searching in huge amounts of metadata.
+    platforms: [ *clarinPlatform, *eudatPlatform, *europeana ]
+    description: |
+      A facet browser for fast navigation and searching in large amounts of metadata.
+      This portal enables the discovery of language data and tools, provided by over 40 CLARIN centres,
+      other language resource providers and Europeana.
+
+
+      The [VLO][1] also provides access to the [Virtual Collection Registry][2] metadata and can be used
+      as a starting point to process language data with the [Language Resource Switchboard][3].
+
+      [1]: https://vlo.clarin.eu
+      [2]: https://www.clarin.eu/content/virtual-collections
+      [3]: https://switchboard.clarin.eu/
+
+    offers:
+      1:
+        name: VLO
         description: |
           A facet browser for fast navigation and searching in large amounts of metadata.
           This portal enables the discovery of language data and tools, provided by over 40 CLARIN centres,
           other language resource providers and Europeana.
 
 
-          The [VLO][1] also provides access to the [Virtual Collection Registry][2] metadata and can be used
-          as a starting point to process language data with the [Language Resource Switchboard][3].
-
-          [1]: https://vlo.clarin.eu
-          [2]: https://www.clarin.eu/content/virtual-collections
-          [3]: https://switchboard.clarin.eu/
-
-        offers:
-          1:
-            name: VLO
-            description: |
-              A facet browser for fast navigation and searching in large amounts of metadata.
-              This portal enables the discovery of language data and tools, provided by over 40 CLARIN centres,
-              other language resource providers and Europeana.
+          The VLO also provides access to the Virtual Collection Registry metadata
+          and can be used as a starting point to process language data with the Language Resource Switchboard.
 
 
-              The VLO also provides access to the Virtual Collection Registry metadata
-              and can be used as a starting point to process language data with the Language Resource Switchboard.
+  LRS:
+    name: &lrsService Language Resource Switchboard
+    parents: *sharingAndDicoveryParent
+    providers: [ *clarin ]
+    logo: lrs-logo.png #component-metadata-infrastructure.png
+    open_access: true
+    webpage_url: https://switchboard.clarin.eu/ #https://clarin.eu/
+    manual_url: https://vlo.clarin.eu/help
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    language_availability: *english
+    domain: [ *otherSocialSciences, *otherHumanities ]
+    geographical_availabilities: *poland
+    target_users: [ *researchers ] #TODO: but not specified
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: A web application that suggests language analysis tools for specific data sets.
+    platforms: [ *clarinPlatform, *eudatPlatform, *europeana ]
+    description: |
+      A web application that suggests language analysis tools for specific
+      data sets, enabling the following tasks:
 
+        **Sentence level analysis**:
 
-    LRS:
-        name: &lrsService Language Resource Switchboard
-        parents: *sharingAndDicoveryParent
-        providers: [*clarin]
-        logo: lrs-logo.png #component-metadata-infrastructure.png
-        open_access: true
-        webpage_url: https://switchboard.clarin.eu/ #https://clarin.eu/
-        manual_url: https://vlo.clarin.eu/help
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        language_availability: *english
-        domain: [*otherSocialSciences, *otherHumanities]
-        geographical_availabilities: *poland
-        target_users: [*researchers] #TODO: but not specified
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: A web application that suggests language analysis tools for specific data sets.
-        platforms: [*clarinPlatform, *eudatPlatform, *europeana]
+        - Constituency Parsing
+        - Dependency Parsing
+        - Shallow Parsing
+
+        **Word level analysis**:
+
+        - Lemmatization
+        - Morphological Analysis
+        - Named Entity Recognition
+        - Part-Of-Speech Tagging
+
+        **Semantic analysis**:
+
+        - Coreference Resolution
+        - Sentiment Analysis
+        - Text Summarization
+
+        **Digital Humanities analysis**:
+
+        - Distant Reading
+        - Named Entity Linking
+        - Stylometry
+        - Topic modelling
+
+      The [Language Resource Switchboard][1] will automatically provide a list
+      of available tools, based on the language and format of the input.
+      The Switchboard can also be invoked from the [Virtual Language Observatory][2]
+      and B2DROP (see Suggested compatible services below).
+
+      [1]: https://switchboard.clarin.eu
+      [2]: https://vlo.clarin.eu
+
+    offers:
+      1:
+        name: LRS
         description: |
-          A web application that suggests language analysis tools for specific
-          data sets, enabling the following tasks:
+          A web application that suggests language analysis tools for specific data sets.
+        order_url: https://switchboard.clarin.eu/
+  VCR:
+    name: &vcrService Virtual Collection Registry
+    parents: *sharingAndDicoveryParent
+    providers: [ *clarin ]
+    logo: vcr-logo.png #component-metadata-infrastructure.png
+    open_access: false
+    webpage_url: https://www.clarin.eu/content/virtual-collections
+    manual_url: https://vlo.clarin.eu/help
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url:
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    language_availability: *english
+    geographical_availabilities: *poland
+    domain: *otherHumanities
+    target_users: [ *researchers ] #TODO: but not specified
+    #        #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: A service that allows researchers to create their own citable digital bookmarks.
+    platforms: [ *clarinPlatform, *eudatPlatform, *europeana ]
+    description: |
+      A service that allows researchers to create their own citable digital bookmarks.
 
-            **Sentence level analysis**:
 
-            - Constituency Parsing
-            - Dependency Parsing
-            - Shallow Parsing
+      A virtual collection is a coherent set of links to digital objects (e.g. annotated text, video)
+      that can be easily created, accessed and cited. The links can originate from different archives,
+      hence the term virtual.
 
-            **Word level analysis**:
 
-            - Lemmatization
-            - Morphological Analysis
-            - Named Entity Recognition
-            - Part-Of-Speech Tagging
+      CLARIN provides a [registry][1] where scholars can create and publish their virtual collections.
+      It provides [persistent identifiers and federated login][2].
 
-            **Semantic analysis**:
 
-            - Coreference Resolution
-            - Sentiment Analysis
-            - Text Summarization
+      The collection metadata is openly available and accessible via the [Virtual Language Observatory][3].
+      The referenced digital objects can also be processed with the [Language Resource Switchboard][4].
 
-            **Digital Humanities analysis**:
+      [1]: https://www.clarin.eu/vcr
+      [2]: https://www.clarin.eu/content/federated-identity
+      [3]: https://vlo.clarin.eu
+      [4]: https://switchboard.clarin.eu
 
-            - Distant Reading
-            - Named Entity Linking
-            - Stylometry
-            - Topic modelling
-
-          The [Language Resource Switchboard][1] will automatically provide a list
-          of available tools, based on the language and format of the input.
-          The Switchboard can also be invoked from the [Virtual Language Observatory][2]
-          and B2DROP (see Suggested compatible services below).
-
-          [1]: https://switchboard.clarin.eu
-          [2]: https://vlo.clarin.eu
-
-        offers:
-          1:
-            name: LRS
-            description: |
-              A web application that suggests language analysis tools for specific data sets.
-            order_url: https://switchboard.clarin.eu/
-    VCR:
-        name: &vcrService Virtual Collection Registry
-        parents: *sharingAndDicoveryParent
-        providers: [*clarin]
-        logo: vcr-logo.png #component-metadata-infrastructure.png
-        open_access: false
-        webpage_url: https://www.clarin.eu/content/virtual-collections
-        manual_url: https://vlo.clarin.eu/help
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://www.eosc-hub.eu/training-material/egi-cloud-compute
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url:
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        language_availability: *english
-        geographical_availabilities: *poland
-        domain: *otherHumanities
-        target_users: [*researchers] #TODO: but not specified
-#        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: A service that allows researchers to create their own citable digital bookmarks.
-        platforms: [*clarinPlatform, *eudatPlatform, *europeana]
+    offers:
+      1:
+        name: VCR
         description: |
           A service that allows researchers to create their own citable digital bookmarks.
 
@@ -2896,557 +2965,551 @@ services:
           hence the term virtual.
 
 
-          CLARIN provides a [registry][1] where scholars can create and publish their virtual collections.
-          It provides [persistent identifiers and federated login][2].
+          CLARIN provides a registry where scholars can create and publish their virtual collections.
+          It provides persistent identifiers and federated login.
 
 
-          The collection metadata is openly available and accessible via the [Virtual Language Observatory][3].
-          The referenced digital objects can also be processed with the [Language Resource Switchboard][4].
-
-          [1]: https://www.clarin.eu/vcr
-          [2]: https://www.clarin.eu/content/federated-identity
-          [3]: https://vlo.clarin.eu
-          [4]: https://switchboard.clarin.eu
-
-        offers:
-          1:
-            name: VCR
-            description: |
-              A service that allows researchers to create their own citable digital bookmarks.
-
-
-              A virtual collection is a coherent set of links to digital objects (e.g. annotated text, video)
-              that can be easily created, accessed and cited. The links can originate from different archives,
-              hence the term virtual.
-
-
-              CLARIN provides a registry where scholars can create and publish their virtual collections.
-              It provides persistent identifiers and federated login.
-
-
-              The collection metadata is openly available and accessible via the Virtual Language Observatory.
-              The referenced digital objects can also be processed with the Language Resource Switchboard.
-#    EIDA Data Archive:
-#        name: EIDA Data Archive
-#        parents: *sharingAndDicoveryParent
-#        providers: *eida
-#        logo: orfeus-european-integrated-data-archive-eida.png
-#        open_access: false
-#        webpage_url: https://www.orfeus-eu.org/data/eida/
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        target_users: ["Reaserchers"] #TODO: but not specified
-#        language_availability: *english
-#        domain: *earthAndEnvironmentalScience
-#        geographical_availabilities: *poland
-##        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: *notSpecified
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          ORFEUS provides access to high quality seismic waveforms and station metadata
-#          from EIDA and strong motion products.
-#          Access to waveform and station metadata is possible through modern APIs and interfaces,
-#          such as the Rapid Raw Strong Motion system."
-#    Applications on Demand:
-#        name: Applications on Demand
-#        parents: *applicationsParent
-#        webpage_url: https://www.egi.eu/services/applications-on-demand/
-#        manual_url: https://wiki.egi.eu/wiki/AoD
-#        helpdesk_url: https://www.egi.eu/more-information/
-#        training_information_url: https://wiki.egi.eu/wiki/HowToAccessTheEGIMarketPlace
-#        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-#        sla_url:
-#        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-#        language_availability: *english
-#        geographical_availabilities: *poland
-#        domain: *otherOther
-#        target_users: ["Researchers", "Research organisations"]
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        description: "Features:
-#
-#                         User-friendly access to online applications that can be executed on parallel architectures (EGI Cloud and High-Throughput Compute)
-#                         Application development and hosting frameworks where custom applications can be executed on EGI Cloud Compute and High-Throughput Compute services
-#                         User support is available by an international network of consultants.
-#
-#                     Development frameworks:
-#
-#                         The WS-PGRADE Portal (Web Services Parallel Grid Runtime and Developer Environment Portal) is a Liferay-based web portal. WS-PGRADE provides a 'job wizard' interface for the user. Through this wizard the user can define, with a few clicks, a computational job that WS-PGRADE will execute on cloud resources of the EGI Applications On Demand infrastructure. The job can be easily scaled up into a parameter study, executing the same simulation on many different input sets. WS-PGRADE takes care of instantiation of a Virtual Machine image for jobs, sending user input for the jobs, and retrieving the results of computations.
-#                         The Elastic Cloud Computing Cluster (EC3) is a platform that allows creating elastic virtual clusters on top of Infrastructure as a Service (IaaS) providers. Through a 'job wizard' interface, the user can configure the cluster with a pre-defined set of applications that will be deployed in the clouds underpinning the EGI Applications On Demand infrastructure. The installation and the configuration of the cluster are performed by means of the execution of Ansible receipts. The cluster configured by EC3 is private: as soon as it is configured You will have root access to the environment, and can setup and configure the cluster installing additional libraries and software to their needs.
-#                         The EGI VMOps dashboard,a framework allows users to perform Virtual Machine (VM) management operations on the EGI Federated Cloud. The graphical interfaces of the dashboard allows the user to choose VMs from the AppDB Catalogue, to define an execution topology for them, and then to instantiate them on infrastructure as a service clouds.
-#
-#                     Featured use cases:
-#
-#                         New viruses implicated in fatal snake disease  how the  platform helped virologists to make sense of millions of virus genomes"
-#    GNU Octave:
-#        name: GNU Octave
-#        parents: *processingAndAnalysisParent
-#        providers: [*ics, *recas, *cyfro, *begrid, *cesga]
-#        logo: gnu-octave.png
-#        open_access: false
-#        webpage_url: https://www.gnu.org/software/octave/
-#        manual_url: https://octave.org/doc/interpreter/
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        language_availability: *english
-#        geographical_availabilities: *poland
-#        domain: *mathematics
-#        target_users: ["Researchers", "Research organisations"]
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          GNU Octave is a high-level interpreted language, primarily intended for numerical computations.
-#          It provides capabilities for the numerical solution of linear and nonlinear problems,
-#          and for performing other numerical experiments.
-#        offers:
-#          1:
-#            name: GNU Octave
-#            description: |
-#              GNU Octave is a high-level interpreted language, primarily intended for numerical computations.
-#              It provides capabilities for the numerical solution of linear and nonlinear problems,
-#              and for performing other numerical experiments.
-#            parameters: &appParameters
-#            - id: "id1"
-#              label: "Number of CPU cores"
-#              description:  "Number of cores for this offer is constant"
-#              type:  "attribute"
-#              value_type:  "integer"
-#              value: 20
-#            - id: "id2"
-#              label: "Total amount of RAM"
-#              description:  "Amount of RAM for this offer is constant"
-#              type:  "attribute"
-#              unit: "GB"
-#              value_type:  "integer"
-#              value: 4
-#            - id: "id3"
-#              label: "Storage capacity"
-#              description:  "Storage capacity for this offer is constant"
-#              type:  "attribute"
-#              unit: "GB"
-#              value_type:  "integer"
-#              value: 100
-#            - id: "id4"
-#              label: "Access type"
-#              description:  "Access type for this offer is constant"
-#              type:  "attribute"
-#              value_type:  "string"
-#              value: "opportunistic"
-#            - id: "id5"
-#              label: "Start of service"
-#              description:  "Choose service start date"
-#              type:  "date"
-#              value_type:  "string"
-#            - id: "id6"
-#              label: "Number of days"
-#              description:  "Choose service start date"
-#              type:  "input"
-#              value_type:  "integer"
-#              value: 365
-#              config:
-#                minimum: 1
-#                maximum: 730
-#
-#
-#    Galaxy:
-#        name: Galaxy
-#        parents: *processingAndAnalysisParent
-#        providers: [*cesga, *recas, *ics]
-#        logo: galaxy.png
-#        open_access: false
-#        webpage_url:
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *otherOther
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          Galaxy is an open, web-based platform for data-intensive biomedical research.
-#        offers:
-#          1:
-#            name: Galaxy
-#            description: Galaxy is an open, web-based platform for data-intensive biomedical research.
-#            parameters: *appParameters
-#    NAMD:
-#        name: NAMD
-#        parents: *processingAndAnalysisParent
-#        providers: [*cesga, *recas, *ics]
-#        logo: namd.png
-#        open_access: false
-#        webpage_url:
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *other
-##        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        platforms: [*egiPlatform, *ec3, *aodp]
-#        description: |
-#          NAMD is a parallel molecular dynamics code designed for high-performance simulation
-#          of large bio-molecular systems.
-#        offers:
-#          1:
-#            name: NAMD
-#            description: |
-#              NAMD is a parallel molecular dynamics code designed for high-performance simulation
-#              of large bio-molecular systems.
-#            parameters: &appParameters
-#            - id: "id1"
-#              label: "Number of CPU cores"
-#              description:  "Number of cores for this offer is constant"
-#              type:  "attribute"
-#              value_type:  "integer"
-#              value: 20
-#            - id: "id2"
-#              label: "Total amount of RAM"
-#              description:  "Amount of RAM for this offer is constant"
-#              type:  "attribute"
-#              unit: "GB"
-#              value_type:  "integer"
-#              value: 4
-#            - id: "id3"
-#              label: "Storage capacity"
-#              description:  "Storage capacity for this offer is constant"
-#              type:  "attribute"
-#              unit: "GB"
-#              value_type:  "integer"
-#              value: 100
-#            - id: "id4"
-#              label: "Access type"
-#              description:  "Access type for this offer is constant"
-#              type:  "attribute"
-#              value_type:  "string"
-#              value: "opportunistic"
-#            - id: "id5"
-#              label: "Start of service"
-#              description:  "Choose service start date"
-#              type:  "date"
-#              value_type:  "string"
-#            - id: "id6"
-#              label: "Number of days"
-#              description:  "Choose service start date"
-#              type:  "range"
-#              value_type:  "integer"
-#              value: 365
-#              config:
-#                minimum: 1
-#                maximum: 730
-#    Apache Tomcat:
-#        name: Apache Tomcat
-#        parents: *networkingParent
-#        providers: [*cesga, *recas, *ics]
-#        logo: apache-tomcat.png
-#        open_access: false
-#        webpage_url:
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *earthAndEnvironmentalScience
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: |
-#          Applications on Demand gives you access to online applications and application-development
-#          and hosting frameworks to support compute-intensive data analysis
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          Apache Tomcat is an open source implementation of the Java Servlet, JavaServer Pages,
-#          Java Expression Language and Java WebSocket technologies.
-#        offers:
-#          1:
-#            name: Apache Tomcat
-#            description: |
-#              Apache Tomcat is an open source implementation of the Java Servlet, JavaServer Pages,
-#              Java Expression Language and Java WebSocket technologies.
-#            parameters: *appParameters
-#    Gnuplot:
-#        name: Gnuplot
-#        parents: *processingAndAnalysisParent
-#        providers: [*cesga, *recas, *ics]
-#        logo: gnuplot.png
-#        open_access: false
-#        webpage_url: http://gnuplot.sourceforge.net
-#        manual_url: http://gnuplot.sourceforge.net/documentation.html
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *otherOther
-##        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        platforms: [*egiPlatform, *ec3, *aodp]
-#        description: |
-#          Gnuplot is a portable command-line driven graphing utility for Linux,
-#          OS/2, MS Windows, OSX, VMS, and other platforms.
-#        offers:
-#          1:
-#            name: Gnuplot
-#            description: |
-#              Gnuplot is a portable command-line driven graphing utility for Linux,
-#              OS/2, MS Windows, OSX, VMS, and other platforms.
-#            parameters: *appParameters
-#    Docker:
-#        name: Docker
-#        parents: *networkingParent
-#        providers: [*cesga, *recas, *ics]
-#        logo: docker.png
-#        open_access: false
-#        webpage_url: https://www.docker.com/
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *applicationFrameworks
-#        #restrictions: *notSpecified
-#        phase: production
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          Docker is an open-source project that automates the deployment of Linux applications inside software containers.
-#        offers:
-#          1:
-#            name: Docker
-#            description: |
-#              Docker is an open-source project that automates the deployment
-#              of Linux applications inside software containers.
-#            parameters: *appParameters
-#    Hadoop:
-#        name: Hadoop
-#        parents: *processingAndAnalysisParent
-#        providers: [*cesga, *recas, *ics]
-#        logo: hadoop.png
-#        open_access: false
-#        webpage_url: http://hadoop.apache.org/
-#        manual_url: http://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *applicationFrameworks
-##        #restrictions: *notSpecified
-#        phase: production
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        platforms: [*egiPlatform, *ec3, *aodp]
-#        description: |
-#          Hadoop is a framework that allows for the distributed processing
-#          of large data sets across clusters of computers using simple programming models.
-#        offers:
-#          1:
-#            name: Hadoop
-#            description: |
-#              Hadoop is a framework that allows for the distributed processing
-#              of large data sets across clusters of computers using simple programming models.
-#            parameters: *appParameters
-#    Marathon:
-#        name: Marathon
-#        parents: *dataManagementParent
-#        providers: [*cesga, *recas, *ics]
-#        logo: marathon.png
-#        open_access: false
-#        webpage_url: https://mesosphere.github.io/marathon/
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *applicationFrameworks
-##        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        platforms: [*egiPlatform, *ec3, *aodp]
-#        description: |
-#          Marathon a production-grade container orchestration platform
-#          for Mesosphere's Data Center/Operating System (DC/OS) and Apache Mesos.
-#        offers:
-#          1:
-#            name: Marathon
-#            description: |
-#              Marathon a production-grade container orchestration platform
-#              for Mesosphere's Data Center/Operating System (DC/OS) and Apache Mesos.
-#            parameters: *appParameters
-#    Chronos:
-#        name: Chronos
-#        open_access: false
-#        providers: [*cesga, *recas, *ics]
-#        logo: chronos.png
-#        parents: *processingAndAnalysisParent
-#        webpage_url: https://github.com/mesos/chronos
-#        manual_url: https://mesos.github.io/chronos/
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *applicationFrameworks
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          Chronos is a distributed and fault-tolerant scheduler that runs on top
-#          of Apache Mesos that can be used for job orchestration.
-#        offers:
-#          1:
-#            name: Chronos
-#            description: |
-#              Chronos is a distributed and fault-tolerant scheduler that runs on top
-#              of Apache Mesos that can be used for job orchestration.
-#            parameters: *appParameters
+          The collection metadata is openly available and accessible via the Virtual Language Observatory.
+          The referenced digital objects can also be processed with the Language Resource Switchboard.
+  #    EIDA Data Archive:
+  #        name: EIDA Data Archive
+  #        parents: *sharingAndDicoveryParent
+  #        providers: *eida
+  #        logo: orfeus-european-integrated-data-archive-eida.png
+  #        open_access: false
+  #        webpage_url: https://www.orfeus-eu.org/data/eida/
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        target_users: ["Reaserchers"] #TODO: but not specified
+  #        language_availability: *english
+  #        domain: *earthAndEnvironmentalScience
+  #        geographical_availabilities: *poland
+  ##        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: *notSpecified
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          ORFEUS provides access to high quality seismic waveforms and station metadata
+  #          from EIDA and strong motion products.
+  #          Access to waveform and station metadata is possible through modern APIs and interfaces,
+  #          such as the Rapid Raw Strong Motion system."
+  #    Applications on Demand:
+  #        name: Applications on Demand
+  #        parents: *applicationsParent
+  #        webpage_url: https://www.egi.eu/services/applications-on-demand/
+  #        manual_url: https://wiki.egi.eu/wiki/AoD
+  #        helpdesk_url: https://www.egi.eu/more-information/
+  #        training_information_url: https://wiki.egi.eu/wiki/HowToAccessTheEGIMarketPlace
+  #        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+  #        sla_url:
+  #        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+  #        language_availability: *english
+  #        geographical_availabilities: *poland
+  #        domain: *otherOther
+  #        target_users: ["Researchers", "Research organisations"]
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        description: "Features:
+  #
+  #                         User-friendly access to online applications that can be executed on parallel architectures (EGI Cloud and High-Throughput Compute)
+  #                         Application development and hosting frameworks where custom applications can be executed on EGI Cloud Compute and High-Throughput Compute services
+  #                         User support is available by an international network of consultants.
+  #
+  #                     Development frameworks:
+  #
+  #                         The WS-PGRADE Portal (Web Services Parallel Grid Runtime and Developer Environment Portal) is a Liferay-based web portal. WS-PGRADE provides a 'job wizard' interface for the user. Through this wizard the user can define, with a few clicks, a computational job that WS-PGRADE will execute on cloud resources of the EGI Applications On Demand infrastructure. The job can be easily scaled up into a parameter study, executing the same simulation on many different input sets. WS-PGRADE takes care of instantiation of a Virtual Machine image for jobs, sending user input for the jobs, and retrieving the results of computations.
+  #                         The Elastic Cloud Computing Cluster (EC3) is a platform that allows creating elastic virtual clusters on top of Infrastructure as a Service (IaaS) providers. Through a 'job wizard' interface, the user can configure the cluster with a pre-defined set of applications that will be deployed in the clouds underpinning the EGI Applications On Demand infrastructure. The installation and the configuration of the cluster are performed by means of the execution of Ansible receipts. The cluster configured by EC3 is private: as soon as it is configured You will have root access to the environment, and can setup and configure the cluster installing additional libraries and software to their needs.
+  #                         The EGI VMOps dashboard,a framework allows users to perform Virtual Machine (VM) management operations on the EGI Federated Cloud. The graphical interfaces of the dashboard allows the user to choose VMs from the AppDB Catalogue, to define an execution topology for them, and then to instantiate them on infrastructure as a service clouds.
+  #
+  #                     Featured use cases:
+  #
+  #                         New viruses implicated in fatal snake disease  how the  platform helped virologists to make sense of millions of virus genomes"
+  #    GNU Octave:
+  #        name: GNU Octave
+  #        parents: *processingAndAnalysisParent
+  #        providers: [*ics, *recas, *cyfro, *begrid, *cesga]
+  #        logo: gnu-octave.png
+  #        open_access: false
+  #        webpage_url: https://www.gnu.org/software/octave/
+  #        manual_url: https://octave.org/doc/interpreter/
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        language_availability: *english
+  #        geographical_availabilities: *poland
+  #        domain: *mathematics
+  #        target_users: ["Researchers", "Research organisations"]
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          GNU Octave is a high-level interpreted language, primarily intended for numerical computations.
+  #          It provides capabilities for the numerical solution of linear and nonlinear problems,
+  #          and for performing other numerical experiments.
+  #        offers:
+  #          1:
+  #            name: GNU Octave
+  #            description: |
+  #              GNU Octave is a high-level interpreted language, primarily intended for numerical computations.
+  #              It provides capabilities for the numerical solution of linear and nonlinear problems,
+  #              and for performing other numerical experiments.
+  #            parameters: &appParameters
+  #            - id: "id1"
+  #              label: "Number of CPU cores"
+  #              description:  "Number of cores for this offer is constant"
+  #              type:  "attribute"
+  #              value_type:  "integer"
+  #              value: 20
+  #            - id: "id2"
+  #              label: "Total amount of RAM"
+  #              description:  "Amount of RAM for this offer is constant"
+  #              type:  "attribute"
+  #              unit: "GB"
+  #              value_type:  "integer"
+  #              value: 4
+  #            - id: "id3"
+  #              label: "Storage capacity"
+  #              description:  "Storage capacity for this offer is constant"
+  #              type:  "attribute"
+  #              unit: "GB"
+  #              value_type:  "integer"
+  #              value: 100
+  #            - id: "id4"
+  #              label: "Access type"
+  #              description:  "Access type for this offer is constant"
+  #              type:  "attribute"
+  #              value_type:  "string"
+  #              value: "opportunistic"
+  #            - id: "id5"
+  #              label: "Start of service"
+  #              description:  "Choose service start date"
+  #              type:  "date"
+  #              value_type:  "string"
+  #            - id: "id6"
+  #              label: "Number of days"
+  #              description:  "Choose service start date"
+  #              type:  "input"
+  #              value_type:  "integer"
+  #              value: 365
+  #              config:
+  #                minimum: 1
+  #                maximum: 730
+  #
+  #
+  #    Galaxy:
+  #        name: Galaxy
+  #        parents: *processingAndAnalysisParent
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: galaxy.png
+  #        open_access: false
+  #        webpage_url:
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *otherOther
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          Galaxy is an open, web-based platform for data-intensive biomedical research.
+  #        offers:
+  #          1:
+  #            name: Galaxy
+  #            description: Galaxy is an open, web-based platform for data-intensive biomedical research.
+  #            parameters: *appParameters
+  #    NAMD:
+  #        name: NAMD
+  #        parents: *processingAndAnalysisParent
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: namd.png
+  #        open_access: false
+  #        webpage_url:
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *other
+  ##        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        platforms: [*egiPlatform, *ec3, *aodp]
+  #        description: |
+  #          NAMD is a parallel molecular dynamics code designed for high-performance simulation
+  #          of large bio-molecular systems.
+  #        offers:
+  #          1:
+  #            name: NAMD
+  #            description: |
+  #              NAMD is a parallel molecular dynamics code designed for high-performance simulation
+  #              of large bio-molecular systems.
+  #            parameters: &appParameters
+  #            - id: "id1"
+  #              label: "Number of CPU cores"
+  #              description:  "Number of cores for this offer is constant"
+  #              type:  "attribute"
+  #              value_type:  "integer"
+  #              value: 20
+  #            - id: "id2"
+  #              label: "Total amount of RAM"
+  #              description:  "Amount of RAM for this offer is constant"
+  #              type:  "attribute"
+  #              unit: "GB"
+  #              value_type:  "integer"
+  #              value: 4
+  #            - id: "id3"
+  #              label: "Storage capacity"
+  #              description:  "Storage capacity for this offer is constant"
+  #              type:  "attribute"
+  #              unit: "GB"
+  #              value_type:  "integer"
+  #              value: 100
+  #            - id: "id4"
+  #              label: "Access type"
+  #              description:  "Access type for this offer is constant"
+  #              type:  "attribute"
+  #              value_type:  "string"
+  #              value: "opportunistic"
+  #            - id: "id5"
+  #              label: "Start of service"
+  #              description:  "Choose service start date"
+  #              type:  "date"
+  #              value_type:  "string"
+  #            - id: "id6"
+  #              label: "Number of days"
+  #              description:  "Choose service start date"
+  #              type:  "range"
+  #              value_type:  "integer"
+  #              value: 365
+  #              config:
+  #                minimum: 1
+  #                maximum: 730
+  #    Apache Tomcat:
+  #        name: Apache Tomcat
+  #        parents: *networkingParent
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: apache-tomcat.png
+  #        open_access: false
+  #        webpage_url:
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *earthAndEnvironmentalScience
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: |
+  #          Applications on Demand gives you access to online applications and application-development
+  #          and hosting frameworks to support compute-intensive data analysis
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          Apache Tomcat is an open source implementation of the Java Servlet, JavaServer Pages,
+  #          Java Expression Language and Java WebSocket technologies.
+  #        offers:
+  #          1:
+  #            name: Apache Tomcat
+  #            description: |
+  #              Apache Tomcat is an open source implementation of the Java Servlet, JavaServer Pages,
+  #              Java Expression Language and Java WebSocket technologies.
+  #            parameters: *appParameters
+  #    Gnuplot:
+  #        name: Gnuplot
+  #        parents: *processingAndAnalysisParent
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: gnuplot.png
+  #        open_access: false
+  #        webpage_url: http://gnuplot.sourceforge.net
+  #        manual_url: http://gnuplot.sourceforge.net/documentation.html
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *otherOther
+  ##        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        platforms: [*egiPlatform, *ec3, *aodp]
+  #        description: |
+  #          Gnuplot is a portable command-line driven graphing utility for Linux,
+  #          OS/2, MS Windows, OSX, VMS, and other platforms.
+  #        offers:
+  #          1:
+  #            name: Gnuplot
+  #            description: |
+  #              Gnuplot is a portable command-line driven graphing utility for Linux,
+  #              OS/2, MS Windows, OSX, VMS, and other platforms.
+  #            parameters: *appParameters
+  #    Docker:
+  #        name: Docker
+  #        parents: *networkingParent
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: docker.png
+  #        open_access: false
+  #        webpage_url: https://www.docker.com/
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *applicationFrameworks
+  #        #restrictions: *notSpecified
+  #        phase: production
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          Docker is an open-source project that automates the deployment of Linux applications inside software containers.
+  #        offers:
+  #          1:
+  #            name: Docker
+  #            description: |
+  #              Docker is an open-source project that automates the deployment
+  #              of Linux applications inside software containers.
+  #            parameters: *appParameters
+  #    Hadoop:
+  #        name: Hadoop
+  #        parents: *processingAndAnalysisParent
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: hadoop.png
+  #        open_access: false
+  #        webpage_url: http://hadoop.apache.org/
+  #        manual_url: http://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *applicationFrameworks
+  ##        #restrictions: *notSpecified
+  #        phase: production
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        platforms: [*egiPlatform, *ec3, *aodp]
+  #        description: |
+  #          Hadoop is a framework that allows for the distributed processing
+  #          of large data sets across clusters of computers using simple programming models.
+  #        offers:
+  #          1:
+  #            name: Hadoop
+  #            description: |
+  #              Hadoop is a framework that allows for the distributed processing
+  #              of large data sets across clusters of computers using simple programming models.
+  #            parameters: *appParameters
+  #    Marathon:
+  #        name: Marathon
+  #        parents: *dataManagementParent
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: marathon.png
+  #        open_access: false
+  #        webpage_url: https://mesosphere.github.io/marathon/
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *applicationFrameworks
+  ##        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        platforms: [*egiPlatform, *ec3, *aodp]
+  #        description: |
+  #          Marathon a production-grade container orchestration platform
+  #          for Mesosphere's Data Center/Operating System (DC/OS) and Apache Mesos.
+  #        offers:
+  #          1:
+  #            name: Marathon
+  #            description: |
+  #              Marathon a production-grade container orchestration platform
+  #              for Mesosphere's Data Center/Operating System (DC/OS) and Apache Mesos.
+  #            parameters: *appParameters
+  #    Chronos:
+  #        name: Chronos
+  #        open_access: false
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: chronos.png
+  #        parents: *processingAndAnalysisParent
+  #        webpage_url: https://github.com/mesos/chronos
+  #        manual_url: https://mesos.github.io/chronos/
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *applicationFrameworks
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          Chronos is a distributed and fault-tolerant scheduler that runs on top
+  #          of Apache Mesos that can be used for job orchestration.
+  #        offers:
+  #          1:
+  #            name: Chronos
+  #            description: |
+  #              Chronos is a distributed and fault-tolerant scheduler that runs on top
+  #              of Apache Mesos that can be used for job orchestration.
+  #            parameters: *appParameters
 
 
-#    The R project for statistical computing:
-#        name: The R project for statistical computing
-#        parents: *processingAndAnalysisParent
-#        providers: [*infnc, *infnb, *cyfro, *begrid, *cesga]
-#        logo: the-r-project-for-statistical-computing.png
-#        open_access: false
-#        webpage_url: https://www.r-project.org
-#        manual_url: https://cran.r-project.org/manuals.html
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *dataAnalysis
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          The R Project for Statistical Computing (v3.2.2)
-#          is a language and environment for statistical computing and graphics.
-#        offers:
-#          1:
-#            name: The R project for statistical computing
-#            description: |
-#              The R Project for Statistical Computing (v3.2.2)
-#              is a language and environment for statistical computing and graphics.
-#            parameters: *appParameters
-#    The Semantic Search Engine (SSE):
-#        name: The Semantic Search Engine (SSE)
-#        parents: *dataManagementParent
-#        providers: [*infnc, *infnb, *cyfro, *begrid, *cesga]
-#        logo: the-semantic-search-engine-sse.png
-#        open_access: false
-#        webpage_url:
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *otherHumanities
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        platforms: [*egiPlatform, *ec3, *aodp]
-#        description: |
-#          The Semantic Search Engine (SSE) is an application conceived to demonstrate the potential of information
-#          coupled with semantic web technologies to address the issues of data discovery and correlation.
-#        offers:
-#          1:
-#            name: The Semantic Search Engine (SSE)
-#            description: |
-#              The Semantic Search Engine (SSE) is an application conceived to demonstrate the potential of information
-#              coupled with semantic web technologies to address the issues of data discovery and correlation.
-#            parameters: *appParameters
-    Chipster:
-        name: &chipster Chipster
-        parents: *processingAndAnalysisParent
-        providers: [*infn, *csc]
-        logo: chipster.png
-        open_access: false
-        webpage_url: https://csgf.egi.eu/
-        manual_url: https://csgf.egi.eu/documents/620030/0/csg_manual_for_ltos.pdf/be218ad7-8a0d-42b7-b932-4b7667524c09
-        helpdesk_url:
-        training_information_url:
-        #contact: applications-platform-info@mailman.egi.eu
-        terms_of_use_url: https://csgf.egi.eu/terms-of-use
-        sla_url: https://documents.egi.eu/document/2733
-        access_policies_url: https://documents.egi.eu/public/ShowDocument?docid=2635
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *business]
-        domain: *otherOther
-        restrictions: "Research affiliation needed"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: NGS and microarray analysis in the cloud.
-        platforms: [*eoscHub, *aodp]
+  #    The R project for statistical computing:
+  #        name: The R project for statistical computing
+  #        parents: *processingAndAnalysisParent
+  #        providers: [*infnc, *infnb, *cyfro, *begrid, *cesga]
+  #        logo: the-r-project-for-statistical-computing.png
+  #        open_access: false
+  #        webpage_url: https://www.r-project.org
+  #        manual_url: https://cran.r-project.org/manuals.html
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *dataAnalysis
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          The R Project for Statistical Computing (v3.2.2)
+  #          is a language and environment for statistical computing and graphics.
+  #        offers:
+  #          1:
+  #            name: The R project for statistical computing
+  #            description: |
+  #              The R Project for Statistical Computing (v3.2.2)
+  #              is a language and environment for statistical computing and graphics.
+  #            parameters: *appParameters
+  #    The Semantic Search Engine (SSE):
+  #        name: The Semantic Search Engine (SSE)
+  #        parents: *dataManagementParent
+  #        providers: [*infnc, *infnb, *cyfro, *begrid, *cesga]
+  #        logo: the-semantic-search-engine-sse.png
+  #        open_access: false
+  #        webpage_url:
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *otherHumanities
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        platforms: [*egiPlatform, *ec3, *aodp]
+  #        description: |
+  #          The Semantic Search Engine (SSE) is an application conceived to demonstrate the potential of information
+  #          coupled with semantic web technologies to address the issues of data discovery and correlation.
+  #        offers:
+  #          1:
+  #            name: The Semantic Search Engine (SSE)
+  #            description: |
+  #              The Semantic Search Engine (SSE) is an application conceived to demonstrate the potential of information
+  #              coupled with semantic web technologies to address the issues of data discovery and correlation.
+  #            parameters: *appParameters
+  Chipster:
+    name: &chipster Chipster
+    parents: *processingAndAnalysisParent
+    providers: [ *infn, *csc ]
+    logo: chipster.png
+    open_access: false
+    webpage_url: https://csgf.egi.eu/
+    manual_url: https://csgf.egi.eu/documents/620030/0/csg_manual_for_ltos.pdf/be218ad7-8a0d-42b7-b932-4b7667524c09
+    helpdesk_url:
+    training_information_url:
+    #contact: applications-platform-info@mailman.egi.eu
+    terms_of_use_url: https://csgf.egi.eu/terms-of-use
+    sla_url: https://documents.egi.eu/document/2733
+    access_policies_url: https://documents.egi.eu/public/ShowDocument?docid=2635
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *business ]
+    domain: *otherOther
+    restrictions: "Research affiliation needed"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: NGS and microarray analysis in the cloud.
+    platforms: [ *eoscHub, *aodp ]
+    description: |
+      Chipster is a user-friendly analysis software for high-throughput data.
+      It contains over 300 analysis tools for next generation sequencing (NGS),
+      microarray, proteomics and sequence data.
+      Users can save and share automatic analysis workflows, and visualize data interactively using
+      a built-in genome browser and many other visualizations.
+
+      ### Features:
+
+
+        - Federated authentication through the EGI Applications on Demand service.
+
+        - Web based access.
+
+        - Execution of analysis tools from the Chipster toolbox.
+    offers:
+      1:
+        name: Chipster
         description: |
           Chipster is a user-friendly analysis software for high-throughput data.
           It contains over 300 analysis tools for next generation sequencing (NGS),
@@ -3454,2174 +3517,2156 @@ services:
           Users can save and share automatic analysis workflows, and visualize data interactively using
           a built-in genome browser and many other visualizations.
 
-          ### Features:
 
+  #    ClustalW2:
+  #        name: ClustalW2
+  #        parents: *processingAndAnalysisParent
+  #        providers: [*infnc, *infnb, *cyfro, *begrid, *cesga]
+  #        logo: clustalw2.png
+  #        open_access: false
+  #        webpage_url: http://www.clustal.org/clustal2/
+  #        manual_url: http://www.clustal.org/clustal2/#Documentation
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *otherOther
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          ClustalW2 is a multiple sequence alignment tool for the alignment of DNA or protein sequences.
+  #        offers:
+  #          1:
+  #            name: ClustalW2
+  #            description: ClustalW2 is a multiple sequence alignment tool for the alignment of DNA or protein sequences.
+  #            parameters: *appParameters
+  #    AutoDock Vina:
+  #        name: AutoDock Vina
+  #        parents: *processingAndAnalysisParent
+  #        providers: [*cesga, *recas, *ics]
+  #        logo: autodock-vina.png
+  #        open_access: false
+  #        webpage_url:
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers", "Research organisations"]
+  #        domain: *otherOther
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: |
+  #          Applications on Demand gives you access to online applications and application-development
+  #          and hosting frameworks to support compute-intensive data analysis
+  #        # platforms: [*eopillar, *ec3]
+  #        description: |
+  #          AutoDock Vina is an open-source software for doing molecular docking.
+  #        offers:
+  #          1:
+  #            name: AutoDock Vina
+  #            description: AutoDock Vina is an open-source software for doing molecular docking.
+  #            parameters: *appParameters
+  EGI Notebooks:
+    pid: egi-fed.notebook
+    name: &notebook EGI Notebooks
+    parents: *processingAndAnalysisParent
+    providers: [ *egi ]
+    open_access: false
+    webpage_url: https://www.egi.eu/services/notebooks/
+    manual_url: https://wiki.egi.eu/wiki/EGI_Notebooks
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    target_users: [ *researchers, *research_organisations ]
+    language_availability: *english
+    domain: *otherOther
+    geographical_availabilities: *poland
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Create interactive documents with live code, visualisations and narrative text powered by the Jupyter technology
+    platforms: [ *egiPlatform ]
+    description: |
+      The service provides a browser-based tool for interactive analysis of data using EGI storage
+      and compute infrastructures based on the JupyterHub technology. The notebooks can combine text,
+      mathematics, computations and their rich media output using Jupyter technology, and can scale
+      to multiple servers and multiple users (hub) with the EGI cloud service.
 
-            - Federated authentication through the EGI Applications on Demand service.
+      ### The service is proposed in two options:
 
-            - Web based access.
-
-            - Execution of analysis tools from the Chipster toolbox.
-        offers:
-          1:
-            name: Chipster
-            description: |
-              Chipster is a user-friendly analysis software for high-throughput data.
-              It contains over 300 analysis tools for next generation sequencing (NGS),
-              microarray, proteomics and sequence data.
-              Users can save and share automatic analysis workflows, and visualize data interactively using
-              a built-in genome browser and many other visualizations.
-
-
-#    ClustalW2:
-#        name: ClustalW2
-#        parents: *processingAndAnalysisParent
-#        providers: [*infnc, *infnb, *cyfro, *begrid, *cesga]
-#        logo: clustalw2.png
-#        open_access: false
-#        webpage_url: http://www.clustal.org/clustal2/
-#        manual_url: http://www.clustal.org/clustal2/#Documentation
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *otherOther
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Applications on Demand gives you access to online applications and application-development and hosting frameworks to support compute-intensive data analysis
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          ClustalW2 is a multiple sequence alignment tool for the alignment of DNA or protein sequences.
-#        offers:
-#          1:
-#            name: ClustalW2
-#            description: ClustalW2 is a multiple sequence alignment tool for the alignment of DNA or protein sequences.
-#            parameters: *appParameters
-#    AutoDock Vina:
-#        name: AutoDock Vina
-#        parents: *processingAndAnalysisParent
-#        providers: [*cesga, *recas, *ics]
-#        logo: autodock-vina.png
-#        open_access: false
-#        webpage_url:
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers", "Research organisations"]
-#        domain: *otherOther
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: |
-#          Applications on Demand gives you access to online applications and application-development
-#          and hosting frameworks to support compute-intensive data analysis
-#        # platforms: [*eopillar, *ec3]
-#        description: |
-#          AutoDock Vina is an open-source software for doing molecular docking.
-#        offers:
-#          1:
-#            name: AutoDock Vina
-#            description: AutoDock Vina is an open-source software for doing molecular docking.
-#            parameters: *appParameters
-    EGI Notebooks:
-      pid: egi-fed.notebook
-      name: &notebook EGI Notebooks
-      parents: *processingAndAnalysisParent
-      providers: [*egi]
-      open_access: false
-      webpage_url: https://www.egi.eu/services/notebooks/
-      manual_url: https://wiki.egi.eu/wiki/EGI_Notebooks
-      helpdesk_url:
-      training_information_url:
-      terms_of_use_url:
-      sla_url:
-      access_policies_url:
-      target_users: [*researchers, *research_organisations]
-      language_availability: *english
-      domain: *otherOther
-      geographical_availabilities: *poland
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: Create interactive documents with live code, visualisations and narrative text powered by the Jupyter technology
-      platforms: [*egiPlatform]
-      description: |
-        The service provides a browser-based tool for interactive analysis of data using EGI storage
-        and compute infrastructures based on the JupyterHub technology. The notebooks can combine text,
-        mathematics, computations and their rich media output using Jupyter technology, and can scale
-        to multiple servers and multiple users (hub) with the EGI cloud service.
-
-        ### The service is proposed in two options:
-
-          1. For individual users EGI hosts and offers a JupyterHub within the Applications On Demand Service.
-          Users (after lightweight approval) can login, write and play notebooks
-          using storage and compute capacity from the access.egi.eu VO.
-          2. For user communities EGI offers consultancy and technology
-          to setup a community-specific JupyterHub on top of community VO
-          (together with EGI-enbled compute and storage resources), and with community-specific storage/data.
-      offers:
-        1:
-          name: "AoD/Catch-all"
-          description: Run your own notebooks with persistent storage on EGI Cloud resources.
-          parameters:
-            - id:  "id1"
-              label:  "Amount of RAM"
-              description:  "Please choose amount of RAM"
-              type:  "select"
-              unit: "GB"
-              value_type:  "integer"
-              config:
-                mode: "buttons"
-                values: [0.5, 1]
-            - id:  "id2"
-              label:  "Number of cores"
-              description:  "Choose number of cores"
-              type:  "select"
-              value_type:  "integer"
-              config:
-                mode: "buttons"
-                values: [1, 2, 4]
-            - id:  "id3"
-              label:  "Persistent storage"
-              unit: "GB"
-              description:  "Choose amount of storage"
-              type:  "select"
-              value_type:  "integer"
-              config:
-                mode: "buttons"
-                values: [1, 10, 20]
-        2:
-          name: Community Notebook
-          description: |
-            Community specific deployment to provide notebooks for all the users of a community.
-            Allows further customisation to meet the community needs (e.g. shared storage)
-          parameters:
-            - id:  "id1"
-              label:  "Number of users"
-              description:  "Please type number of users"
-              type:  "range"
-              value_type:  "integer"
-              config:
-                minimum: 1
-                maximum: 99999
-            - id:  "id2"
-              label:  "Amount of RAM"
-              description:  "Please choose amount of RAM"
-              type:  "input"
-              unit: "GB"
-              value_type:  "integer"
-            - id:  "id3"
-              label:  "Number of cores per user"
-              description:  "Choose number of cores"
-              type:  "select"
-              value_type:  "integer"
-              config:
-                mode: "buttons"
-                values: [1, 2, 4]
-            - id:  "id4"
-              label:  "Storage per user"
-              unit: "GB"
-              description:  "Choose amount of storage"
-              type:  "input"
-              value_type:  "integer"
-#    Component Metadata Infrastructure:
-#        name: Component Metadata Infrastructure
-#        parents: *thematicServicesParent
-#        providers: [*not]
-#        open_access: false
-#        webpage_url: https://www.clarin.eu/content/component-metadata
-#        manual_url: https://www.clarin.eu/content/component-metadata
-#        helpdesk_url: https://www.clarin.eu/content/support
-#        training_information_url: https://www.eosc-hub.eu/training-material/component-metadata-infrastructure-services
-#        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-#        sla_url:
-#        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers"] #TODO: but not specified
-#        domain: *otherOther
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: Services for Social Sciences and Humanities provided via the national CLARIN centres
-#        description: |
-#          CLARIN-ERIC is a consortium of national service providers dedicated to Social Sicences and Humanities. The CLARIN Metadata Infrastructure offers several services through EOSC-hub:
-#
-#            - The Virtual Language Observatory
-#            - The Virtual Collection Registry
-#            - The Language Resource Switchboard
-#
-#          ### How to access the services:
-#
-#          The services are freely available online.
-#
-#          ### Service provided by
-#
-#          The majority of the CMI service components were developed at the CLARIN ERIC.
-#
-#          CMI will rely on and connect to the following EOSC-hub services:
-#
-#            - INDIGO-DataCloud components, currently used by the DARIAH community), in the context of providing interoperable metadata for (digital) humanities between CLARIN and DARIAH.
-#            - EGI Federated Cloud, e.g. through the hosting of services at the CESNET computing centre.
-#            - EUDAT, by the integration with several services, such as B2SHARE, B2ACCESS and B2DROP.
-
-    DARIAH:
-        name: &dariah DARIAH Science Gateway
-        parents: *processingAndAnalysisParent
-        providers: [*rbi]
-        logo: dariah.png
-        open_access: false
-        webpage_url: https://dariah-gateway.lpds.sztaki.hu/
-        manual_url: https://dariah-gateway.lpds.sztaki.hu/help2
-        helpdesk_url: https://www.dariah.eu/contact
-        training_information_url: https://www.dariah.eu/tools-services/dariah-training/
-        terms_of_use_url:
-        sla_url:
-        access_policies_url: https://www.dariah.eu/privacy-notice/
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: *otherHumanities
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: The DARIAH Science Gateway is a platform that provides access to various digital applications and services for the Arts & Humanities researchers
-        # platforms: [*eopillar, *ec3]
+        1. For individual users EGI hosts and offers a JupyterHub within the Applications On Demand Service.
+        Users (after lightweight approval) can login, write and play notebooks
+        using storage and compute capacity from the access.egi.eu VO.
+        2. For user communities EGI offers consultancy and technology
+        to setup a community-specific JupyterHub on top of community VO
+        (together with EGI-enbled compute and storage resources), and with community-specific storage/data.
+    offers:
+      1:
+        name: "AoD/Catch-all"
+        description: Run your own notebooks with persistent storage on EGI Cloud resources.
+        parameters:
+          - id: "id1"
+            label: "Amount of RAM"
+            description: "Please choose amount of RAM"
+            type: "select"
+            unit: "GB"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 0.5, 1 ]
+          - id: "id2"
+            label: "Number of cores"
+            description: "Choose number of cores"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 1, 2, 4 ]
+          - id: "id3"
+            label: "Persistent storage"
+            unit: "GB"
+            description: "Choose amount of storage"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 1, 10, 20 ]
+      2:
+        name: Community Notebook
         description: |
-          The DARIAH Science Gateway provides various web-based applications and services for the Digital Humanities researchers, institutes and communities.
+          Community specific deployment to provide notebooks for all the users of a community.
+          Allows further customisation to meet the community needs (e.g. shared storage)
+        parameters:
+          - id: "id1"
+            label: "Number of users"
+            description: "Please type number of users"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 99999
+          - id: "id2"
+            label: "Amount of RAM"
+            description: "Please choose amount of RAM"
+            type: "input"
+            unit: "GB"
+            value_type: "integer"
+          - id: "id3"
+            label: "Number of cores per user"
+            description: "Choose number of cores"
+            type: "select"
+            value_type: "integer"
+            config:
+              mode: "buttons"
+              values: [ 1, 2, 4 ]
+          - id: "id4"
+            label: "Storage per user"
+            unit: "GB"
+            description: "Choose amount of storage"
+            type: "input"
+            value_type: "integer"
+  #    Component Metadata Infrastructure:
+  #        name: Component Metadata Infrastructure
+  #        parents: *thematicServicesParent
+  #        providers: [*not]
+  #        open_access: false
+  #        webpage_url: https://www.clarin.eu/content/component-metadata
+  #        manual_url: https://www.clarin.eu/content/component-metadata
+  #        helpdesk_url: https://www.clarin.eu/content/support
+  #        training_information_url: https://www.eosc-hub.eu/training-material/component-metadata-infrastructure-services
+  #        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+  #        sla_url:
+  #        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers"] #TODO: but not specified
+  #        domain: *otherOther
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: Services for Social Sciences and Humanities provided via the national CLARIN centres
+  #        description: |
+  #          CLARIN-ERIC is a consortium of national service providers dedicated to Social Sicences and Humanities. The CLARIN Metadata Infrastructure offers several services through EOSC-hub:
+  #
+  #            - The Virtual Language Observatory
+  #            - The Virtual Collection Registry
+  #            - The Language Resource Switchboard
+  #
+  #          ### How to access the services:
+  #
+  #          The services are freely available online.
+  #
+  #          ### Service provided by
+  #
+  #          The majority of the CMI service components were developed at the CLARIN ERIC.
+  #
+  #          CMI will rely on and connect to the following EOSC-hub services:
+  #
+  #            - INDIGO-DataCloud components, currently used by the DARIAH community), in the context of providing interoperable metadata for (digital) humanities between CLARIN and DARIAH.
+  #            - EGI Federated Cloud, e.g. through the hosting of services at the CESNET computing centre.
+  #            - EUDAT, by the integration with several services, such as B2SHARE, B2ACCESS and B2DROP.
 
-          ### Features:
+  DARIAH:
+    name: &dariah DARIAH Science Gateway
+    parents: *processingAndAnalysisParent
+    providers: [ *rbi ]
+    logo: dariah.png
+    open_access: false
+    webpage_url: https://dariah-gateway.lpds.sztaki.hu/
+    manual_url: https://dariah-gateway.lpds.sztaki.hu/help2
+    helpdesk_url: https://www.dariah.eu/contact
+    training_information_url: https://www.dariah.eu/tools-services/dariah-training/
+    terms_of_use_url:
+    sla_url:
+    access_policies_url: https://www.dariah.eu/privacy-notice/
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: *otherHumanities
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: The DARIAH Science Gateway is a platform that provides access to various digital applications and services for the Arts & Humanities researchers
+    # platforms: [*eopillar, *ec3]
+    description: |
+      The DARIAH Science Gateway provides various web-based applications and services for the Digital Humanities researchers, institutes and communities.
 
-          The DARIAH Science Gateway offers easy access to the following applications:
+      ### Features:
 
-            - Simple Semantic Search Engine (SSE): Allows users to search in the
-            e-Infrastructure Knowledge Base (Open Access Document Repositories and Data Repositories).
-            - Parallel Semantic Search Engine (PSSE): A parallelised version of SSE enabling simultaneously
-            search across the e-Infrastructure Knowledge Base, Europeana, Cultura Italia, Isidore, OpenAgris,
-            PubMed and DBpedia platforms.
-            - DBO@Cloud: A Cloud-based repository presenting 100+ years old collection of Bavarian dialects.
-            - Cloud Access service: Single-job applications and parameter-sweep applications can be run on
-            the DARIAH VO clouds without porting efforts.
-            - Workflow Development service: Complex workflow applications can be developed and run
-            on all the resources of the DARIAH VO.
-            - File transfer service: Enables transferring data from, to and between storage services providing HTTP,
-            HTTPS, SFTP, GSIFTP, SRM, iRODS and S3 protocols.
-        offers:
-          1:
-            name: DARIAH
-            description: |
-              The DARIAH Science Gateway is a platform that provides access to various digital applications
-              and services for the Arts & Humanities researchers.
-              The DARIAH Science Gateway provides various web-based applications and services
-              for the Digital Humanities researchers, institutes and communities.
-            parameters:
-              - id:  "id1"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-    Dynamic On Demand Analysis Service:
-        name: Dynamic On Demand Analysis Service (DODAS Portal)
-        parents: *processingAndAnalysisParent
-        providers: [*infn]
-        logo: dynamic-on-demand-analysis-service.png
-        open_access: false
-        webpage_url: https://dodas-iam.cloud.cnaf.infn.it/login
-        manual_url: https://dodas-ts.github.io/dodas-doc/
-        helpdesk_url:
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: &highEnergyPhysics High-Energy Physics
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Simplify the access and management of computing resources
-        # platforms: [*eopillar, *ec3]
+      The DARIAH Science Gateway offers easy access to the following applications:
+
+        - Simple Semantic Search Engine (SSE): Allows users to search in the
+        e-Infrastructure Knowledge Base (Open Access Document Repositories and Data Repositories).
+        - Parallel Semantic Search Engine (PSSE): A parallelised version of SSE enabling simultaneously
+        search across the e-Infrastructure Knowledge Base, Europeana, Cultura Italia, Isidore, OpenAgris,
+        PubMed and DBpedia platforms.
+        - DBO@Cloud: A Cloud-based repository presenting 100+ years old collection of Bavarian dialects.
+        - Cloud Access service: Single-job applications and parameter-sweep applications can be run on
+        the DARIAH VO clouds without porting efforts.
+        - Workflow Development service: Complex workflow applications can be developed and run
+        on all the resources of the DARIAH VO.
+        - File transfer service: Enables transferring data from, to and between storage services providing HTTP,
+        HTTPS, SFTP, GSIFTP, SRM, iRODS and S3 protocols.
+    offers:
+      1:
+        name: DARIAH
         description: |
-          DODAS acts as cloud enabler designed for scientists seeking to easily exploit distributed
-          and heterogeneous clouds to process data. Aiming to reduce the learning curve as well as
-          the operational cost of managing community specific services running on distributed cloud,
-          DODAS completely automates the process of provisioning, creating, managing and accessing
-          a pool of heterogeneous computing and storage resources.
+          The DARIAH Science Gateway is a platform that provides access to various digital applications
+          and services for the Arts & Humanities researchers.
+          The DARIAH Science Gateway provides various web-based applications and services
+          for the Digital Humanities researchers, institutes and communities.
+        parameters:
+          - id: "id1"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id2"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  Dynamic On Demand Analysis Service:
+    name: Dynamic On Demand Analysis Service (DODAS Portal)
+    parents: *processingAndAnalysisParent
+    providers: [ *infn ]
+    logo: dynamic-on-demand-analysis-service.png
+    open_access: false
+    webpage_url: https://dodas-iam.cloud.cnaf.infn.it/login
+    manual_url: https://dodas-ts.github.io/dodas-doc/
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: &highEnergyPhysics High-Energy Physics
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Simplify the access and management of computing resources
+    # platforms: [*eopillar, *ec3]
+    description: |
+      DODAS acts as cloud enabler designed for scientists seeking to easily exploit distributed
+      and heterogeneous clouds to process data. Aiming to reduce the learning curve as well as
+      the operational cost of managing community specific services running on distributed cloud,
+      DODAS completely automates the process of provisioning, creating, managing and accessing
+      a pool of heterogeneous computing and storage resources.
 
-          ### DODAS provides:
+      ### DODAS provides:
 
-            - A comprehensive approach to opportunistic computing, with the possibility of
-            orchestrate multiple centers (e.g. campus facilities, public or private clouds,
-            to gather all available computing and storage resources).
-            - A simple solution for elastic computing site extensions, e.g. extension
-            of allocated resources in order to absorb peaks of usage.
-            - An easy and controlled procedure to dynamically instantiate a spot ‘Data Analysis Facility’,
-            for example a mission specific site. This is meant as the generation of an ephemeral WLCG-Tier
-            as a Service to share computing and data resources with collaborators.
-            - The support to create HTCondor batch systems and BigData Platform
-            on demand over multi-backend IaaS cloud resources.
-
-
-          ### How to access the service
-
-          To access the DODAS service, users are first required to [register online][1].
+        - A comprehensive approach to opportunistic computing, with the possibility of
+        orchestrate multiple centers (e.g. campus facilities, public or private clouds,
+        to gather all available computing and storage resources).
+        - A simple solution for elastic computing site extensions, e.g. extension
+        of allocated resources in order to absorb peaks of usage.
+        - An easy and controlled procedure to dynamically instantiate a spot ‘Data Analysis Facility’,
+        for example a mission specific site. This is meant as the generation of an ephemeral WLCG-Tier
+        as a Service to share computing and data resources with collaborators.
+        - The support to create HTCondor batch systems and BigData Platform
+        on demand over multi-backend IaaS cloud resources.
 
 
-          ### See the online manual:
+      ### How to access the service
 
-          https://dodas.gitbook.io/dynamic-on-demand-analysis-service
+      To access the DODAS service, users are first required to [register online][1].
 
 
-          ### Service provided by
+      ### See the online manual:
 
-          The service is provided by the Italian National Institute of Nuclear Physics (INFN).
+      https://dodas.gitbook.io/dynamic-on-demand-analysis-service
 
-          The DODAS service builds on EOSC-hub services developed during the INDIGO-DataCloud project
-          (Identity Access Management - IAM, Token Translation Service - TTS, PaaS Orchestration, TOSCA Templates).
 
-          [1]: https://dodas-iam.cloud.cnaf.infn.it/register
-        offers:
-          1:
-            name: DODAS Portal
-            description: |
-              The Dynamic On Demand Analysis Service (DODAS) allows to instantiate on-demand container-based clusters.
-              Both HTCondor batch systems, and platforms for Big Data analysis based for example on Spark or Hadoop,
-              can be deployed on any cloud-based infrastructures with almost zero effort.
-            parameters:
-              - id:  "id1"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-    D4 Science Particle Formation:
-        name: &d4scienceService New Particle Formation Event Analysis
-        parents: *processingAndAnalysisParent
-        providers: [*d4science, *egi, *smartSmear]
-        logo: vre.png
-        open_access: true
-        webpage_url: https://services.d4science.org/web/particleformation/
-        manual_url: https://github.com/markusstocker/pynpf-d4science
-        helpdesk_url: https://github.com/markusstocker/pynpf-d4science
-        training_information_url: https://youtu.be/ra9W7b5DbgI
-        terms_of_use_url: https://documents.egi.eu/public/ShowDocument?docid=2623
-        sla_url: https://documents.egi.eu/document/2875
-        access_policies_url: https://wiki.d4science.org/index.php?title=D4Science_Deployment_and_Operation:_Policies
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: *earthAndEnvironmentalScience
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: D4Science Service
-        platforms: [*egiPlatform, *d4sciencePlatform]
+      ### Service provided by
+
+      The service is provided by the Italian National Institute of Nuclear Physics (INFN).
+
+      The DODAS service builds on EOSC-hub services developed during the INDIGO-DataCloud project
+      (Identity Access Management - IAM, Token Translation Service - TTS, PaaS Orchestration, TOSCA Templates).
+
+      [1]: https://dodas-iam.cloud.cnaf.infn.it/register
+    offers:
+      1:
+        name: DODAS Portal
         description: |
-          The VRE supports new particle formation event analysis on interoperable e-Infrastructures.
-          It provides access to Jupyter notebooks to classify events and process information about them.
-          It integrates the SMEAR Research Infrastructure (provider of primary data) and uses EGI
-          and D4Science services to support primary data interpretation and the cataloging of data derived in analysis.
-          Access to the VRE requires a D4Science account.
-        offers:
-          1:
-            name: New Particle Formation Event Analysis
-            description: *notSpecified
-            order_url: https://services.d4science.org/web/particleformation/
-    ENES Climate Analytics Service:
-        name: &enes ENES Climate Analytics Service
-        parents: *processingAndAnalysisParent
-        logo: enes-climate-analytics-service.png
-        providers: [*ccmc, *dkrz]
-        open_access: false
-        webpage_url: https://portal.enes.org/data/data-metadata-service/processing/ecas
-        manual_url:
-        helpdesk_url: https://portal.enes.org/contact
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: *otherOther
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Analyze and process data from multiple communities with the Ophidia Big Data Analytics framework
-        platforms: [*enesPlatform]
+          The Dynamic On Demand Analysis Service (DODAS) allows to instantiate on-demand container-based clusters.
+          Both HTCondor batch systems, and platforms for Big Data analysis based for example on Spark or Hadoop,
+          can be deployed on any cloud-based infrastructures with almost zero effort.
+        parameters:
+          - id: "id1"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id2"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  D4 Science Particle Formation:
+    name: &d4scienceService New Particle Formation Event Analysis
+    parents: *processingAndAnalysisParent
+    providers: [ *d4science, *egi, *smartSmear ]
+    logo: vre.png
+    open_access: true
+    webpage_url: https://services.d4science.org/web/particleformation/
+    manual_url: https://github.com/markusstocker/pynpf-d4science
+    helpdesk_url: https://github.com/markusstocker/pynpf-d4science
+    training_information_url: https://youtu.be/ra9W7b5DbgI
+    terms_of_use_url: https://documents.egi.eu/public/ShowDocument?docid=2623
+    sla_url: https://documents.egi.eu/document/2875
+    access_policies_url: https://wiki.d4science.org/index.php?title=D4Science_Deployment_and_Operation:_Policies
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: *earthAndEnvironmentalScience
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: D4Science Service
+    platforms: [ *egiPlatform, *d4sciencePlatform ]
+    description: |
+      The VRE supports new particle formation event analysis on interoperable e-Infrastructures.
+      It provides access to Jupyter notebooks to classify events and process information about them.
+      It integrates the SMEAR Research Infrastructure (provider of primary data) and uses EGI
+      and D4Science services to support primary data interpretation and the cataloging of data derived in analysis.
+      Access to the VRE requires a D4Science account.
+    offers:
+      1:
+        name: New Particle Formation Event Analysis
+        description: *notSpecified
+        order_url: https://services.d4science.org/web/particleformation/
+  ENES Climate Analytics Service:
+    name: &enes ENES Climate Analytics Service
+    parents: *processingAndAnalysisParent
+    logo: enes-climate-analytics-service.png
+    providers: [ *ccmc, *dkrz ]
+    open_access: false
+    webpage_url: https://portal.enes.org/data/data-metadata-service/processing/ecas
+    manual_url:
+    helpdesk_url: https://portal.enes.org/contact
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Analyze and process data from multiple communities with the Ophidia Big Data Analytics framework
+    platforms: [ *enesPlatform ]
+    description: |
+      Users can define parallel processing workflows, executed remotely without needing
+      to download data or provide own computing resources as these are provided by ECAS.
+      Moreover, users can explore workflows others have created and shared, and apply these to their own data.
+      ECAS enables users to write a workflow once and apply it to diverse data without having to customize it again.
+
+      ### To access the service you need to:
+
+      ECAS is open for use by users interested in working on Earth Sciences data.
+      Available data sources may be different between CMCC and DKRZ.
+
+      To use ECAS and to learn more about the different datasets available,
+      please follow the instructions for registration and access at the two sites:
+
+        - [CMCC][1]
+        - [DKRZ][2]
+
+
+      ### See the online manual:
+
+        - [Ophidia][3]
+        - [More about Ophidia][4]
+        - [ENES][5]
+        - [IS-ENES][6]
+        - [ESGF][7]
+
+      [1]: https://ophidialab.cmcc.it/
+      [2]: https://ecaslab.dkrz.de/
+      [3]: http://ophidia.cmcc.it/
+      [4]: http://ophidia.cmcc.it/documentation/
+      [5]: https://verc.enes.org/
+      [6]: https://is.enes.org/
+      [7]: http://esgf.llnl.gov/
+    offers:
+      1:
+        name: ECAS
         description: |
-          Users can define parallel processing workflows, executed remotely without needing
-          to download data or provide own computing resources as these are provided by ECAS.
-          Moreover, users can explore workflows others have created and shared, and apply these to their own data.
-          ECAS enables users to write a workflow once and apply it to diverse data without having to customize it again.
+          The ENES Climate Analytics Service (ECAS) enables scientific end-users to perform data analysis
+          experiments on large volumes of research data from multiple disciplines.
+        parameters:
+          - id: "id1"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id2"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  LifeWatch ERIC Plants Identification App:
+    name: &lifewatchERICPlants LifeWatch ERIC Plants Identification App
+    parents: *processingAndAnalysisParent
+    providers: [ *lifewatch ]
+    logo: lifewatch-eric-plants-identification-app.png
+    open_access: false
+    webpage_url: https://www.lifewatch.eu/
+    manual_url: https://github.com/IgnacioHeredia/plant_classification/blob/master/webpage/README.md#using-the-api%20
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: *earthAndEnvironmentalScience
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Web service to classify plant pictures based on convolutional neural networks
+    # platforms: [*eopillar, *ec3]
+    description: |
+      This web service connects to a deep neural network which has been trained with thousands
+      of plant images from Europe. It can classify different types of plants, including flowers.
+      The input to be sent to the web service is an image URL or a local image.
+      The response is a JSON with the potential classification (the name of the potential specie),
+      a percentage, link to google images and link to wikipedia.sets.
 
-          ### To access the service you need to:
+      ### How to access the services:
 
-          ECAS is open for use by users interested in working on Earth Sciences data.
-          Available data sources may be different between CMCC and DKRZ.
+      The service is freely available online.
 
-          To use ECAS and to learn more about the different datasets available,
-          please follow the instructions for registration and access at the two sites:
+      The service is provided as a REST API and it uses JSON over HTTP as communication channel. Example:
 
-            - [CMCC][1]
-            - [DKRZ][2]
+      ```
+          curl --data 'mode=url&url_list=https://public-media.smithsonianmag.com/filer/89/47/8947cd5c-ac01-4c0e-891a-505517cc0663/istock-540753808.jpg&url_list=https://cdn.pixabay.com/photo/2014/04/10/11/24/red-rose-320868_960_720.jpg' http://deep.ifca.es/plants/api
+      ```
+
+      ### See the online manual:
+
+      https://github.com/IgnacioHeredia/plant_classification/blob/master/webpage/README.md#using-the-api
 
 
-          ### See the online manual:
+      ### Service provided by
 
-            - [Ophidia][3]
-            - [More about Ophidia][4]
-            - [ENES][5]
-            - [IS-ENES][6]
-            - [ESGF][7]
-
-          [1]: https://ophidialab.cmcc.it/
-          [2]: https://ecaslab.dkrz.de/
-          [3]: http://ophidia.cmcc.it/
-          [4]: http://ophidia.cmcc.it/documentation/
-          [5]: https://verc.enes.org/
-          [6]: https://is.enes.org/
-          [7]: http://esgf.llnl.gov/
-        offers:
-          1:
-            name: ECAS
-            description: |
-              The ENES Climate Analytics Service (ECAS) enables scientific end-users to perform data analysis
-              experiments on large volumes of research data from multiple disciplines.
-            parameters:
-              - id:  "id1"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-    LifeWatch ERIC Plants Identification App:
-        name: &lifewatchERICPlants LifeWatch ERIC Plants Identification App
-        parents: *processingAndAnalysisParent
-        providers: [*lifewatch]
-        logo: lifewatch-eric-plants-identification-app.png
-        open_access: false
-        webpage_url: https://www.lifewatch.eu/
-        manual_url: https://github.com/IgnacioHeredia/plant_classification/blob/master/webpage/README.md#using-the-api%20
-        helpdesk_url:
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: *earthAndEnvironmentalScience
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Web service to classify plant pictures based on convolutional neural networks
-        # platforms: [*eopillar, *ec3]
+      The Service is provided by LifeWatch ERIC.
+    offers:
+      1:
+        name: ERIC
         description: |
-          This web service connects to a deep neural network which has been trained with thousands
-          of plant images from Europe. It can classify different types of plants, including flowers.
-          The input to be sent to the web service is an image URL or a local image.
-          The response is a JSON with the potential classification (the name of the potential specie),
-          a percentage, link to google images and link to wikipedia.sets.
+          Web service for online plant search.
+        parameters:
+          - id: "id1"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id2"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
+  #    ELIXIR Core Data Resources:
+  #        name: ELIXIR Core Data Resources
+  #        parents: *sharingAndDicoveryParent
+  #        providers: [*not]
+  #        open_access: false
+  #        webpage_url:
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers"] #TODO: but not specified
+  #        domain: *otherOther
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: *notSpecified
+  #        platforms: [*elixirPlatform]
+  #        description: *notSpecified
+  #    EISCAT:
+  #        name: EISCAT
+  #        parents: *sharingAndDicoveryParent
+  #        providers: [*not]
+  #        open_access: false
+  #        webpage_url:
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers"] #TODO: but not specified
+  #        domain: *otherOther
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: *notSpecified
+  #        # platforms: [*eopillar, *ec3]
+  #        description: *notSpecified
+  #    LOFAR:
+  #        name: LOFAR
+  #        parents: *sharingAndDicoveryParent
+  #        providers: [*astron, *rug, *surfsara, *fzj, *psnc]
+  #        open_access: false
+  #        webpage_url:
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Researchers"] #TODO: but not specified
+  #        domain: *otherOther
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: *notSpecified
+  #        # platforms: [*eopillar, *ec3]
+  #        description: *notSpecified
+  OPENCoastS:
+    name: &openCoastS OPENCoastS Portal
+    parents: *processingAndAnalysisParent
+    providers: [ *pncel ]
+    logo: opencoasts.png
+    open_access: false
+    webpage_url: https://opencoasts.ncg.ingrid.pt/
+    manual_url: https://opencoasts.ncg.ingrid.pt/static/OPENCoastS_manual.pdf
+    helpdesk_url:
+    training_information_url: https://www.eosc-hub.eu/training-material/opencoasts-service
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: *earthAndEnvironmentalScience
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: On-demand operational coastal circulation forecast service
+    # platforms: [*eopillar, *ec3]
+    description: |
+      OPENCoastS builds on-demand circulation forecast systems for user-selected sections
+      of the North Atlantic coast and maintains them running operationally for the timeframe defined by the user.
+      This daily service generates forecasts of water levels and 2D velocities over the spatial region
+      of interest for periods of 48 hours, based on numerical simulations of the relevant physical processes.
+      Forcing conditions at the boundaries and over the domain are defined by the user
+      from global forecast databases. Automatic comparison with real-time in-situ sensor data can be provided
+      for a number of user specified locations.
 
-          ### How to access the services:
+      It takes advantage of LNEC’s team long-term work on coastal modelling as model developers,
+      integrated in several open source modelling communities (SCHISM, ELCIRC, SELFE, ADCIRC),
+      and in its advanced competences  in developing forecast frameworks and operating forecasts deployments.
 
-          The service is freely available online.
+      ### Users and application potential
 
-          The service is provided as a REST API and it uses JSON over HTTP as communication channel. Example:
+      OPENCoastS can contribute directly to the development of new research methodologies
+      and workflows regarding water quality, biological, biochemical and coastal erosion studies.
 
-          ```
-              curl --data 'mode=url&url_list=https://public-media.smithsonianmag.com/filer/89/47/8947cd5c-ac01-4c0e-891a-505517cc0663/istock-540753808.jpg&url_list=https://cdn.pixabay.com/photo/2014/04/10/11/24/red-rose-320868_960_720.jpg' http://deep.ifca.es/plants/api
-          ```
+      SMEs will benefit from these operational systems to feed their own higher-level service portfolios
+      to respond to other societal needs, without the need
+      to invest time and resources to deploy forecast systems from scratch.
 
-          ### See the online manual:
+      Port and coastal authorities –Through the use of this platform coastal managers have all the information
+      required to fulfill their responsibilities (examples of uses include facilitating navigation,
+      reducing port operation costs, reducing emergency planning and response of coastal hazards,
+      and better exploring recreational uses of the coast).
 
-          https://github.com/IgnacioHeredia/plant_classification/blob/master/webpage/README.md#using-the-api
+
+      ### How to request a service
+
+      To request use of the OPENCoastS, please fill in thee request form and register at
+      https://opencoasts.ncg.ingrid.pt/. After analysis and validation of the request,
+      you will be allowed to log in and start building your forecasts.
 
 
-          ### Service provided by
+      Service provided by
 
-          The Service is provided by LifeWatch ERIC.
-        offers:
-          1:
-            name: ERIC
-            description: |
-              Web service for online plant search.
-            parameters:
-              - id:  "id1"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-#    ELIXIR Core Data Resources:
-#        name: ELIXIR Core Data Resources
-#        parents: *sharingAndDicoveryParent
-#        providers: [*not]
-#        open_access: false
-#        webpage_url:
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers"] #TODO: but not specified
-#        domain: *otherOther
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: *notSpecified
-#        platforms: [*elixirPlatform]
-#        description: *notSpecified
-#    EISCAT:
-#        name: EISCAT
-#        parents: *sharingAndDicoveryParent
-#        providers: [*not]
-#        open_access: false
-#        webpage_url:
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers"] #TODO: but not specified
-#        domain: *otherOther
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: *notSpecified
-#        # platforms: [*eopillar, *ec3]
-#        description: *notSpecified
-#    LOFAR:
-#        name: LOFAR
-#        parents: *sharingAndDicoveryParent
-#        providers: [*astron, *rug, *surfsara, *fzj, *psnc]
-#        open_access: false
-#        webpage_url:
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Researchers"] #TODO: but not specified
-#        domain: *otherOther
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: *notSpecified
-#        # platforms: [*eopillar, *ec3]
-#        description: *notSpecified
-    OPENCoastS:
-        name: &openCoastS OPENCoastS Portal
-        parents: *processingAndAnalysisParent
-        providers: [*pncel]
-        logo: opencoasts.png
-        open_access: false
-        webpage_url: https://opencoasts.ncg.ingrid.pt/
-        manual_url: https://opencoasts.ncg.ingrid.pt/static/OPENCoastS_manual.pdf
-        helpdesk_url:
-        training_information_url: https://www.eosc-hub.eu/training-material/opencoasts-service
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: *earthAndEnvironmentalScience
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: On-demand operational coastal circulation forecast service
-        # platforms: [*eopillar, *ec3]
+      OPENCoastS is provided by the Portuguese National Civil Engineering Laboratory,
+      and was jointly developed by LNEC and LIP.
+
+      Currently, the service is deployed at a single computing site (NCG-INGRID-PT,
+      part of [INCD][1] and the [EGI Federation][2]).
+
+      Through EOSC-hub, OPENCoastS will be expanded to include a more diverse set of geographical data,
+      and improved with integration of new features from the EGI, EUDAT and INDIGO-DataCloud service catalogues.
+
+      [1]: http://www.incd.pt/
+      [2]: https://www.egi.eu/federation/
+    offers:
+      1:
+        name: OPENCoastS Portal
         description: |
-          OPENCoastS builds on-demand circulation forecast systems for user-selected sections
-          of the North Atlantic coast and maintains them running operationally for the timeframe defined by the user.
-          This daily service generates forecasts of water levels and 2D velocities over the spatial region
-          of interest for periods of 48 hours, based on numerical simulations of the relevant physical processes.
-          Forcing conditions at the boundaries and over the domain are defined by the user
-          from global forecast databases. Automatic comparison with real-time in-situ sensor data can be provided
-          for a number of user specified locations.
+          The OPENCoastS service assembles on-demand circulation forecast systems for selected areas
+          in the Atlantic coast and keeps them running operationally for a period defined by the user.
+          This service generates daily forecasts of water levels and vertically averaged velocities
+          over the region of interest for 48 hours.
+          The system is useful in anticipating natural disasters and accidents in the coast,
+          for example floods and chemical spills and can help in search and rescue operations.
+        parameters:
+          - id: "id1"
+            label: "Start of service"
+            description: "Please choose the start date"
+            type: "date"
+            value_type: "string"
+          - id: "id2"
+            label: "Number of days"
+            description: "Choose number of days"
+            type: "input"
+            value_type: "integer"
+            value: 365
 
-          It takes advantage of LNEC’s team long-term work on coastal modelling as model developers,
-          integrated in several open source modelling communities (SCHISM, ELCIRC, SELFE, ADCIRC),
-          and in its advanced competences  in developing forecast frameworks and operating forecasts deployments.
-
-          ### Users and application potential
-
-          OPENCoastS can contribute directly to the development of new research methodologies
-          and workflows regarding water quality, biological, biochemical and coastal erosion studies.
-
-          SMEs will benefit from these operational systems to feed their own higher-level service portfolios
-          to respond to other societal needs, without the need
-          to invest time and resources to deploy forecast systems from scratch.
-
-          Port and coastal authorities –Through the use of this platform coastal managers have all the information
-          required to fulfill their responsibilities (examples of uses include facilitating navigation,
-          reducing port operation costs, reducing emergency planning and response of coastal hazards,
-          and better exploring recreational uses of the coast).
-
-
-          ### How to request a service
-
-          To request use of the OPENCoastS, please fill in thee request form and register at
-          https://opencoasts.ncg.ingrid.pt/. After analysis and validation of the request,
-          you will be allowed to log in and start building your forecasts.
-
-
-          Service provided by
-
-          OPENCoastS is provided by the Portuguese National Civil Engineering Laboratory,
-          and was jointly developed by LNEC and LIP.
-
-          Currently, the service is deployed at a single computing site (NCG-INGRID-PT,
-          part of [INCD][1] and the [EGI Federation][2]).
-
-          Through EOSC-hub, OPENCoastS will be expanded to include a more diverse set of geographical data,
-          and improved with integration of new features from the EGI, EUDAT and INDIGO-DataCloud service catalogues.
-
-          [1]: http://www.incd.pt/
-          [2]: https://www.egi.eu/federation/
-        offers:
-          1:
-            name: OPENCoastS Portal
-            description: |
-              The OPENCoastS service assembles on-demand circulation forecast systems for selected areas
-              in the Atlantic coast and keeps them running operationally for a period defined by the user.
-              This service generates daily forecasts of water levels and vertically averaged velocities
-              over the region of interest for 48 hours.
-              The system is useful in anticipating natural disasters and accidents in the coast,
-              for example floods and chemical spills and can help in search and rescue operations.
-            parameters:
-              - id:  "id1"
-                label:  "Start of service"
-                description:  "Please choose the start date"
-                type:  "date"
-                value_type:  "string"
-              - id:  "id2"
-                label:  "Number of days"
-                description:  "Choose number of days"
-                type:  "input"
-                value_type:  "integer"
-                value: 365
-
-#    WeNMR Suite for Structural Biology:
-#        name: WeNMR Suite for Structural Biology
-#        parents: *thematicServicesParent
-#        webpage_url: https://www.wenmr.eu/
-#        manual_url: https://www.wenmr.eu/tutorials/
-#        helpdesk_url: https://www.wenmr.eu/support/
-#        training_information_url: https://www.wenmr.eu/tutorials/
-#        terms_of_use_url:
-#        sla_url:
-#        access_policies_url:
-#        language_availability: *english
-#        domain: *otherOther
-#        geographical_availabilities: *poland
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: A suite of computational tools for structural biology
-#        description: "The WeNMR suite of computational tools is composed of eight individual platforms:
-#
-#                          DISVIS to visualise and quantify the accessible interaction space in macromolecular complexes
-#
-#                          POWERFIT for rigid body fitting of atomic structures into cryo-EM density maps
-#
-#                          HADDOCK to model complexes of proteins and other biomolecules
-#
-#                          GROMACS to simulate the Newtonian equations of motion for systems with hundreds to millions of particles
-#
-#                          AMPS-NMR a web portal for Nuclear Magnetic Resonance (NMR) structures
-#
-#                          CS-ROSETTA to model the 3D structure of proteins
-#
-#                          FANTEN for multiple alignment of nucleic acid and protein sequences
-#
-#                          SPOTON to identify and classify interfacial residues as Hot-Spots (HS) in protein-protein complexes
-#
-#
-#                      Service provided by
-#
-#                      The WeNMR tools are provided by the University of Utrecht, the University of Florence, and the Interuniversity consortium CIRMMP.
-#
-#
-#                      How to access the service
-#
-#                      The WeNMR platforms are freely available online and can be accessed by researchers upon registration.
-#
-#                      The tools are powered by High-Throughput Compute capabilities provided by the EGI Federation and enhanced with software components developed by the INDIGO DataCloud project.
-#
-#                      During EOSC-hub, the WeNMR services will be integrated with EUDAT services and other components from the INDIGO catalogue."
-    HADDOCK:
-        name: &haddock HADDOCK
-        parents: *processingAndAnalysisParent
-        providers: [*uou]
-        logo: haddock.png
-        open_access: true
-        webpage_url: http://haddock.science.uu.nl/enmr/services/HADDOCK2.2
-        manual_url: http://www.bonvinlab.org/software/haddock2.2/manual/
-        helpdesk_url: http://ask.bioexcel.eu/c/haddock
-        training_information_url: https://www.wenmr.eu/tutorials/#haddock
-        terms_of_use_url: https://wenmr.science.uu.nl/conditions
-        sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
-        access_policies_url: https://wenmr.science.uu.nl/conditions
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers]
-        domain: *biologicalSciences
-        restrictions: "Registration required, Limited to non-profit users"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Integrative modeling of biomolecular complexes with the user-friendly, EGI HTC-enabled HADDOCK portal
-        platforms: [*wenmr, *egiPlatform, *bioexcel, *instruct]
+  #    WeNMR Suite for Structural Biology:
+  #        name: WeNMR Suite for Structural Biology
+  #        parents: *thematicServicesParent
+  #        webpage_url: https://www.wenmr.eu/
+  #        manual_url: https://www.wenmr.eu/tutorials/
+  #        helpdesk_url: https://www.wenmr.eu/support/
+  #        training_information_url: https://www.wenmr.eu/tutorials/
+  #        terms_of_use_url:
+  #        sla_url:
+  #        access_policies_url:
+  #        language_availability: *english
+  #        domain: *otherOther
+  #        geographical_availabilities: *poland
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: A suite of computational tools for structural biology
+  #        description: "The WeNMR suite of computational tools is composed of eight individual platforms:
+  #
+  #                          DISVIS to visualise and quantify the accessible interaction space in macromolecular complexes
+  #
+  #                          POWERFIT for rigid body fitting of atomic structures into cryo-EM density maps
+  #
+  #                          HADDOCK to model complexes of proteins and other biomolecules
+  #
+  #                          GROMACS to simulate the Newtonian equations of motion for systems with hundreds to millions of particles
+  #
+  #                          AMPS-NMR a web portal for Nuclear Magnetic Resonance (NMR) structures
+  #
+  #                          CS-ROSETTA to model the 3D structure of proteins
+  #
+  #                          FANTEN for multiple alignment of nucleic acid and protein sequences
+  #
+  #                          SPOTON to identify and classify interfacial residues as Hot-Spots (HS) in protein-protein complexes
+  #
+  #
+  #                      Service provided by
+  #
+  #                      The WeNMR tools are provided by the University of Utrecht, the University of Florence, and the Interuniversity consortium CIRMMP.
+  #
+  #
+  #                      How to access the service
+  #
+  #                      The WeNMR platforms are freely available online and can be accessed by researchers upon registration.
+  #
+  #                      The tools are powered by High-Throughput Compute capabilities provided by the EGI Federation and enhanced with software components developed by the INDIGO DataCloud project.
+  #
+  #                      During EOSC-hub, the WeNMR services will be integrated with EUDAT services and other components from the INDIGO catalogue."
+  HADDOCK:
+    name: &haddock HADDOCK
+    parents: *processingAndAnalysisParent
+    providers: [ *uou ]
+    logo: haddock.png
+    open_access: true
+    webpage_url: http://haddock.science.uu.nl/enmr/services/HADDOCK2.2
+    manual_url: http://www.bonvinlab.org/software/haddock2.2/manual/
+    helpdesk_url: http://ask.bioexcel.eu/c/haddock
+    training_information_url: https://www.wenmr.eu/tutorials/#haddock
+    terms_of_use_url: https://wenmr.science.uu.nl/conditions
+    sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
+    access_policies_url: https://wenmr.science.uu.nl/conditions
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *biologicalSciences
+    restrictions: "Registration required, Limited to non-profit users"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Integrative modeling of biomolecular complexes with the user-friendly, EGI HTC-enabled HADDOCK portal
+    platforms: [ *wenmr, *egiPlatform, *bioexcel, *instruct ]
+    description: |
+      HADDOCK is a web portal that offers computational tools for structural biologists to model the structure
+      of complexes of proteins and other biomolecules via a user-friendly interface. The portal offers a number
+      of interfaces, depending on the amount of information and restraints that researchers wish
+      to place on their models.
+      HADDOCK is prepared to deal with several classes of problems,
+      including protein-protein, protein-nucleic acids and protein-ligand complexes.
+    offers:
+      1: &wenMRService
+        name: WeNMR Suite for Structural Biology
         description: |
-          HADDOCK is a web portal that offers computational tools for structural biologists to model the structure
-          of complexes of proteins and other biomolecules via a user-friendly interface. The portal offers a number
-          of interfaces, depending on the amount of information and restraints that researchers wish
-          to place on their models.
-          HADDOCK is prepared to deal with several classes of problems,
-          including protein-protein, protein-nucleic acids and protein-ligand complexes.
-        offers:
-          1: &wenMRService
-            name: WeNMR Suite for Structural Biology
-            description: |
-              WeNMR is a Virtual Research Community supported by EGI.
-              WeNMR aims at bringing together complementary research teams in the structural biology
-              and life science area into a virtual research community at a worldwide level and provide them
-              with a platform integrating and streamlining the computational approaches
-              necessary for data analysis and modelling.
-            order_url: http://haddock.science.uu.nl/enmr/services/HADDOCK2.2
-    PowerFit:
-        name: &powerFit PowerFit
-        parents: *processingAndAnalysisParent
-        providers: [*uou]
-        logo: powerfit.png
-        open_access: true
-        webpage_url: http://haddock.science.uu.nl/enmr/services/POWERFIT
-        manual_url: http://haddock.science.uu.nl/cgi/enmr/services/POWERFIT/powerfit/help
-        helpdesk_url: http://ask.bioexcel.eu/c/powerfit
-        training_information_url: https://www.wenmr.eu/tutorials/#powerfit
-        terms_of_use_url: https://wenmr.science.uu.nl/conditions
-        sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
-        access_policies_url: https://wenmr.science.uu.nl/conditions
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers]
-        domain: *biologicalSciences
-        restrictions: "Registration required, Limited to non-profit users"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: The PowerFit server allows you to fit your 3D structures in any map!
-        platforms: [*wenmr, *egiPlatform, *bioexcel, *instruct]
-        description: |
-          PowerFit is a software designed to fit atomic structures into cryo-EM density maps,
-          using an exhaustive 6-dimensional cross-correlation search.
-        offers:
-          1:
-            <<: *wenMRService
-            order_url: http://haddock.science.uu.nl/enmr/services/POWERFIT
-    DisVis:
-        name: &disVis DisVis
-        parents: *processingAndAnalysisParent
-        providers: [*uou]
-        logo: disvis.png
-        open_access: true
-        webpage_url: http://haddock.science.uu.nl/enmr/services/DISVIS
-        manual_url: http://haddock.science.uu.nl/cgi/enmr/services/DISVIS/disvis/help
-        helpdesk_url: http://ask.bioexcel.eu/c/disvis
-        training_information_url: https://www.wenmr.eu/tutorials/#disvis
-        terms_of_use_url: https://wenmr.science.uu.nl/conditions
-        sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
-        access_policies_url: https://wenmr.science.uu.nl/conditions
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers]
-        domain: *biologicalSciences
-        restrictions: "Registration required, Limited to non-profit users"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: |
-          Visualizes and quantify the information content of distance
-          restraints between macromolecular complexes with DisVis
-        platforms: [*wenmr, *egiPlatform, *bioexcel, *instruct]
-        description: |
-          DisVis is a software designed to visualize and quantify the accessible interaction space
-          defined by distance restraints between biomolecules.
-        offers:
-          1:
-            <<: *wenMRService
-            order_url: http://haddock.science.uu.nl/enmr/services/DISVIS
-    CS-ROSETTA:
-        name: &csRoseta CS-ROSETTA
-        parents: *processingAndAnalysisParent
-        providers: [*uou]
-        logo: cs-rosetta.png
-        open_access: true
-        webpage_url: https://haddock.science.uu.nl/enmr/services/CS-ROSETTA3/
-        manual_url: https://www.wenmr.eu/tutorials/#cs-rosetta
-        helpdesk_url:
-        training_information_url: https://www.wenmr.eu/tutorials/
-        terms_of_use_url: https://wenmr.science.uu.nl/conditions
-        sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
-        access_policies_url: https://wenmr.science.uu.nl/conditions
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers]
-        domain: *biologicalSciences
-        restrictions: "Registration required, Limited to non-profit users"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: NMR protein structure prediction using the EGI HTC-enabled CS-ROSETTA portal
-        platforms: [*wenmr, *egiPlatform, *instruct]
-        description: |
-          The CS-ROSETTA3 web portal allows structural biologists to model the 3D structure of proteins
-          using only the 13CA, 13CB, 13C’, 15N, 1HA and 1HN NMR chemical shifts as input.
+          WeNMR is a Virtual Research Community supported by EGI.
+          WeNMR aims at bringing together complementary research teams in the structural biology
+          and life science area into a virtual research community at a worldwide level and provide them
+          with a platform integrating and streamlining the computational approaches
+          necessary for data analysis and modelling.
+        order_url: http://haddock.science.uu.nl/enmr/services/HADDOCK2.2
+  PowerFit:
+    name: &powerFit PowerFit
+    parents: *processingAndAnalysisParent
+    providers: [ *uou ]
+    logo: powerfit.png
+    open_access: true
+    webpage_url: http://haddock.science.uu.nl/enmr/services/POWERFIT
+    manual_url: http://haddock.science.uu.nl/cgi/enmr/services/POWERFIT/powerfit/help
+    helpdesk_url: http://ask.bioexcel.eu/c/powerfit
+    training_information_url: https://www.wenmr.eu/tutorials/#powerfit
+    terms_of_use_url: https://wenmr.science.uu.nl/conditions
+    sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
+    access_policies_url: https://wenmr.science.uu.nl/conditions
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *biologicalSciences
+    restrictions: "Registration required, Limited to non-profit users"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: The PowerFit server allows you to fit your 3D structures in any map!
+    platforms: [ *wenmr, *egiPlatform, *bioexcel, *instruct ]
+    description: |
+      PowerFit is a software designed to fit atomic structures into cryo-EM density maps,
+      using an exhaustive 6-dimensional cross-correlation search.
+    offers:
+      1:
+        <<: *wenMRService
+        order_url: http://haddock.science.uu.nl/enmr/services/POWERFIT
+  DisVis:
+    name: &disVis DisVis
+    parents: *processingAndAnalysisParent
+    providers: [ *uou ]
+    logo: disvis.png
+    open_access: true
+    webpage_url: http://haddock.science.uu.nl/enmr/services/DISVIS
+    manual_url: http://haddock.science.uu.nl/cgi/enmr/services/DISVIS/disvis/help
+    helpdesk_url: http://ask.bioexcel.eu/c/disvis
+    training_information_url: https://www.wenmr.eu/tutorials/#disvis
+    terms_of_use_url: https://wenmr.science.uu.nl/conditions
+    sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
+    access_policies_url: https://wenmr.science.uu.nl/conditions
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *biologicalSciences
+    restrictions: "Registration required, Limited to non-profit users"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: |
+      Visualizes and quantify the information content of distance
+      restraints between macromolecular complexes with DisVis
+    platforms: [ *wenmr, *egiPlatform, *bioexcel, *instruct ]
+    description: |
+      DisVis is a software designed to visualize and quantify the accessible interaction space
+      defined by distance restraints between biomolecules.
+    offers:
+      1:
+        <<: *wenMRService
+        order_url: http://haddock.science.uu.nl/enmr/services/DISVIS
+  CS-ROSETTA:
+    name: &csRoseta CS-ROSETTA
+    parents: *processingAndAnalysisParent
+    providers: [ *uou ]
+    logo: cs-rosetta.png
+    open_access: true
+    webpage_url: https://haddock.science.uu.nl/enmr/services/CS-ROSETTA3/
+    manual_url: https://www.wenmr.eu/tutorials/#cs-rosetta
+    helpdesk_url:
+    training_information_url: https://www.wenmr.eu/tutorials/
+    terms_of_use_url: https://wenmr.science.uu.nl/conditions
+    sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
+    access_policies_url: https://wenmr.science.uu.nl/conditions
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *biologicalSciences
+    restrictions: "Registration required, Limited to non-profit users"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: NMR protein structure prediction using the EGI HTC-enabled CS-ROSETTA portal
+    platforms: [ *wenmr, *egiPlatform, *instruct ]
+    description: |
+      The CS-ROSETTA3 web portal allows structural biologists to model the 3D structure of proteins
+      using only the 13CA, 13CB, 13C’, 15N, 1HA and 1HN NMR chemical shifts as input.
 
-        offers:
-          1:
-            <<: *wenMRService
-            order_url: https://haddock.science.uu.nl/enmr/services/CS-ROSETTA3/
-    AMBER:
-        name: &amber AMBER
-        parents: *processingAndAnalysisParent
-        providers: [*cerm, *cirmmp]
-        logo: amber.png
-        open_access: true
-        webpage_url: http://py-enmr.cerm.unifi.it/access/index
-        manual_url: https://www.wenmr.eu/tutorials
-        helpdesk_url: http://py-enmr.cerm.unifi.it/feedback/index?type=amps-nmr
-        training_information_url: https://www.wenmr.eu/tutorials/
-        terms_of_use_url: http://py-enmr.cerm.unifi.it/POLICY.pdf
-        sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
-        access_policies_url: http://py-enmr.cerm.unifi.it/POLICY.pdf
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers]
-        domain: *biologicalSciences
-        restrictions: "Limited to non-profit users, For-profit users can use the service if they a license agreement with the University of California for the AMBER toolkit"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Web portal for Nuclear Magnetic Resonance (NMR) structure refinement
-        platforms: [*wenmr, *egiPlatform, *instruct]
-        funding_bodies: ["funding_body-esa", "funding_body-epsrc"]
-        funding_programs: ["funding_program-h2020","funding_program-health"]
-        description: |
-          Simple and user-friendly NMR-based refinement of the 3D structures of biological macromolecules
-          thought the AMPS-NMR portal. Amber (Assisted Model Building with Energy Refinement) is a suite
-          of programs that allow users to perform molecular dynamics (MD) simulations on biological systems
-          and to store different calculations.
+    offers:
+      1:
+        <<: *wenMRService
+        order_url: https://haddock.science.uu.nl/enmr/services/CS-ROSETTA3/
+  AMBER:
+    name: &amber AMBER
+    parents: *processingAndAnalysisParent
+    providers: [ *cerm, *cirmmp ]
+    logo: amber.png
+    open_access: true
+    webpage_url: http://py-enmr.cerm.unifi.it/access/index
+    manual_url: https://www.wenmr.eu/tutorials
+    helpdesk_url: http://py-enmr.cerm.unifi.it/feedback/index?type=amps-nmr
+    training_information_url: https://www.wenmr.eu/tutorials/
+    terms_of_use_url: http://py-enmr.cerm.unifi.it/POLICY.pdf
+    sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
+    access_policies_url: http://py-enmr.cerm.unifi.it/POLICY.pdf
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *biologicalSciences
+    restrictions: "Limited to non-profit users, For-profit users can use the service if they a license agreement with the University of California for the AMBER toolkit"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Web portal for Nuclear Magnetic Resonance (NMR) structure refinement
+    platforms: [ *wenmr, *egiPlatform, *instruct ]
+    funding_bodies: [ "funding_body-esa", "funding_body-epsrc" ]
+    funding_programs: [ "funding_program-h2020","funding_program-health" ]
+    description: |
+      Simple and user-friendly NMR-based refinement of the 3D structures of biological macromolecules
+      thought the AMPS-NMR portal. Amber (Assisted Model Building with Energy Refinement) is a suite
+      of programs that allow users to perform molecular dynamics (MD) simulations on biological systems
+      and to store different calculations.
 
-          The portal was developed with the help of the WestLife and INDIGO-DataCloud projects
-          and supported by the MoBrain Competence Centre, under the EGI-Engage project.
-        offers:
-          1:
-            <<: *wenMRService
-            order_url: http://py-enmr.cerm.unifi.it/access/index
-    FANTEN:
-        name: &fanten FANTEN
-        parents: *processingAndAnalysisParent
-        providers: [*cerm, *cirmmp]
-        logo: fanten.png
-        open_access: true
-        webpage_url: http://abs.cerm.unifi.it:8080
-        manual_url: http://abs.cerm.unifi.it:8080/manual/FANTEN_manual.pdf
-        helpdesk_url:
-        training_information_url: https://www.wenmr.eu/tutorials/
-        terms_of_use_url: http://py-enmr.cerm.unifi.it/POLICY.pdf
-        sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
-        access_policies_url: http://py-enmr.cerm.unifi.it/POLICY.pdf
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers]
-        domain: *biologicalSciences
-        restrictions: "Limited to non-profit users"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: FANTEN for the analysis of magnetic anisotropy-induced NMR data
-        platforms: [*wenmr, *egiPlatform, *instruct]
-        description: |
-          FANTEN is a user-friendly web tool for the
-          determination of anisotropy tensors. It is freely available through the WeNMR gateway.
+      The portal was developed with the help of the WestLife and INDIGO-DataCloud projects
+      and supported by the MoBrain Competence Centre, under the EGI-Engage project.
+    offers:
+      1:
+        <<: *wenMRService
+        order_url: http://py-enmr.cerm.unifi.it/access/index
+  FANTEN:
+    name: &fanten FANTEN
+    parents: *processingAndAnalysisParent
+    providers: [ *cerm, *cirmmp ]
+    logo: fanten.png
+    open_access: true
+    webpage_url: http://abs.cerm.unifi.it:8080
+    manual_url: http://abs.cerm.unifi.it:8080/manual/FANTEN_manual.pdf
+    helpdesk_url:
+    training_information_url: https://www.wenmr.eu/tutorials/
+    terms_of_use_url: http://py-enmr.cerm.unifi.it/POLICY.pdf
+    sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
+    access_policies_url: http://py-enmr.cerm.unifi.it/POLICY.pdf
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *biologicalSciences
+    restrictions: "Limited to non-profit users"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: FANTEN for the analysis of magnetic anisotropy-induced NMR data
+    platforms: [ *wenmr, *egiPlatform, *instruct ]
+    description: |
+      FANTEN is a user-friendly web tool for the
+      determination of anisotropy tensors. It is freely available through the WeNMR gateway.
 
-          The portal was developed with the help of the WestLife and INDIGO-DataCloud projects
-          and supported by the MoBrain Competence Centre, under the EGI-Engage project.
-        offers:
-          1:
-            <<: *wenMRService
-            order_url: http://abs.cerm.unifi.it:8080
-    SpotOn:
-        name: &spotOn SpotOn
-        parents: *processingAndAnalysisParent
-        providers: [*uou]
-        logo: SpotOn-logo.png
-        open_access: true
-        webpage_url: https://haddock.science.uu.nl/enmr/services/SPOTON
-        manual_url: https://haddock.science.uu.nl/cgi/enmr/services/SPOTON/spoton/help
-        helpdesk_url: http://ask.bioexcel.eu/c/spoton
-        training_information_url: https://www.wenmr.eu/tutorials/#spoton
-        terms_of_use_url: https://wenmr.science.uu.nl/conditions
-        sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
-        access_policies_url: https://wenmr.science.uu.nl/conditions
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers]
-        domain: [*biologicalSciences, *otherOther]
-        restrictions: "Registration required, Limited to non-profit users"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "SpotOn: determination of Hot-Spots at protein-protein interfaces"
-        platforms: [*wenmr, *egiPlatform, *bioexcel, *instruct]
-        description: |
-          SpotOn is a robust algorithm developed to identify and classify the interfacial residues
-          as Hot-Spots (HS) and Null-Spots (NS) with a final accuracy of 0.95
-          and a sensitivity of 0.95 on an independent test set.
-        offers:
-          1:
-            <<: *wenMRService
-            order_url: https://haddock.science.uu.nl/enmr/services/SPOTON
-    GEP - HRCM:
-        name: &gepHRCM GEP - High-Resolution Change Monitoring for the Alpine Region
-        parents: *processingAndAnalysisParent
-        providers: [*terradue]
-        logo: gep-alpine.png
-        open_access: false
-        webpage_url: https://geohazards-tep.eo.esa.int/#!communities/details/eoschub
-        manual_url: https://terradue.github.io/doc-tep-geohazards/
-        helpdesk_url: https://helpdesk.terradue.com
-        #contect: support@terradue.com
-        training_information_url: https://discuss.terradue.com/t/interpreting-the-layers-of-dlr-s-insar-browse-service/216 #TODO: should be able to link several urls
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *business]
-        domain: [*earthAndEnvironmentalScience, *otherOther]
-        restrictions: " Research affiliation needed, user account registration needed."
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "Continuous systematic interferogram generation with Sentinel-1 data over the Alpine Region."
-        platforms: [*gepPlatform, *esaPlatform]
-        description: |
-          This service provides an interferometric product at 50m resolution and 25m pixel spacing systematically
-          for every 6-day Sentinel-1 SLC pair over the Alpine Region.
-          It allows rapid response to earthquakes occurring within the processing mask by automatic generation
-          of co-seismic interferograms that are published in a dedicated GeoBrowser
-          and made available for visualization and download.
-        offers:
-            1:
-                name: GEP Portal
-                description: description
-                order_url: https://geohazards-tep.eo.esa.int/
-    GEP - EO:
-        name: &gepEO GEP - EO Services for Earthquake Response and Landslides Analysis
-        parents: *sharingAndDicoveryParent
-        providers: [*terradue]
-        logo: gep-eo.png
-        open_access: false
-        webpage_url: https://geohazards-tep.eo.esa.int/#!communities/details/eoschub
-        manual_url: https://terradue.github.io/doc-tep-geohazards/
-        helpdesk_url: https://helpdesk.terradue.com
-        #contect: support@terradue.com
-        training_information_url: https://terradue.github.io/doc-tep-geohazards/tutorials/index.html
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *business]
-        domain: [*earthAndEnvironmentalScience, *otherOther]
-        restrictions: " Research affiliation needed, user account registration needed."
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "On-demand EO processing services for Earthquake Response and Landslides Analysis."
-        platforms: [*gepPlatform, *esaPlatform]
-        description: |
-            This is a Thematic Application of the Geohazards Thematic Exploitation Platform providing access to a set
-            of on-demand terrain motion services supporting interferogram generation, co-seismic displacement mapping,
-            landslide rapid mapping and landslide displacement field monitoring with Sentinel-1 and Sentinel-2 data.
-        offers:
-            1:
-                name: GEP Portal
-                description: description
-                order_url: https://geohazards-tep.eo.esa.int/#!
+      The portal was developed with the help of the WestLife and INDIGO-DataCloud projects
+      and supported by the MoBrain Competence Centre, under the EGI-Engage project.
+    offers:
+      1:
+        <<: *wenMRService
+        order_url: http://abs.cerm.unifi.it:8080
+  SpotOn:
+    name: &spotOn SpotOn
+    parents: *processingAndAnalysisParent
+    providers: [ *uou ]
+    logo: SpotOn-logo.png
+    open_access: true
+    webpage_url: https://haddock.science.uu.nl/enmr/services/SPOTON
+    manual_url: https://haddock.science.uu.nl/cgi/enmr/services/SPOTON/spoton/help
+    helpdesk_url: http://ask.bioexcel.eu/c/spoton
+    training_information_url: https://www.wenmr.eu/tutorials/#spoton
+    terms_of_use_url: https://wenmr.science.uu.nl/conditions
+    sla_url: https://documents.egi.eu/public/ShowDocument?docid=2751
+    access_policies_url: https://wenmr.science.uu.nl/conditions
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: [ *biologicalSciences, *otherOther ]
+    restrictions: "Registration required, Limited to non-profit users"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "SpotOn: determination of Hot-Spots at protein-protein interfaces"
+    platforms: [ *wenmr, *egiPlatform, *bioexcel, *instruct ]
+    description: |
+      SpotOn is a robust algorithm developed to identify and classify the interfacial residues
+      as Hot-Spots (HS) and Null-Spots (NS) with a final accuracy of 0.95
+      and a sensitivity of 0.95 on an independent test set.
+    offers:
+      1:
+        <<: *wenMRService
+        order_url: https://haddock.science.uu.nl/enmr/services/SPOTON
+  GEP - HRCM:
+    name: &gepHRCM GEP - High-Resolution Change Monitoring for the Alpine Region
+    parents: *processingAndAnalysisParent
+    providers: [ *terradue ]
+    logo: gep-alpine.png
+    open_access: false
+    webpage_url: https://geohazards-tep.eo.esa.int/#!communities/details/eoschub
+    manual_url: https://terradue.github.io/doc-tep-geohazards/
+    helpdesk_url: https://helpdesk.terradue.com
+    #contect: support@terradue.com
+    training_information_url: https://discuss.terradue.com/t/interpreting-the-layers-of-dlr-s-insar-browse-service/216 #TODO: should be able to link several urls
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *business ]
+    domain: [ *earthAndEnvironmentalScience, *otherOther ]
+    restrictions: " Research affiliation needed, user account registration needed."
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "Continuous systematic interferogram generation with Sentinel-1 data over the Alpine Region."
+    platforms: [ *gepPlatform, *esaPlatform ]
+    description: |
+      This service provides an interferometric product at 50m resolution and 25m pixel spacing systematically
+      for every 6-day Sentinel-1 SLC pair over the Alpine Region.
+      It allows rapid response to earthquakes occurring within the processing mask by automatic generation
+      of co-seismic interferograms that are published in a dedicated GeoBrowser
+      and made available for visualization and download.
+    offers:
+      1:
+        name: GEP Portal
+        description: description
+        order_url: https://geohazards-tep.eo.esa.int/
+  GEP - EO:
+    name: &gepEO GEP - EO Services for Earthquake Response and Landslides Analysis
+    parents: *sharingAndDicoveryParent
+    providers: [ *terradue ]
+    logo: gep-eo.png
+    open_access: false
+    webpage_url: https://geohazards-tep.eo.esa.int/#!communities/details/eoschub
+    manual_url: https://terradue.github.io/doc-tep-geohazards/
+    helpdesk_url: https://helpdesk.terradue.com
+    #contect: support@terradue.com
+    training_information_url: https://terradue.github.io/doc-tep-geohazards/tutorials/index.html
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *business ]
+    domain: [ *earthAndEnvironmentalScience, *otherOther ]
+    restrictions: " Research affiliation needed, user account registration needed."
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "On-demand EO processing services for Earthquake Response and Landslides Analysis."
+    platforms: [ *gepPlatform, *esaPlatform ]
+    description: |
+      This is a Thematic Application of the Geohazards Thematic Exploitation Platform providing access to a set
+      of on-demand terrain motion services supporting interferogram generation, co-seismic displacement mapping,
+      landslide rapid mapping and landslide displacement field monitoring with Sentinel-1 and Sentinel-2 data.
+    offers:
+      1:
+        name: GEP Portal
+        description: description
+        order_url: https://geohazards-tep.eo.esa.int/#!
 
-    EODC JupyterHub for global Copernicus data:
-        name: &eodcJH EODC JupyterHub for global Copernicus data
-        parents: *processingAndAnalysisParent
-        providers: [*eodc]
-        logo: eodc-jupyter.png
-        open_access: false
-        #contact: support@eodc.eu
-        webpage_url: https://jupyterhub.eodc.eu
-        manual_url: https://github.com/jupyterhub/jupyterhub
-        helpdesk_url: https://www.eodc.eu/support-request/
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *research_groups]
-        domain: [*otherSocialSciences, *physicalSciences, *otherOther]
-        restrictions: "Research affiliation needed"
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "EODC JupyterHub provides access to the global EODC Copernicus Data Archive."
-#        platforms: [*eopillar]
+  EODC JupyterHub for global Copernicus data:
+    name: &eodcJH EODC JupyterHub for global Copernicus data
+    parents: *processingAndAnalysisParent
+    providers: [ *eodc ]
+    logo: eodc-jupyter.png
+    open_access: false
+    #contact: support@eodc.eu
+    webpage_url: https://jupyterhub.eodc.eu
+    manual_url: https://github.com/jupyterhub/jupyterhub
+    helpdesk_url: https://www.eodc.eu/support-request/
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *research_groups ]
+    domain: [ *otherSocialSciences, *physicalSciences, *otherOther ]
+    restrictions: "Research affiliation needed"
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "EODC JupyterHub provides access to the global EODC Copernicus Data Archive."
+    #        platforms: [*eopillar]
+    description: |
+      EODC JupyterHub provides access to the global EODC Copernicus Data Archive.
+      Eliminate the barrier to get access to and to start to develop algorithms in view of remote sensing data.
+      Full access to EODC Copernicus satellite data archive.
+      No need to setup a VM to access data archive.Simple python dev. environment.
+    offers:
+      1:
+        name: JupyterHub
         description: |
           EODC JupyterHub provides access to the global EODC Copernicus Data Archive.
-          Eliminate the barrier to get access to and to start to develop algorithms in view of remote sensing data.
-          Full access to EODC Copernicus satellite data archive.
-          No need to setup a VM to access data archive.Simple python dev. environment.
-        offers:
-          1:
-            name: JupyterHub
-            description: |
-              EODC JupyterHub provides access to the global EODC Copernicus Data Archive.
-            order_url: https://jupyterhub.eodc.eu
-#              Eliminate the barrier to get access to and to start to develop algorithms in view of remote sensing data.
-#              Full access to EODC Copernicus satellite data archive.
-#              No need to setup a VM to access data archive.Simple python dev. environment.
-#            parameters:
-#              - id:  "id1"
-#                label:  "First name"
-#                description:  "Type your first name"
-#                type:  "input"
-#                value_type:  "string"
-#              - id:  "id2"
-#                label:  "Last name"
-#                description:  "Type your last name"
-#                type:  "input"
-#                value_type:  "string"
-#              - id:  "id3"
-#                label:  "E-mail"
-#                description:  "Type your e-mail"
-#                type:  "input"
-#                value_type:  "string"
-#              - id:  "id4"
-#                label:  "Institution"
-#                description:  "Type institution name"
-#                type:  "input"
-#                value_type:  "string"
-    EODC Data Catalogue Service:
-        name: &eodcDCS EODC Data Catalogue Service
-        parents: *dataManagementParent
-        providers: [*eodc]
-        logo: eodc-jupyter.png
-        open_access: true
-        webpage_url: https://www.eodc.eu/support-request/
-        manual_url: https://csw.eodc.eu
-        helpdesk_url: https://www.eodc.eu/support-request/
-        #contact: support@eodc.eu
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *research_groups, *providers]
-        domain: [*otherSocialSciences, *physicalSciences, *otherOther]
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "Catalog Service for the Web (CSW), OGC compliant catalogue service to expose metadata of geospatial records hosted at EODC"
-        platforms: [*openGC]
+        order_url: https://jupyterhub.eodc.eu
+  #              Eliminate the barrier to get access to and to start to develop algorithms in view of remote sensing data.
+  #              Full access to EODC Copernicus satellite data archive.
+  #              No need to setup a VM to access data archive.Simple python dev. environment.
+  #            parameters:
+  #              - id:  "id1"
+  #                label:  "First name"
+  #                description:  "Type your first name"
+  #                type:  "input"
+  #                value_type:  "string"
+  #              - id:  "id2"
+  #                label:  "Last name"
+  #                description:  "Type your last name"
+  #                type:  "input"
+  #                value_type:  "string"
+  #              - id:  "id3"
+  #                label:  "E-mail"
+  #                description:  "Type your e-mail"
+  #                type:  "input"
+  #                value_type:  "string"
+  #              - id:  "id4"
+  #                label:  "Institution"
+  #                description:  "Type institution name"
+  #                type:  "input"
+  #                value_type:  "string"
+  EODC Data Catalogue Service:
+    name: &eodcDCS EODC Data Catalogue Service
+    parents: *dataManagementParent
+    providers: [ *eodc ]
+    logo: eodc-jupyter.png
+    open_access: true
+    webpage_url: https://www.eodc.eu/support-request/
+    manual_url: https://csw.eodc.eu
+    helpdesk_url: https://www.eodc.eu/support-request/
+    #contact: support@eodc.eu
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *research_groups, *providers ]
+    domain: [ *otherSocialSciences, *physicalSciences, *otherOther ]
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "Catalog Service for the Web (CSW), OGC compliant catalogue service to expose metadata of geospatial records hosted at EODC"
+    platforms: [ *openGC ]
+    description: |
+      The EODC Data Catalogue service allows querying the Copernicus Sentinel satellite data hosted at EODC.
+      The service is available through a  simple Web GUI, eomEX+, as well as an API. The back-end of eomEX+
+      is the EODC pycsw server, an implementation of an OGC CSW server. As a consequence,
+      the eomEX+ API is accompanied by an expert level  API provided by the EODC CSW server, located at [link][1].
+
+      Further details can be found [here][2].
+
+
+      [1]: https://csw.eodc.eu
+      [2]: https://eomex.eodc.eu/manual
+    offers:
+      1:
+        name: EODC Data Catalogue Service
         description: |
-            The EODC Data Catalogue service allows querying the Copernicus Sentinel satellite data hosted at EODC.
-            The service is available through a  simple Web GUI, eomEX+, as well as an API. The back-end of eomEX+
-            is the EODC pycsw server, an implementation of an OGC CSW server. As a consequence,
-            the eomEX+ API is accompanied by an expert level  API provided by the EODC CSW server, located at [link][1].
-
-            Further details can be found [here][2].
-
-
-            [1]: https://csw.eodc.eu
-            [2]: https://eomex.eodc.eu/manual
-        offers:
-          1:
-            name: EODC Data Catalogue Service
-            description: |
-              Catalog Service for the Web (CSW)
-            order_url: https://csw.eodc.eu
-    Sentinel hub:
-        name: &sentinelHub Sentinel Hub
-        parents: *sharingAndDicoveryParent
-        providers: [*sinergise]
-        open_access: false
-        webpage_url: http://sentinel-hub.com/
-        manual_url: https://www.sentinel-hub.com/develop/documentation
-        helpdesk_url:
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: *earthAndEnvironmentalScience
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Big data satellite imagery service
-        platforms: [*eopillar]
+          Catalog Service for the Web (CSW)
+        order_url: https://csw.eodc.eu
+  Sentinel hub:
+    name: &sentinelHub Sentinel Hub
+    parents: *sharingAndDicoveryParent
+    providers: [ *sinergise ]
+    open_access: false
+    webpage_url: http://sentinel-hub.com/
+    manual_url: https://www.sentinel-hub.com/develop/documentation
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: *earthAndEnvironmentalScience
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Big data satellite imagery service
+    platforms: [ *eopillar ]
+    description: |
+      Sentinel Hub is a multi- spectral and multi-temporal big data satellite imagery service,
+      capable of fully automated archiving, real-time processing and distribution
+      of remote sensing data and related EO products.
+      Users can use OGC compliant and proprietary APIs to retrieve satellite data over their AOI
+      and specific time range from full archives in a matter of seconds.
+      Sentinel Hub received Copernicus Masters Award 2016.
+  MEA Platform:
+    name: &meaPlatform MEA Platform (Data access and exploitation service)
+    parents: *sharingAndDicoveryParent
+    providers: [ *meeo ]
+    open_access: false
+    webpage_url: https://eodataservice.org
+    manual_url: https://www.youtube.com/channel/UCqy-bd6CpXMOlRqfHmBqlZw
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: *earthAndEnvironmentalScience
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Cross-domain application supporting various application fields
+    platforms: [ *eopillar ]
+    description: |
+      MEA platform implements the concept of Digital Earth making global environmental geospatial data Findable,
+      Accessible, Interoperable and Reusable (FAIR). MEA platform provides an effective subsetting functionality
+      that accesses the data only when requested and serves to the client
+      only the data amount that is really needed.
+      MEA platform exposes OGC-standardised discovery (openSearch) and access (WCS 2.0) interfaces.
+  Rasdaman EO Datacube:
+    name: &rasdamanDatacube Rasdaman EO Datacube
+    parents: *processingAndAnalysisParent
+    providers: [ *terradue ]
+    logo: rasdaman-eo-datacube.png
+    open_access: false
+    webpage_url: http://eoschub.rasdaman.com:8080/rasdaman/ows
+    manual_url: http://doc.rasdaman.org/05_geo-services-guide.html#ogc-web-services
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations ]
+    domain: *earthAndEnvironmentalScience
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Service providing analysis-ready EO data
+    platforms: [ *eopillar ]
+    description: |
+      Rasdaman is a datacube engine providing analysis-ready EO data by abstracting
+      millions of satellite images into few spatio-temporal cubes.
+      Visualize via WMS, extract via WCS or perform server-side analytics via WCPS
+      on any subset of Sentinel or Landsat data in real time, in your favorite client.
+    offers:
+      1:
+        name: Rasdaman EO Datacube
         description: |
-          Sentinel Hub is a multi- spectral and multi-temporal big data satellite imagery service,
-          capable of fully automated archiving, real-time processing and distribution
-          of remote sensing data and related EO products.
-          Users can use OGC compliant and proprietary APIs to retrieve satellite data over their AOI
-          and specific time range from full archives in a matter of seconds.
-          Sentinel Hub received Copernicus Masters Award 2016.
-    MEA Platform:
-        name: &meaPlatform MEA Platform (Data access and exploitation service)
-        parents: *sharingAndDicoveryParent
-        providers: [*meeo]
-        open_access: false
-        webpage_url: https://eodataservice.org
-        manual_url: https://www.youtube.com/channel/UCqy-bd6CpXMOlRqfHmBqlZw
-        helpdesk_url:
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: *earthAndEnvironmentalScience
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Cross-domain application supporting various application fields
-        platforms: [*eopillar]
+          Catalog Service for the Web (CSW)
+  #            parameters:
+  #            - id:  "id1"
+  #              label:  "First name"
+  #              description:  "Type your first name"
+  #              type:  "input"
+  #              value_type:  "string"
+  #            - id:  "id2"
+  #              label:  "Last name"
+  #              description:  "Type your last name"
+  #              type:  "input"
+  #              value_type:  "string"
+  #            - id:  "id3"
+  #              label:  "E-mail"
+  #              description:  "Type your e-mail"
+  #              type:  "input"
+  #              value_type:  "string"
+  #            - id:  "id4"
+  #              label:  "Institution"
+  #              description:  "Type institution name"
+  #              type:  "input"
+  #              value_type:  "string"
+  CloudFerro Data Collections Catalog:
+    name: &cfdcc CloudFerro Data Collections Catalog
+    parents: *dataManagementParent
+    providers: [ *cloudFerro ]
+    logo: &cfLogo cloud-ferro.png
+    open_access: true
+    webpage_url: https://discovery.creodias.eu/dataset
+    #contact: support@creodias.eu
+    manual_url: https://creodias.eu/data-related-services
+    helpdesk_url:
+    training_information_url: https://creodias.eu/knowledgebase
+    terms_of_use_url: https://creodias.eu/terms-of-service
+    sla_url: https://creodias.eu/appendix-service-level
+    access_policies_url: https://creodias.eu/legal-matters
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *research_groups, *providers, *business ]
+    domain: [ *otherSocialSciences, *physicalSciences, *otherOther ]
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "Data Collections Catalog is based on two solutions  – CKAN - comprehensive frontend catalogue application for information discovery and EO Browser – specialized catalogue application for robust satellite imagery discovery and quick georeferenced preview"
+    platforms: [ *copernicus, *esaPlatform ]
+    description: |
+      The Catalogue is be based on CKAN open source software which is widely used for open data publications like
+      e.g. European Data Portal, data.org.uk or danepubliczne.gov.pl. CKAN provides user friendly web interface
+      for all activities associated with data publication and subscription.
+      It is capable of advanced data management.
+      All datasets are organized and described with metadata, which allows it to be easily discoverable,
+      with the use of search phrases and customizable filters (e.g.: tags, categories, data formats).
+      It is possible to publish one dataset in different data formats, not only as downloadable files but also
+      as links to web service, web API or links to external WWW resources. Datasets can be stored in CKAN,
+      along with version history and dataset statistics, which allows to monitor the interest in datasets.
+      CKAN also provides functionalities for collaboration, community participation and providing feedback,
+      such as comments, ratings and sharing.
+      CKAN is highly customizable in both terms of Look&Feel and functionalities.
+      CKAN provides very rich RESTful JSON API, which allows other applications to discover and access the datasets.
+      It can be integrated easily with Semantic Web technologies such as RDF data model and SPARQL.
+    offers:
+      1:
+        name: Cloudferro
         description: |
-          MEA platform implements the concept of Digital Earth making global environmental geospatial data Findable,
-          Accessible, Interoperable and Reusable (FAIR). MEA platform provides an effective subsetting functionality
-          that accesses the data only when requested and serves to the client
-          only the data amount that is really needed.
-          MEA platform exposes OGC-standardised discovery (openSearch) and access (WCS 2.0) interfaces.
-    Rasdaman EO Datacube:
-        name: &rasdamanDatacube Rasdaman EO Datacube
-        parents: *processingAndAnalysisParent
-        providers: [*terradue]
-        logo: rasdaman-eo-datacube.png
-        open_access: false
-        webpage_url: http://eoschub.rasdaman.com:8080/rasdaman/ows
-        manual_url: http://doc.rasdaman.org/05_geo-services-guide.html#ogc-web-services
-        helpdesk_url:
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations]
-        domain: *earthAndEnvironmentalScience
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Service providing analysis-ready EO data
-        platforms: [*eopillar]
+          cloudferro
+        order_url: https://discovery.creodias.eu/dataset
+  CloudFerro Infrastructure:
+    name: &cfi CloudFerro Infrastructure
+    parents: [ *computeParent, *storageParent, *processingAndAnalysisParent ]
+    providers: [ *cloudFerro ]
+    logo: *cfLogo
+    open_access: true
+    webpage_url: https://creodias.eu
+    #contact: support@creodias.eu
+    manual_url: https://creodias.eu/your-processing-environment
+    helpdesk_url:
+    training_information_url: https://creodias.eu/knowledgebase
+    terms_of_use_url: https://creodias.eu/terms-of-service
+    sla_url: https://creodias.eu/appendix-service-level
+    access_policies_url: https://creodias.eu/legal-matters
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *research_groups, *providers, *business ]
+    domain: [ *otherSocialSciences, *physicalSciences, *otherOther ]
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "CREODIAS platform is a cloud infrastructure adapted to the processing of big amounts of EO data, including an EO Data storage cluster and a dedicated IaaS cloud infrastructure for the platform’s Users"
+    platforms: [ *copernicus, *esaPlatform ]
+    description: |
+      CREODIAS processing covers full set of virtual resources available in the solution:
+      VM – Virtual Machines (or virtual computing servers) with several operating systems available
+      (both free like CentOS, Ubuntu, Debian, Scientific Linux,
+      and commercial like RedHat, SUSE, Microsoft Windows Server),
+      virtual storage volumes that can be easily mounted to the VMs together with object storage solution,
+      virtual networks, virtual appliances like firewalls (FWaaS) and VPN concentrators (VPNaaS),
+      physical servers (baremetal) that can be integrated to the virtual world,
+      Single Server VMs – full physical server with a single VM and very fast passthrough NVMe storage –
+      a combination of advantages of a dedicated server and a cloud VM
+      (high capacity, storage speed, no noisy neighbor problem).
+    offers:
+      1:
+        name: Cloudferro2
         description: |
-          Rasdaman is a datacube engine providing analysis-ready EO data by abstracting
-          millions of satellite images into few spatio-temporal cubes.
-          Visualize via WMS, extract via WCS or perform server-side analytics via WCPS
-          on any subset of Sentinel or Landsat data in real time, in your favorite client.
-        offers:
-          1:
-            name: Rasdaman EO Datacube
-            description: |
-              Catalog Service for the Web (CSW)
-#            parameters:
-#            - id:  "id1"
-#              label:  "First name"
-#              description:  "Type your first name"
-#              type:  "input"
-#              value_type:  "string"
-#            - id:  "id2"
-#              label:  "Last name"
-#              description:  "Type your last name"
-#              type:  "input"
-#              value_type:  "string"
-#            - id:  "id3"
-#              label:  "E-mail"
-#              description:  "Type your e-mail"
-#              type:  "input"
-#              value_type:  "string"
-#            - id:  "id4"
-#              label:  "Institution"
-#              description:  "Type institution name"
-#              type:  "input"
-#              value_type:  "string"
-    CloudFerro Data Collections Catalog:
-        name: &cfdcc CloudFerro Data Collections Catalog
-        parents: *dataManagementParent
-        providers: [*cloudFerro]
-        logo: &cfLogo cloud-ferro.png
-        open_access: true
-        webpage_url: https://discovery.creodias.eu/dataset
-        #contact: support@creodias.eu
-        manual_url: https://creodias.eu/data-related-services
-        helpdesk_url:
-        training_information_url: https://creodias.eu/knowledgebase
-        terms_of_use_url: https://creodias.eu/terms-of-service
-        sla_url: https://creodias.eu/appendix-service-level
-        access_policies_url: https://creodias.eu/legal-matters
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *research_groups, *providers, *business]
-        domain: [*otherSocialSciences, *physicalSciences, *otherOther]
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "Data Collections Catalog is based on two solutions  – CKAN - comprehensive frontend catalogue application for information discovery and EO Browser – specialized catalogue application for robust satellite imagery discovery and quick georeferenced preview"
-        platforms: [*copernicus, *esaPlatform]
+          cloudferro
+        order_url: https://creodias.eu
+  Cloudferro Data related Services - EO Finder:
+    name: &cfdrsEOF Cloudferro Data related Services - EO Finder
+    parents: [ *dataManagementParent ]
+    providers: [ *cloudFerro ]
+    logo: *cfLogo
+    open_access: true
+    webpage_url: https://finder.creodias.eu/www
+    #contact: support@creodias.eu
+    manual_url: https://creodias.eu/eo-data-finder-api-manual
+    helpdesk_url:
+    training_information_url: https://creodias.eu/knowledgebase
+    terms_of_use_url: https://creodias.eu/terms-of-service
+    sla_url: https://creodias.eu/appendix-service-level
+    access_policies_url: https://creodias.eu/legal-matters
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *research_groups, *providers, *business ]
+    domain: [ *otherSocialSciences, *physicalSciences, *otherOther ]
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "Manage your data products"
+    platforms: [ *copernicus, *esaPlatform ]
+    description: |
+      The Finder tool allows finding data products stored in the repository, obtained or processed at
+      selected times with selected cloud coverage levels and with other selection criteria.
+    offers:
+      1:
+        name: Cloudferro3
         description: |
-          The Catalogue is be based on CKAN open source software which is widely used for open data publications like
-          e.g. European Data Portal, data.org.uk or danepubliczne.gov.pl. CKAN provides user friendly web interface
-          for all activities associated with data publication and subscription.
-          It is capable of advanced data management.
-          All datasets are organized and described with metadata, which allows it to be easily discoverable,
-          with the use of search phrases and customizable filters (e.g.: tags, categories, data formats).
-          It is possible to publish one dataset in different data formats, not only as downloadable files but also
-          as links to web service, web API or links to external WWW resources. Datasets can be stored in CKAN,
-          along with version history and dataset statistics, which allows to monitor the interest in datasets.
-          CKAN also provides functionalities for collaboration, community participation and providing feedback,
-          such as comments, ratings and sharing.
-          CKAN is highly customizable in both terms of Look&Feel and functionalities.
-          CKAN provides very rich RESTful JSON API, which allows other applications to discover and access the datasets.
-          It can be integrated easily with Semantic Web technologies such as RDF data model and SPARQL.
-        offers:
-            1:
-                name: Cloudferro
-                description: |
-                    cloudferro
-                order_url: https://discovery.creodias.eu/dataset
-    CloudFerro Infrastructure:
-        name: &cfi CloudFerro Infrastructure
-        parents: [*computeParent, *storageParent, *processingAndAnalysisParent]
-        providers: [*cloudFerro]
-        logo: *cfLogo
-        open_access: true
-        webpage_url: https://creodias.eu
-        #contact: support@creodias.eu
-        manual_url: https://creodias.eu/your-processing-environment
-        helpdesk_url:
-        training_information_url: https://creodias.eu/knowledgebase
-        terms_of_use_url: https://creodias.eu/terms-of-service
-        sla_url: https://creodias.eu/appendix-service-level
-        access_policies_url: https://creodias.eu/legal-matters
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *research_groups, *providers, *business]
-        domain: [*otherSocialSciences, *physicalSciences, *otherOther]
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "CREODIAS platform is a cloud infrastructure adapted to the processing of big amounts of EO data, including an EO Data storage cluster and a dedicated IaaS cloud infrastructure for the platform’s Users"
-        platforms: [*copernicus, *esaPlatform]
+          cloudferro
+        order_url: https://finder.creodias.eu/www
+  Cloudferro Data related Services - EO browser:
+    name: &cfdrsEOB Cloudferro Data related Services - EO browser
+    parents: *dataManagementParent
+    providers: [ *cloudFerro ]
+    logo: cloud-ferro-eo-browser.png
+    open_access: true
+    webpage_url: https://browser.creodias.eu
+    #contact: support@creodias.eu
+    manual_url: https://creodias.eu/using-the-eo-browser
+    helpdesk_url:
+    training_information_url: https://creodias.eu/knowledgebase
+    terms_of_use_url: https://creodias.eu/terms-of-service
+    sla_url: https://creodias.eu/appendix-service-level
+    access_policies_url: https://creodias.eu/legal-matters
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *research_groups, *providers, *business ]
+    domain: [ *otherSocialSciences, *physicalSciences, *otherOther ]
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: "The EO Browser allows visualization and basic processing of selected data collections (like Sentinel-1 L1 GRD or Sentinel-2 L1C)"
+    platforms: [ *copernicus, *esaPlatform ]
+    description: |
+      CreoDias EO browser allows browsing wide archive of Earth Observation products, created  by
+      ESA’s [Sentinel 1][1], [Sentinel 2][2], [Sentinel 3][3], ESA’s archives of [Landsat 5][4], [Landsat 7][5],
+      [Landsat 8] [6] and [Envisat][7].
+
+      It provides ability to visualize and download chosen products in .png and .jpg formats.
+
+      [1]: https://sentinel.esa.int/web/sentinel/missions/sentinel-1
+      [2]: https://sentinel.esa.int/web/sentinel/missions/sentinel-2
+      [3]: https://sentinel.esa.int/web/sentinel/missions/sentinel-3
+      [4]: https://landsat.gsfc.nasa.gov/landsat-5/
+      [5]: https://landsat.gsfc.nasa.gov/landsat-7/
+      [6]: https://landsat.gsfc.nasa.gov/landsat-8/landsat-8-overview/
+      [7]: https://earth.esa.int/web/guest/missions/esa-operational-eo-missions/envisat
+    offers:
+      1:
+        name: Cloudferro4
         description: |
-          CREODIAS processing covers full set of virtual resources available in the solution:
-          VM – Virtual Machines (or virtual computing servers) with several operating systems available
-          (both free like CentOS, Ubuntu, Debian, Scientific Linux,
-          and commercial like RedHat, SUSE, Microsoft Windows Server),
-          virtual storage volumes that can be easily mounted to the VMs together with object storage solution,
-          virtual networks, virtual appliances like firewalls (FWaaS) and VPN concentrators (VPNaaS),
-          physical servers (baremetal) that can be integrated to the virtual world,
-          Single Server VMs – full physical server with a single VM and very fast passthrough NVMe storage –
-          a combination of advantages of a dedicated server and a cloud VM
-          (high capacity, storage speed, no noisy neighbor problem).
-        offers:
-            1:
-                name: Cloudferro2
-                description: |
-                    cloudferro
-                order_url: https://creodias.eu
-    Cloudferro Data related Services - EO Finder:
-        name: &cfdrsEOF Cloudferro Data related Services - EO Finder
-        parents: [*dataManagementParent]
-        providers: [*cloudFerro]
-        logo: *cfLogo
-        open_access: true
-        webpage_url: https://finder.creodias.eu/www
-        #contact: support@creodias.eu
-        manual_url: https://creodias.eu/eo-data-finder-api-manual
-        helpdesk_url:
-        training_information_url: https://creodias.eu/knowledgebase
-        terms_of_use_url: https://creodias.eu/terms-of-service
-        sla_url: https://creodias.eu/appendix-service-level
-        access_policies_url: https://creodias.eu/legal-matters
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *research_groups, *providers, *business]
-        domain: [*otherSocialSciences, *physicalSciences, *otherOther]
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "Manage your data products"
-        platforms: [*copernicus, *esaPlatform]
+          cloudferro
+        order_url: https://browser.creodias.eu
+  Check-in:
+    name: &checkIn EGI Check-in
+    parents: *securityAndOperationsParent
+    providers: [ *egi ]
+    open_access: false
+    webpage_url: https://www.egi.eu/services/check-in/
+    manual_url:
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *research_organisations ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Handle transparent Single Sign-On from multiple heterogeneous identity providers
+    platforms: [ *egiPlatform ]
+    description: |
+      Check-in is a proxy service that operates as a central hub to connect federated Identity Providers (IdPs)
+      with service providers. Check-in allows users to select their preferred IdP so that they can access and use
+      services in a uniform and easy way. For the user the feature is transparent:
+      as soon as their IdP is integrated with the proxy, they are redirected by the service to their own IdP.
+      Once integrated the IdP with the proxy, all the services using the IdP proxy will be available.
+      The service providers will get all the AuthN/AuthZ information needed from the IdP Proxy
+      (in form of attributes), without the need to deal with individual IdPs.
+
+      Other components that can be attached to the IdP Proxy are credential translation services
+      and attribute authorities.
+
+      ### Main characteristics:
+
+        - Enables multiple federated authentication sources using
+        different technologies
+        - Increased productivity and security
+        - Federated in eduGAIN as a service provider, publishingREFEDS RnSandSirtficompliance
+        - User registration portal to allow accounts-linkingo
+        - Combines user attributes originating from various authoritative sources
+        (IdPs and attribute provider services) and delivers them to the connected service providers
+        in a transparent way.
+
+      ### Features:
+
+      - Enables federated access to services:
+          *Support for IdPs: SAML2.0, OIDC
+          * Support for SPs: SAML2.0, OIDC
+      - Connection with the CILogon TTS
+      - Enables multiple federated authentication sources using different technologies
+      - Direct integration with the communities AAI services
+      - User registration portal to allow accounts-linkingProvisioning to SPs of an EGI User UID
+
+
+      Brochure: https://www.egi.eu/wp-content/uploads/2017/09/Check-in.pdf
+  #    Attribute management:
+  #        name: Attribute management
+  #        parents: *securityAndOperationsParent
+  #        providers: [*grnet, *cesnet]
+  #        open_access: false
+  #        webpage_url: https://www.egi.eu/internal-services/attribute-management/
+  #        manual_url:
+  #        helpdesk_url:
+  #        training_information_url:
+  #        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+  #        sla_url: https://documents.egi.eu/document/2733
+  #        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+  #        geographical_availabilities: *poland
+  #        language_availability: *english
+  #        target_users: ["Research organisations"]
+  #        domain: *otherOther
+  #        #restrictions: *notSpecified
+  #        trl: *trl_9
+  #        life_cycle_status: *prod
+  #        tagline: ToFill
+  #        platforms: [*egiPlatform]
+  #        description: |
+  #          EGI provides services to manage user membership, where users can register and ask to be part of a VO,
+  #          and where the VO supervisor can approve or remove users from the VO.
+  #          The service is a third party service that can be queried by service providers
+  #          to decide on user authorization.
+  #
+  #          Currently EGI has in production: VOMS an X.509 based service
+  #
+  #          In the wake of extending AAI capabilities, EGI will provide similar capabilities also
+  #          for other authentication technologies, like OpenID and SAML2, for example.
+  Training infrastructure:
+    name: Training infrastructure
+    parents: *trainingAndSupportParent
+    providers: [ *egi ]
+    logo: training-infrastructure.png
+    open_access: false
+    webpage_url: https://www.egi.eu/services/training-infrastructure/
+    manual_url: https://wiki.egi.eu/wiki/Training_infrastructure
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://wiki.egi.eu/wiki/Training_infrastructure
+    terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
+    sla_url: https://documents.egi.eu/document/2733
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *research_groups, *research_organisations ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Dedicated computing and storage for training and education
+    platforms: [ *egiPlatform ]
+    description: |
+      The Training Infrastructure is a cloud­based computing and storage resources for training events.
+      It is useful to organise onsite tutorials or workshops and online training courses or as a platform
+      for self­paced learning.
+
+      Trainers can deploy custom virtual machine images on the Training Infrastructure
+      as the training environment for the students. The virtual machines can be customised according
+      to specific needs and the community can benefit from the easy deployment and easy reuse
+      of course materials.
+
+      The Training Infrastructure uses the same high­quality computing and storage environment
+      that EGI provides to researchers.
+
+      ### To request a training you need to:
+
+        1. Choose the training courses that best fit with your needs below.
+        2. Add the courses to the cart.
+        3. Go to the cart and submit your order.
+        4. You will receive an email summarising your order.
+        5. You will be contacted by the EGI support team.
+    offers:
+      1:
+        name: Training Infrastructure
         description: |
-            The Finder tool allows finding data products stored in the repository, obtained or processed at
-            selected times with selected cloud coverage levels and with other selection criteria.
-        offers:
-            1:
-                name: Cloudferro3
-                description: |
-                    cloudferro
-                order_url: https://finder.creodias.eu/www
-    Cloudferro Data related Services - EO browser:
-        name: &cfdrsEOB Cloudferro Data related Services - EO browser
-        parents: *dataManagementParent
-        providers: [*cloudFerro]
-        logo: cloud-ferro-eo-browser.png
-        open_access: true
-        webpage_url: https://browser.creodias.eu
-        #contact: support@creodias.eu
-        manual_url: https://creodias.eu/using-the-eo-browser
-        helpdesk_url:
-        training_information_url: https://creodias.eu/knowledgebase
-        terms_of_use_url: https://creodias.eu/terms-of-service
-        sla_url: https://creodias.eu/appendix-service-level
-        access_policies_url: https://creodias.eu/legal-matters
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*researchers, *research_organisations, *research_groups, *providers, *business]
-        domain: [*otherSocialSciences, *physicalSciences, *otherOther]
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: "The EO Browser allows visualization and basic processing of selected data collections (like Sentinel-1 L1 GRD or Sentinel-2 L1C)"
-        platforms: [*copernicus, *esaPlatform]
+          The Training Infrastructure offers cloud compute and online storage for training activities.
+          It is useful to organise onsite tutorials or workshops
+          and online training courses or as a platform for self­-paced learning.
+          For example, with the Training Infrastructure trainers can create
+          and deploy any custom virtual machine images for the students.
+        parameters:
+          - id: "id1"
+            label: "Location"
+            description: "Type your location"
+            type: "input"
+            value_type: "string"
+          - id: "id2"
+            label: "Aim of the training event"
+            description: "Type aim of the training event"
+            type: "input"
+            value_type: "string"
+          - id: "id3"
+            label: "Number of concurrent trainees"
+            description: "Type number of concurrent trainees"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 99999
+          - id: "id4"
+            label: "Number of cores"
+            description: "Type number of cores"
+            type: "select"
+            value_type: "integer"
+            config:
+              values: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+              mode: "dropdown"
+          - id: "id5"
+            label: "Amount od RAM"
+            description: "Type amount of RAM"
+            type: "range"
+            unit: "GB"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 99999
+          - id: "id6"
+            label: "Online storage size"
+            description: "Type online storage size"
+            type: "range"
+            unit: "GB"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 99999
+          - id: "id7"
+            label: "Special requirements"
+            description: "Type special requirements"
+            type: "input"
+            value_type: "string"
+          - id: "id8"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id9"
+            label: "Number of days"
+            description: "Type number of days"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 730
+
+  FitSM:
+    name: FitSM
+    parents: *trainingAndSupportParent
+    providers: [ *egi ]
+    logo: fitsm.png
+    open_access: false
+    webpage_url: https://www.egi.eu/services/fitsm-training/
+    manual_url: https://www.egi.eu/services/fitsm-training/
+    helpdesk_url: https://www.egi.eu/more-information/
+    training_information_url: https://www.egi.eu/services/fitsm-training/
+    terms_of_use_url: https://www.egi.eu/services/fitsm-training/terms-and-conditions/
+    sla_url: https://documents.egi.eu/document/2733
+    access_policies_url: https://marketplace.egi.eu/content/7-access-policy
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *research_organisations ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Learn how to manage IT services with a pragmatic and lightweight standard
+    platforms: [ *egiPlatform ]
+    description: |
+      FitSM is a lightweight standards family aimed at facilitating service management in IT service provision,
+      including federated scenarios. FitSM training aims at providing those involved in operating
+      federated infrastructures with the professional skills they need in order
+      to effectively manage their services.
+
+      FitSM professional training is certified by TÜV SÜD, a global leader in standardisation and certification.
+      The qualification programme offers three training levels: Foundation, Advanced and Expert.
+
+
+      ### To request a training you need to:
+
+      1. Choose the training courses that best fit with your needs below.
+      2. Add the courses to the cart.
+      3. Go to the cart and submit your order.
+      4. You will receive an email summarising your order.
+      5. You will be contacted by the EGI support team."
+    offers:
+      1:
+        name: FitSM Foundation Level
         description: |
-            CreoDias EO browser allows browsing wide archive of Earth Observation products, created  by
-            ESA’s [Sentinel 1][1], [Sentinel 2][2], [Sentinel 3][3], ESA’s archives of [Landsat 5][4], [Landsat 7][5],
-            [Landsat 8] [6] and [Envisat][7].
-
-            It provides ability to visualize and download chosen products in .png and .jpg formats.
-
-            [1]: https://sentinel.esa.int/web/sentinel/missions/sentinel-1
-            [2]: https://sentinel.esa.int/web/sentinel/missions/sentinel-2
-            [3]: https://sentinel.esa.int/web/sentinel/missions/sentinel-3
-            [4]: https://landsat.gsfc.nasa.gov/landsat-5/
-            [5]: https://landsat.gsfc.nasa.gov/landsat-7/
-            [6]: https://landsat.gsfc.nasa.gov/landsat-8/landsat-8-overview/
-            [7]: https://earth.esa.int/web/guest/missions/esa-operational-eo-missions/envisat
-        offers:
-            1:
-                name: Cloudferro4
-                description: |
-                    cloudferro
-                order_url: https://browser.creodias.eu
-    Check-in:
-        name: &checkIn EGI Check-in
-        parents: *securityAndOperationsParent
-        providers: [*egi]
-        open_access: false
-        webpage_url: https://www.egi.eu/services/check-in/
-        manual_url:
-        helpdesk_url:
-        training_information_url:
-        terms_of_use_url:
-        sla_url:
-        access_policies_url:
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*research_organisations]
-        domain: *otherOther
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Handle transparent Single Sign-On from multiple heterogeneous identity providers
-        platforms: [*egiPlatform]
+          Target audience: All individuals involved in the provisioning of (federated) IT services,
+          Candidates who wish to progress to advance level of the qualification and certification scheme
+        parameters: &fitSMParameters
+          - id: "id1"
+            label: "Location"
+            description: "Type your location"
+            type: "input"
+            value_type: "string"
+          - id: "id2"
+            label: "Start of service"
+            description: "Please choose start date"
+            type: "date"
+            value_type: "string"
+          - id: "id3"
+            label: "Number of students"
+            description: "Type number of students"
+            type: "range"
+            value_type: "integer"
+            config:
+              minimum: 1
+              maximum: 99999
+      2:
+        name: Advanced Level in Service Planning and Delivery
         description: |
-          Check-in is a proxy service that operates as a central hub to connect federated Identity Providers (IdPs)
-          with service providers. Check-in allows users to select their preferred IdP so that they can access and use
-          services in a uniform and easy way. For the user the feature is transparent:
-          as soon as their IdP is integrated with the proxy, they are redirected by the service to their own IdP.
-          Once integrated the IdP with the proxy, all the services using the IdP proxy will be available.
-          The service providers will get all the AuthN/AuthZ information needed from the IdP Proxy
-          (in form of attributes), without the need to deal with individual IdPs.
-
-          Other components that can be attached to the IdP Proxy are credential translation services
-          and attribute authorities.
-
-          ### Main characteristics:
-
-            - Enables multiple federated authentication sources using
-            different technologies
-            - Increased productivity and security
-            - Federated in eduGAIN as a service provider, publishingREFEDS RnSandSirtficompliance
-            - User registration portal to allow accounts-linkingo
-            - Combines user attributes originating from various authoritative sources
-            (IdPs and attribute provider services) and delivers them to the connected service providers
-            in a transparent way.
-
-          ### Features:
-
-          - Enables federated access to services:
-              *Support for IdPs: SAML2.0, OIDC
-              * Support for SPs: SAML2.0, OIDC
-          - Connection with the CILogon TTS
-          - Enables multiple federated authentication sources using different technologies
-          - Direct integration with the communities AAI services
-          - User registration portal to allow accounts-linkingProvisioning to SPs of an EGI User UID
-
-
-          Brochure: https://www.egi.eu/wp-content/uploads/2017/09/Check-in.pdf
-#    Attribute management:
-#        name: Attribute management
-#        parents: *securityAndOperationsParent
-#        providers: [*grnet, *cesnet]
-#        open_access: false
-#        webpage_url: https://www.egi.eu/internal-services/attribute-management/
-#        manual_url:
-#        helpdesk_url:
-#        training_information_url:
-#        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-#        sla_url: https://documents.egi.eu/document/2733
-#        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-#        geographical_availabilities: *poland
-#        language_availability: *english
-#        target_users: ["Research organisations"]
-#        domain: *otherOther
-#        #restrictions: *notSpecified
-#        trl: *trl_9
-#        life_cycle_status: *prod
-#        tagline: ToFill
-#        platforms: [*egiPlatform]
-#        description: |
-#          EGI provides services to manage user membership, where users can register and ask to be part of a VO,
-#          and where the VO supervisor can approve or remove users from the VO.
-#          The service is a third party service that can be queried by service providers
-#          to decide on user authorization.
-#
-#          Currently EGI has in production: VOMS an X.509 based service
-#
-#          In the wake of extending AAI capabilities, EGI will provide similar capabilities also
-#          for other authentication technologies, like OpenID and SAML2, for example.
-    Training infrastructure:
-        name: Training infrastructure
-        parents: *trainingAndSupportParent
-        providers: [*egi]
-        logo: training-infrastructure.png
-        open_access: false
-        webpage_url: https://www.egi.eu/services/training-infrastructure/
-        manual_url: https://wiki.egi.eu/wiki/Training_infrastructure
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://wiki.egi.eu/wiki/Training_infrastructure
-        terms_of_use_url: https://marketplace.egi.eu/content/3-terms-and-conditions-of-use
-        sla_url: https://documents.egi.eu/document/2733
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*research_groups, *research_organisations]
-        domain: *otherOther
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Dedicated computing and storage for training and education
-        platforms: [*egiPlatform]
+          Target audience: Individuals aiming to fulfil a coordinating role
+          in the ITSM processes related to the planning and delivery of IT services,
+          Candidates who wish to progress to expert level of the qualification and certification scheme.
+        parameters: *fitSMParameters
+      3:
+        name: Advanced Level in Service Operation and Control
         description: |
-          The Training Infrastructure is a cloud­based computing and storage resources for training events.
-          It is useful to organise onsite tutorials or workshops and online training courses or as a platform
-          for self­paced learning.
-
-          Trainers can deploy custom virtual machine images on the Training Infrastructure
-          as the training environment for the students. The virtual machines can be customised according
-          to specific needs and the community can benefit from the easy deployment and easy reuse
-          of course materials.
-
-          The Training Infrastructure uses the same high­quality computing and storage environment
-          that EGI provides to researchers.
-
-          ### To request a training you need to:
-
-            1. Choose the training courses that best fit with your needs below.
-            2. Add the courses to the cart.
-            3. Go to the cart and submit your order.
-            4. You will receive an email summarising your order.
-            5. You will be contacted by the EGI support team.
-        offers:
-          1:
-            name: Training Infrastructure
-            description: |
-              The Training Infrastructure offers cloud compute and online storage for training activities.
-              It is useful to organise onsite tutorials or workshops
-              and online training courses or as a platform for self­-paced learning.
-              For example, with the Training Infrastructure trainers can create
-              and deploy any custom virtual machine images for the students.
-            parameters:
-            - id:  "id1"
-              label:  "Location"
-              description:  "Type your location"
-              type:  "input"
-              value_type:  "string"
-            - id:  "id2"
-              label:  "Aim of the training event"
-              description:  "Type aim of the training event"
-              type:  "input"
-              value_type:  "string"
-            - id:  "id3"
-              label:  "Number of concurrent trainees"
-              description:  "Type number of concurrent trainees"
-              type:  "range"
-              value_type:  "integer"
-              config:
-                minimum: 1
-                maximum: 99999
-            - id:  "id4"
-              label:  "Number of cores"
-              description:  "Type number of cores"
-              type:  "select"
-              value_type:  "integer"
-              config:
-                values: [1, 2, 3, 4, 5, 6, 7, 8]
-                mode: "dropdown"
-            - id:  "id5"
-              label:  "Amount od RAM"
-              description:  "Type amount of RAM"
-              type:  "range"
-              unit: "GB"
-              value_type:  "integer"
-              config:
-                minimum: 1
-                maximum: 99999
-            - id:  "id6"
-              label:  "Online storage size"
-              description:  "Type online storage size"
-              type:  "range"
-              unit: "GB"
-              value_type:  "integer"
-              config:
-                minimum: 1
-                maximum: 99999
-            - id:  "id7"
-              label:  "Special requirements"
-              description:  "Type special requirements"
-              type:  "input"
-              value_type:  "string"
-            - id:  "id8"
-              label:  "Start of service"
-              description:  "Please choose start date"
-              type:  "date"
-              value_type:  "string"
-            - id:  "id9"
-              label:  "Number of days"
-              description:  "Type number of days"
-              type:  "range"
-              value_type:  "integer"
-              config:
-                minimum: 1
-                maximum: 730
-
-    FitSM:
-        name: FitSM
-        parents: *trainingAndSupportParent
-        providers: [*egi]
-        logo: fitsm.png
-        open_access: false
-        webpage_url: https://www.egi.eu/services/fitsm-training/
-        manual_url: https://www.egi.eu/services/fitsm-training/
-        helpdesk_url: https://www.egi.eu/more-information/
-        training_information_url: https://www.egi.eu/services/fitsm-training/
-        terms_of_use_url: https://www.egi.eu/services/fitsm-training/terms-and-conditions/
-        sla_url: https://documents.egi.eu/document/2733
-        access_policies_url: https://marketplace.egi.eu/content/7-access-policy
-        geographical_availabilities: *poland
-        language_availability: *english
-        target_users: [*research_organisations]
-        domain: *otherOther
-        #restrictions: *notSpecified
-        trl: *trl_9
-        life_cycle_status: *prod
-        tagline: Learn how to manage IT services with a pragmatic and lightweight standard
-        platforms: [*egiPlatform]
+          Target audience: Individuals aiming to fulfil a coordinating role
+          in the ITSM processes related to the operation and control of IT services,
+          Candidates who wish to progress to expert level of the qualification and certification scheme.
+        parameters: *fitSMParameters
+      4:
+        name: Expert Level
         description: |
-          FitSM is a lightweight standards family aimed at facilitating service management in IT service provision,
-          including federated scenarios. FitSM training aims at providing those involved in operating
-          federated infrastructures with the professional skills they need in order
-          to effectively manage their services.
+          Target audience: Individuals aiming to fulfil the role of internal or external consultant
+          or auditor in the topic area of IT service management (ITSM).
+        parameters: *fitSMParameters
+      5:
+        name: Consultancy
+        description: |
+          Advise on how to manage IT services with a pragmatic and lightweight standard.
+        parameters:
+          - id: "id1"
+            label: "Description of the consultancy"
+            description: "Type description of the consultancy"
+            type: "input"
+            value_type: "string"
+  Alien and Invasive Species:
+    name: &alien Alien and Invasive Species Virtual Research Environment
+    parents: *processingAndAnalysisParent
+    providers: [ *d4science ]
+    logo: alien.png
+    open_access: true
+    webpage_url: https://services.d4science.org/web/alienandinvasivespecies
+    manual_url: https://services.d4science.org/web/alienandinvasivespecies
+    helpdesk_url: https://support.d4science.org/
+    training_information_url: https://dev.d4science.org/
+    terms_of_use_url: https://services.d4science.org/terms-of-use
+    sla_url: https://wiki.d4science.org/index.php?title=D4Science_Deployment_and_Operation:_Policies#Service_Level_Agreement
+    access_policies_url: https://wiki.d4science.org/index.php?title=D4Science_Deployment_and_Operation:_Policies
+    geographical_availabilities: *poland
+    target_users: [ *research_groups ]
+    restrictions: No restrictions
+    language_availability: *english
+    domain: *otherOther
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: |
+      A web-based, collaborative working environment enacting to predict the spread of an invasive species
+      (possibly alien) in a new environment
+    platforms: [ *egiPlatform, *gbif, *obis, *d4sciencePlatform, *gCube, *seaDataCloud ]
+    description: |
+      Alien and Invasive Species Virtual Research Environment (VRE) is a web-based, comprehensive,
+      collaborative working environment supporting decision makers and scientists in predicting the spread
+      of an invasive species (possibly alien) in a new environment. The VRE hosts examples of suitable habitat maps
+      produced for today and 2050 in new areas for more than 11,000 species and provides models and workflows
+      to combine environmental data with species observations in their habitats to predict their future spread.
 
-          FitSM professional training is certified by TÜV SÜD, a global leader in standardisation and certification.
-          The qualification programme offers three training levels: Foundation, Advanced and Expert.
+      ### Features:
+        - A service providing state-of-the art Data Analytics algorithms suitable for alien
+          and invasive species spread prediction;
+        - A service for seamless discovery and access to species occurrence data and taxa names
+          from several providers providers (eg. BrazilianFlora, OBIS, WoRMS, GBIF, ITIS, CatalogueOfLife);
+        - A complete spatial data infrastructure for discovering, accessing and publishing
+          spatial datasets according to OGC standards;
+        - A catalogue service for discovering, accessing and publishing any research object
+          (multi-part objects with actionable parts) and promoting its re-use;
+        - A social networking service supporting communication among VRE members by sharing and commenting posts;
 
+    offers:
+      1:
+        name: General access
+        description: "a"
+        order_url: https://services.d4science.org/web/alienandinvasivespecies
 
-          ### To request a training you need to:
+  #    OpenAIRE:
+  #      name: &openAIRE OpenAIRE
+  #      parents: *sharingAndDicoveryParent
+  #      providers: [*not]
+  ##      logo: training-infrastructure. TODO: logo
+  #      open_access: false
+  #      webpage_url:
+  #      manual_url:
+  #      helpdesk_url:
+  #      training_information_url:
+  #      terms_of_use_url:
+  #      sla_url:
+  #      access_policies_url:
+  #      geographical_availabilities: *poland
+  #      language_availability: *english
+  #      target_users: ["Research groups", "Research organisations"]
+  #      domain: *otherOther
+  #      #restrictions: *notSpecified
+  #      trl: *trl_9
+  #      life_cycle_status: *prod
+  #      tagline: *notSpecified
+  #      # platforms: [*eopillar, *ec3]
+  #      description: *notSpecified
+  #      offers:
+  #        1:
+  #          name: *notSpecified
+  #          description: *notSpecified
+  PROMINENCE:
+    name: &prominence PROMINENCE
+    parents: *computeParent
+    providers: [ *egi ] #TODO: change to United Kingdom Atomic Energy Authority (or UKAEA)
+    logo: prominence-logo.png
+    open_access: false
+    webpage_url: https://alahiff.github.io/prominence/
+    manual_url:
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *research_groups, *research_organisations ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Enabling HTC & HPC applications opportunistically across private, academic and public clouds
+    # platforms: [*eopillar, *ec3]
+    description: |
+      PROMINENCE is a platform which allows users to exploit idle cloud resources for running scientific workloads
+      with a simple batch system style interface. Key features include:
 
-          1. Choose the training courses that best fit with your needs below.
-          2. Add the courses to the cart.
-          3. Go to the cart and submit your order.
-          4. You will receive an email summarising your order.
-          5. You will be contacted by the EGI support team."
-        offers:
-          1:
-            name: FitSM Foundation Level
-            description: |
-              Target audience: All individuals involved in the provisioning of (federated) IT services,
-              Candidates who wish to progress to advance level of the qualification and certification scheme
-            parameters: &fitSMParameters
-            - id:  "id1"
-              label:  "Location"
-              description:  "Type your location"
-              type:  "input"
-              value_type:  "string"
-            - id:  "id2"
-              label:  "Start of service"
-              description:  "Please choose start date"
-              type:  "date"
-              value_type:  "string"
-            - id:  "id3"
-              label:  "Number of students"
-              description:  "Type number of students"
-              type:  "range"
-              value_type:  "integer"
-              config:
-                minimum: 1
-                maximum: 99999
-          2:
-            name: Advanced Level in Service Planning and Delivery
-            description: |
-              Target audience: Individuals aiming to fulfil a coordinating role
-              in the ITSM processes related to the planning and delivery of IT services,
-              Candidates who wish to progress to expert level of the qualification and certification scheme.
-            parameters: *fitSMParameters
-          3:
-            name: Advanced Level in Service Operation and Control
-            description: |
-              Target audience: Individuals aiming to fulfil a coordinating role
-              in the ITSM processes related to the operation and control of IT services,
-              Candidates who wish to progress to expert level of the qualification and certification scheme.
-            parameters: *fitSMParameters
-          4:
-            name: Expert Level
-            description: |
-              Target audience: Individuals aiming to fulfil the role of internal or external consultant
-              or auditor in the topic area of IT service management (ITSM).
-            parameters: *fitSMParameters
-          5:
-            name: Consultancy
-            description: |
-              Advise on how to manage IT services with a pragmatic and lightweight standard.
-            parameters:
-              - id:  "id1"
-                label:  "Description of the consultancy"
-                description:  "Type description of the consultancy"
-                type:  "input"
-                value_type:  "string"
-    Alien and Invasive Species:
-      name: &alien Alien and Invasive Species Virtual Research Environment
-      parents: *processingAndAnalysisParent
-      providers: [*d4science]
-      logo: alien.png
-      open_access: true
-      webpage_url: https://services.d4science.org/web/alienandinvasivespecies
-      manual_url: https://services.d4science.org/web/alienandinvasivespecies
-      helpdesk_url: https://support.d4science.org/
-      training_information_url: https://dev.d4science.org/
-      terms_of_use_url:  https://services.d4science.org/terms-of-use
-      sla_url: https://wiki.d4science.org/index.php?title=D4Science_Deployment_and_Operation:_Policies#Service_Level_Agreement
-      access_policies_url: https://wiki.d4science.org/index.php?title=D4Science_Deployment_and_Operation:_Policies
-      geographical_availabilities: *poland
-      target_users: [*research_groups]
-      restrictions: No restrictions
-      language_availability: *english
-      domain: *otherOther
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: |
-        A web-based, collaborative working environment enacting to predict the spread of an invasive species
-        (possibly alien) in a new environment
-      platforms: [*egiPlatform, *gbif, *obis, *d4sciencePlatform, *gCube, *seaDataCloud]
-      description: |
-        Alien and Invasive Species Virtual Research Environment (VRE) is a web-based, comprehensive,
-        collaborative working environment supporting decision makers and scientists in predicting the spread
-        of an invasive species (possibly alien) in a new environment. The VRE hosts examples of suitable habitat maps
-        produced for today and 2050 in new areas for more than 11,000 species and provides models and workflows
-        to combine environmental data with species observations in their habitats to predict their future spread.
+        - Jobs can be submitted from anywhere using any OS and any language.
+        - All jobs are run in containers to ensure they will can run reliably anywhere and are reproducible.
+        - Multi-node OpenMPI jobs can be run in addition to HTC jobs.
+        - On-premises resources can be utilised with the ability to burst onto external clouds
+          at times of peak demand.
+        - Goes beyond bursting onto a single external cloud with hierarchical cloud bursting.
+          For example, burst onto national research clouds, to EGI FedCloud and finally to public clouds.
+        - All infrastructure provisioning is handled completely automatically and is totally transparent to the user.
+        - Clouds are selected automatically based on job requirements and preferences,
+          and any failures are handled automatically.
+        - Output data can be accessed from cloud-based object storage.
+    offers:
+      1:
+        name: *notSpecified
+        description: *notSpecified
+  PAN data:
+    name: &panData PaN data
+    parents: *storageParent
+    providers: [ *desyProvider ]
+    logo: panData.png
+    open_access: false
+    webpage_url: https://dcache-xdc.desy.de
+    manual_url: https://eosc-pan-git.desy.de/support
+    helpdesk_url: https://eosc-pan-git.desy.de/support
+    training_information_url: https://eosc-pan-git.desy.de
+    terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
+    access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *otherOther
+    restrictions: |
+      Access to the platform is granted based on motivation / proposal,
+      In the pilot phase, usage is only supported for  photon and neutron science use-cases
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: dCache backend storage for the EOSC PAN Science Demonstrator
+    platforms: [ *eoscPan ]
+    description: |
+      Data backend storage service for EOSC PAN notebooks and cloud functions for EOSC PAN FaaS.
+      Streams for storage events via kafka and Server Sent Events.
+      Delegation of read/write access with Macaroons.
+    offers:
+      1:
+        name: PAN Demo
+        description: |
+          Bind gitlab repositories to Jupyter Notebooks and use functions as a service
+          on photon and neutron research data.
+          The demo version of this service will be restricted to read access to data, notebooks,
+          gitlab repos and the ability to invoke functions. Please contact eosc-pan-info@desy.de
+          in case of special requests for write access to backend storage, cloud functions from
+          new gitlab repositories, events streaming from the dCache backend.
+  Pan faas:
+    name: &panFaas PaN faas
+    parents: *computeParent
+    providers: [ *desyProvider ]
+    logo: panFaas.png
+    open_access: false
+    webpage_url: https://eosc-pan-git.desy.de/pan/support/
+    manual_url: https://eosc-pan-git.desy.de/support
+    helpdesk_url: https://eosc-pan-git.desy.de/support
+    training_information_url: https://eosc-pan-git.desy.de
+    terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
+    access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: OpenWhisk, cloud functions for the EOSC PAN Science Demonstrator
+    platforms: [ *eoscPan ]
+    description: |
+      Compute backend service for EOSC PAN notebooks and EOSC PAN data.
+      Continuous integration and deployments of docker containers as cloud functions on the DESY Compute Cloud.
+    offers:
+      1:
+        name: PAN Demo
+        description: |
+          Bind gitlab repositories to Jupyter Notebooks and use functions as a service
+          on photon and neutron research data.
+          The demo version of this service will be restricted to read access to data, notebooks,
+          gitlab repos and the ability to invoke functions. Please contact eosc-pan-info@desy.de
+          in case of special requests for write access to backend storage, cloud functions from
+          new gitlab repositories, events streaming from the dCache backend.
+  "da|ra - DOI Registration Service for social science and economic data":
+    name: &daRaDoiRegistrationServiceForSocialScienceAndEconomicData "da|ra - DOI Registration Service for social science and economic data"
+    parents: *sharingAndDicoveryParent
+    providers: [ *desyProvider ]
+    logo: panFaas.png
+    open_access: false
+    webpage_url: https://eosc-pan-git.desy.de/pan/support/
+    manual_url: https://eosc-pan-git.desy.de/support
+    helpdesk_url: https://eosc-pan-git.desy.de/support
+    training_information_url: https://eosc-pan-git.desy.de
+    terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
+    access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    platforms: [ *eoscPan ]
+    description: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia risus velit,
+      in tempus erat interdum vel. Suspendisse elit metus, lobortis et felis a,
+      tristique rhoncus erat. Vestibulum varius egestas arcu sit amet rhoncus. Sed sem ligula,
+      faucibus ac felis eu, blandit elementum velit. Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit. Etiam at condimentum diam. Cras sed arcu nisl.
+    offers:
+      1:
+        name: Test 1
+        order_type: open_access
+        description: |
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia risus velit,
+          in tempus erat interdum vel. Suspendisse elit metus, lobortis et felis a,
+          tristique rhoncus erat. Vestibulum varius egestas arcu sit amet rhoncus. Sed sem ligula,
+          faucibus ac felis eu, blandit elementum velit. Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit. Etiam at condimentum diam. Cras sed arcu nisl.
+      2:
+        name: Test 2
+        description: |
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia risus velit,
+          in tempus erat interdum vel. Suspendisse elit metus, lobortis et felis a,
+          tristique rhoncus erat. Vestibulum varius egestas arcu sit amet rhoncus. Sed sem ligula,
+          faucibus ac felis eu, blandit elementum velit. Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit. Etiam at condimentum diam. Cras sed arcu nisl.
+      3:
+        name: Test 3
+        description: |
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia risus velit,
+          in tempus erat interdum vel. Suspendisse elit metus, lobortis et felis a,
+          tristique rhoncus erat. Vestibulum varius egestas arcu sit amet rhoncus. Sed sem ligula,
+          faucibus ac felis eu, blandit elementum velit. Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit. Etiam at condimentum diam. Cras sed arcu nisl.
+  PAN notebook:
+    name: &panNotebook PaN notebook
+    parents: *computeParent
+    providers: [ *desyProvider ]
+    logo: panFaas.png
+    open_access: false
+    webpage_url: https://eosc-pan-jhub.desy.de
+    manual_url: https://eosc-pan-git.desy.de/support
+    helpdesk_url: https://eosc-pan-git.desy.de/support
+    training_information_url: https://eosc-pan-git.desy.de
+    terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
+    access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: JupyterHub for the EOSC PAN Science Demonstrator
+    platforms: [ *eoscPan ]
+    description: |
+      Spawn Jupyter Servers in the DESY Compute Cloud and run notebooks which can make use
+      of the EOSC PaN FaaS Service and connect to EOSC PaN Data Service.
+    offers:
+      1:
+        name: PAN Demo
+        description: |
+          Bind gitlab repositories to Jupyter Notebooks and use functions as a service
+          on photon and neutron research data.
+          The demo version of this service will be restricted to read access to data, notebooks,
+          gitlab repos and the ability to invoke functions. Please contact eosc-pan-info@desy.de
+          in case of special requests for write access to backend storage, cloud functions from
+          new gitlab repositories, events streaming from the dCache backend.
+  PAN gitlab:
+    name: &panGitlab PAN gitlab
+    parents: *computeParent
+    providers: [ *desyProvider ]
+    logo: panFaas.png
+    open_access: false
+    webpage_url: https://eosc-pan-git.desy.de
+    manual_url: https://eosc-pan-git.desy.de/support
+    helpdesk_url: https://eosc-pan-git.desy.de/support
+    training_information_url: https://eosc-pan-git.desy.de
+    terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
+    access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: GitLab for the EOSC PAN Science Demonstrator
+    platforms: [ *eoscPan ]
+    description: |
+      Repository service for EOSC PAN notebooks and cloud functions for EOSC PAN FaaS. Gitlab runners
+      for continuous integration in the DESY Compute Cloud,
+      building and publishing docker containers in the project registry.
+    offers:
+      1:
+        name: PAN Demo
+        description: |
+          Bind gitlab repositories to Jupyter Notebooks and use functions as a service
+          on photon and neutron research data.
+          The demo version of this service will be restricted to read access to data, notebooks,
+          gitlab repos and the ability to invoke functions. Please contact eosc-pan-info@desy.de
+          in case of special requests for write access to backend storage, cloud functions from
+          new gitlab repositories, events streaming from the dCache backend.
+  WS-PGRADE:
+    name: &wsPgrade WS-PGRADE
+    parents: *processingAndAnalysisParent
+    providers: [ *mtaSztaki ]
+    logo: wspgrade.png
+    open_access: false
+    webpage_url: https://ltos-gateway.lpds.sztaki.hu/web/wizard
+    manual_url: https://ltos-gateway.lpds.sztaki.hu/web/wizard/help
+    helpdesk_url: https://wiki.egi.eu/wiki/GGUS:WS-PGRADE/gUSE_FAQ
+    training_information_url: https://ltos-gateway.lpds.sztaki.hu/web/wizard/help
+    terms_of_use_url: https://ltos-gateway.lpds.sztaki.hu/web/wizard/terms-of-use
+    sla_url: https://documents.egi.eu/document/2733
+    access_policies_url: https://documents.egi.eu/public/ShowDocument?docid=2635
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *business ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Setup and run parameter studies in the cloud with a few clicks.
+    platforms: [ *eoscHub, *aodp ]
+    description: |
+      The WS-PGRADE Portal (Web Services Parallel Grid Runtime and Developer Environment Portal)
+      is the Liferay-based web portal (WS-PGRADE web application) of gUSE high level middleware system.
+      This WS-PGRADE deployment is operated within the EGI ‘Applications on Demand’ service and provides
+      an easy to use 'Job Wizard' environment for users. Through the Job Wizard one can define with
+      a few clicks computational jobs that WS-PGRADE will execute on Infrastructure as a Service
+      clouds pre-configured by EGI. WS-PGRADE takes care of all aspects of job management in the cloud,
+      including instantiation of Virtual Machine images and retrieval of outputs. Jobs can be single processor
+      applications or 'parameter study' type applications where each instance
+      of the job takes different input parameters.
 
-        ### Features:
-          - A service providing state-of-the art Data Analytics algorithms suitable for alien
-            and invasive species spread prediction;
-          - A service for seamless discovery and access to species occurrence data and taxa names
-            from several providers providers (eg. BrazilianFlora, OBIS, WoRMS, GBIF, ITIS, CatalogueOfLife);
-          - A complete spatial data infrastructure for discovering, accessing and publishing
-            spatial datasets according to OGC standards;
-          - A catalogue service for discovering, accessing and publishing any research object
-            (multi-part objects with actionable parts) and promoting its re-use;
-          - A social networking service supporting communication among VRE members by sharing and commenting posts;
+      ### Features:
 
-      offers:
-        1:
-          name: General access
-          description: "a"
-          order_url: https://services.d4science.org/web/alienandinvasivespecies
+        - Federated authentication through the EGI Applications on Demand service.
+        - Graphical interfaces for job definition, job execution, inspection of results.
+        - Web based access.
+        - Interoperability with most widely used IaaS cloud technologies
+        - Job wizard interface to streamline analytical steps.
+        - Use of ‘per-user subproxies’ from EGI to access X.509-protected resources on the users’ behalf.
+    offers:
+      1:
+        name: WS Demo
+        description: |
+          demo
+  CSC ePouta:
+    name: &cscEpouta CSC ePouta
+    parents: [ *processingAndAnalysisParent, *computeParent ]
+    providers: [ *csc ]
+    logo: ePouta-logo.jpg
+    open_access: false
+    webpage_url: https://research.csc.fi/epouta
+    manual_url: https://research.csc.fi/pouta-user-guide
+    helpdesk_url:
+    training_information_url:
+    terms_of_use_url: https://research.csc.fi/pouta-user-policy
+    sla_url: https://research.csc.fi/documents/48467/0/ePouta+SLA/cbac49af-f069-4a8b-9636-e519b1ee331d
+    access_policies_url: https://research.csc.fi/pricing-of-computing-services
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *research_groups, *providers ]
+    domain: [ *otherSocialSciences, *otherHumanities, *otherOther, *philosophy ]
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Secure and cost-effective cloud computing for processing sensitive data
+    platforms: [ *eudatPlatform, *elixirPlatform ]
+    description: |
+      This service provides a infrastructure as a-service for running analysis on sensitive data.
+      The ePouta Virtual Private Cloud service allows customers to provision virtual machines and
+      storage resources directly to their own internal networks. It provides an easy to use admin web interface and
+      a programmable API for managing virtual machines, networks and storage. CSC ePouta meets elevated information
+      security level regulations and is targeted for sensitive data processing
+    offers:
+      1:
+        name: CSC Demo
+        description: |
+          demo
+  TDS:
+    name: &tds TDS
+    parents: [ *processingAndAnalysisParent, *storageParent ]
+    providers: [ *uioProider ]
+    #logo: panFaas.png TODO: nologo
+    open_access: false
+    webpage_url: https://www.uio.no/english/services/it/research/sensitive-data/
+    manual_url:
+    helpdesk_url: https://www.uio.no/english/services/it/research/sensitive-data/
+    training_information_url:
+    terms_of_use_url:
+    sla_url:
+    access_policies_url:
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers ]
+    domain: *otherOther
+    #restrictions: *notSpecified
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Services for sensitive data
+    platforms: [ *eudatPlatform, *nird ]
+    description: |
+      This service provides researchers with a desktop with secure storage and software
+      to run your collection and analysis of sensitive data. The system is built on the idea
+      that having a robust firewall around a system that provides a full separation of projects, is the best policy.
+      A two-step authentication is needed to gain access to the system. Inside the system,
+      every project has its own VLAN and its own virtual file system.
+      This means that projects cannot find any information about any other project on the system.
+    offers:
+      1:
+        name: TDS Demo
+        description: |
+          demo
+  Elastic Cloud Compute Cluster (EC3):
+    name: &ec3Service Elastic Cloud Compute Cluster (EC3)
+    parents: *processingAndAnalysisParent
+    providers: [ *grycap ]
+    logo: ec3.png
+    open_access: false
+    webpage_url: https://servproject.i3m.upv.es/ec3-ltos/index.php
+    manual_url: https://ec3.readthedocs.io/en/devel/
+    helpdesk_url: https://wiki.egi.eu/wiki/GGUS:EC3_FAQ
+    training_information_url: https://github.com/grycap/ec3
+    terms_of_use_url: https://servproject.i3m.upv.es/ec3-ltos/terms.html
+    sla_url: https://documents.egi.eu/document/2733
+    access_policies_url: https://documents.egi.eu/public/ShowDocument?docid=2635
+    geographical_availabilities: *poland
+    language_availability: *english
+    target_users: [ *researchers, *research_organisations, *business ]
+    domain: *otherOther
+    restrictions: Research affiliation needed
+    trl: *trl_9
+    life_cycle_status: *prod
+    tagline: Deploy a virtual cluster on top of IaaS infrastructures with a few clicks.
+    platforms: [ *eoscHub, *aodp ]
+    description: |
+      The Elastic Cloud Computing Cluster (EC3) is a platform that allows creating elastic virtual clusters
+      on top of Infrastructure as a Service (IaaS) providers, either public (such as Amazon Web Services,
+      Google Cloud or Microsoft Azure) or on-premises (such as OpenNebula and OpenStack).
+      Through a 'job wizard' interface, the user can configure the virtual cluster with a predefined set
+      of applications that will be deployed in the clouds underpinning the EGI Applications On Demand infrastructure.
+      The installation and the configuration of the cluster are performed by means of the execution
+      of Ansible receipts. The cluster configured by EC3 is private: as soon as it is configured
+      the user will have root access to the environment, and can setup and configure the cluster
+      installing additional libraries and software to their needs.
 
-#    OpenAIRE:
-#      name: &openAIRE OpenAIRE
-#      parents: *sharingAndDicoveryParent
-#      providers: [*not]
-##      logo: training-infrastructure. TODO: logo
-#      open_access: false
-#      webpage_url:
-#      manual_url:
-#      helpdesk_url:
-#      training_information_url:
-#      terms_of_use_url:
-#      sla_url:
-#      access_policies_url:
-#      geographical_availabilities: *poland
-#      language_availability: *english
-#      target_users: ["Research groups", "Research organisations"]
-#      domain: *otherOther
-#      #restrictions: *notSpecified
-#      trl: *trl_9
-#      life_cycle_status: *prod
-#      tagline: *notSpecified
-#      # platforms: [*eopillar, *ec3]
-#      description: *notSpecified
-#      offers:
-#        1:
-#          name: *notSpecified
-#          description: *notSpecified
-    PROMINENCE:
-      name: &prominence PROMINENCE
-      parents: *computeParent
-      providers: [*egi] #TODO: change to United Kingdom Atomic Energy Authority (or UKAEA)
-      logo: prominence-logo.png
-      open_access: false
-      webpage_url: https://alahiff.github.io/prominence/
-      manual_url:
-      helpdesk_url:
-      training_information_url:
-      terms_of_use_url:
-      sla_url:
-      access_policies_url:
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*research_groups, *research_organisations]
-      domain: *otherOther
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: Enabling HTC & HPC applications opportunistically across private, academic and public clouds
-      # platforms: [*eopillar, *ec3]
-      description: |
-        PROMINENCE is a platform which allows users to exploit idle cloud resources for running scientific workloads
-        with a simple batch system style interface. Key features include:
+      ### Features:
 
-          - Jobs can be submitted from anywhere using any OS and any language.
-          - All jobs are run in containers to ensure they will can run reliably anywhere and are reproducible.
-          - Multi-node OpenMPI jobs can be run in addition to HTC jobs.
-          - On-premises resources can be utilised with the ability to burst onto external clouds
-            at times of peak demand.
-          - Goes beyond bursting onto a single external cloud with hierarchical cloud bursting.
-            For example, burst onto national research clouds, to EGI FedCloud and finally to public clouds.
-          - All infrastructure provisioning is handled completely automatically and is totally transparent to the user.
-          - Clouds are selected automatically based on job requirements and preferences,
-            and any failures are handled automatically.
-          - Output data can be accessed from cloud-based object storage.
-      offers:
-        1:
-          name: *notSpecified
-          description: *notSpecified
-    PAN data:
-      name: &panData PaN data
-      parents: *storageParent
-      providers: [*desyProvider]
-      logo: panData.png
-      open_access: false
-      webpage_url: https://dcache-xdc.desy.de
-      manual_url: https://eosc-pan-git.desy.de/support
-      helpdesk_url: https://eosc-pan-git.desy.de/support
-      training_information_url: https://eosc-pan-git.desy.de
-      terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
-      access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*researchers]
-      domain: *otherOther
-      restrictions: |
-        Access to the platform is granted based on motivation / proposal,
-        In the pilot phase, usage is only supported for  photon and neutron science use-cases
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: dCache backend storage for the EOSC PAN Science Demonstrator
-      platforms: [*eoscPan]
-      description: |
-        Data backend storage service for EOSC PAN notebooks and cloud functions for EOSC PAN FaaS.
-        Streams for storage events via kafka and Server Sent Events.
-        Delegation of read/write access with Macaroons.
-      offers:
-        1:
-          name: PAN Demo
-          description: |
-            Bind gitlab repositories to Jupyter Notebooks and use functions as a service
-            on photon and neutron research data.
-            The demo version of this service will be restricted to read access to data, notebooks,
-            gitlab repos and the ability to invoke functions. Please contact eosc-pan-info@desy.de
-            in case of special requests for write access to backend storage, cloud functions from
-            new gitlab repositories, events streaming from the dCache backend.
-    Pan faas:
-      name: &panFaas PaN faas
-      parents: *computeParent
-      providers: [*desyProvider]
-      logo: panFaas.png
-      open_access: false
-      webpage_url: https://eosc-pan-git.desy.de/pan/support/
-      manual_url: https://eosc-pan-git.desy.de/support
-      helpdesk_url: https://eosc-pan-git.desy.de/support
-      training_information_url: https://eosc-pan-git.desy.de
-      terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
-      access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*researchers]
-      domain: *otherOther
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: OpenWhisk, cloud functions for the EOSC PAN Science Demonstrator
-      platforms: [*eoscPan]
-      description: |
-        Compute backend service for EOSC PAN notebooks and EOSC PAN data.
-        Continuous integration and deployments of docker containers as cloud functions on the DESY Compute Cloud.
-      offers:
-        1:
-          name: PAN Demo
-          description: |
-            Bind gitlab repositories to Jupyter Notebooks and use functions as a service
-            on photon and neutron research data.
-            The demo version of this service will be restricted to read access to data, notebooks,
-            gitlab repos and the ability to invoke functions. Please contact eosc-pan-info@desy.de
-            in case of special requests for write access to backend storage, cloud functions from
-            new gitlab repositories, events streaming from the dCache backend.
-    "da|ra - DOI Registration Service for social science and economic data":
-      name: &daRaDoiRegistrationServiceForSocialScienceAndEconomicData "da|ra - DOI Registration Service for social science and economic data"
-      parents: *sharingAndDicoveryParent
-      providers: [ *desyProvider ]
-      logo: panFaas.png
-      open_access: false
-      webpage_url: https://eosc-pan-git.desy.de/pan/support/
-      manual_url: https://eosc-pan-git.desy.de/support
-      helpdesk_url: https://eosc-pan-git.desy.de/support
-      training_information_url: https://eosc-pan-git.desy.de
-      terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
-      access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [ *researchers ]
-      domain: *otherOther
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      platforms: [ *eoscPan ]
-      description: |
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia risus velit,
-        in tempus erat interdum vel. Suspendisse elit metus, lobortis et felis a,
-        tristique rhoncus erat. Vestibulum varius egestas arcu sit amet rhoncus. Sed sem ligula,
-        faucibus ac felis eu, blandit elementum velit. Lorem ipsum dolor sit amet,
-        consectetur adipiscing elit. Etiam at condimentum diam. Cras sed arcu nisl.
-      offers:
-        1:
-          name: Test 1
-          order_type: open_access
-          description: |
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia risus velit,
-            in tempus erat interdum vel. Suspendisse elit metus, lobortis et felis a,
-            tristique rhoncus erat. Vestibulum varius egestas arcu sit amet rhoncus. Sed sem ligula,
-            faucibus ac felis eu, blandit elementum velit. Lorem ipsum dolor sit amet,
-            consectetur adipiscing elit. Etiam at condimentum diam. Cras sed arcu nisl.
-        2:
-          name: Test 2
-          description: |
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia risus velit,
-            in tempus erat interdum vel. Suspendisse elit metus, lobortis et felis a,
-            tristique rhoncus erat. Vestibulum varius egestas arcu sit amet rhoncus. Sed sem ligula,
-            faucibus ac felis eu, blandit elementum velit. Lorem ipsum dolor sit amet,
-            consectetur adipiscing elit. Etiam at condimentum diam. Cras sed arcu nisl.
-        3:
-          name: Test 3
-          description: |
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia risus velit,
-            in tempus erat interdum vel. Suspendisse elit metus, lobortis et felis a,
-            tristique rhoncus erat. Vestibulum varius egestas arcu sit amet rhoncus. Sed sem ligula,
-            faucibus ac felis eu, blandit elementum velit. Lorem ipsum dolor sit amet,
-            consectetur adipiscing elit. Etiam at condimentum diam. Cras sed arcu nisl.
-    PAN notebook:
-      name: &panNotebook PaN notebook
-      parents: *computeParent
-      providers: [*desyProvider]
-      logo: panFaas.png
-      open_access: false
-      webpage_url: https://eosc-pan-jhub.desy.de
-      manual_url: https://eosc-pan-git.desy.de/support
-      helpdesk_url: https://eosc-pan-git.desy.de/support
-      training_information_url: https://eosc-pan-git.desy.de
-      terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
-      access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*researchers]
-      domain: *otherOther
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: JupyterHub for the EOSC PAN Science Demonstrator
-      platforms: [*eoscPan]
-      description: |
-        Spawn Jupyter Servers in the DESY Compute Cloud and run notebooks which can make use
-        of the EOSC PaN FaaS Service and connect to EOSC PaN Data Service.
-      offers:
-        1:
-          name: PAN Demo
-          description: |
-            Bind gitlab repositories to Jupyter Notebooks and use functions as a service
-            on photon and neutron research data.
-            The demo version of this service will be restricted to read access to data, notebooks,
-            gitlab repos and the ability to invoke functions. Please contact eosc-pan-info@desy.de
-            in case of special requests for write access to backend storage, cloud functions from
-            new gitlab repositories, events streaming from the dCache backend.
-    PAN gitlab:
-      name: &panGitlab PAN gitlab
-      parents: *computeParent
-      providers: [*desyProvider]
-      logo: panFaas.png
-      open_access: false
-      webpage_url: https://eosc-pan-git.desy.de
-      manual_url: https://eosc-pan-git.desy.de/support
-      helpdesk_url: https://eosc-pan-git.desy.de/support
-      training_information_url: https://eosc-pan-git.desy.de
-      terms_of_use_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      sla_url: https://desycloud.desy.de/index.php/s/XrKEbpXFBBKfq4G
-      access_policies_url: https://it.desy.de/sites2009/site_it/content/e1993/e163002/infoboxContent163004/BO-IV-DESY-Eng_eng.pdf
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*researchers]
-      domain: *otherOther
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: GitLab for the EOSC PAN Science Demonstrator
-      platforms: [*eoscPan]
-      description: |
-        Repository service for EOSC PAN notebooks and cloud functions for EOSC PAN FaaS. Gitlab runners
-        for continuous integration in the DESY Compute Cloud,
-        building and publishing docker containers in the project registry.
-      offers:
-        1:
-          name: PAN Demo
-          description: |
-            Bind gitlab repositories to Jupyter Notebooks and use functions as a service
-            on photon and neutron research data.
-            The demo version of this service will be restricted to read access to data, notebooks,
-            gitlab repos and the ability to invoke functions. Please contact eosc-pan-info@desy.de
-            in case of special requests for write access to backend storage, cloud functions from
-            new gitlab repositories, events streaming from the dCache backend.
-    WS-PGRADE:
-      name: &wsPgrade WS-PGRADE
-      parents: *processingAndAnalysisParent
-      providers: [*mtaSztaki]
-      logo: wspgrade.png
-      open_access: false
-      webpage_url: https://ltos-gateway.lpds.sztaki.hu/web/wizard
-      manual_url: https://ltos-gateway.lpds.sztaki.hu/web/wizard/help
-      helpdesk_url: https://wiki.egi.eu/wiki/GGUS:WS-PGRADE/gUSE_FAQ
-      training_information_url: https://ltos-gateway.lpds.sztaki.hu/web/wizard/help
-      terms_of_use_url: https://ltos-gateway.lpds.sztaki.hu/web/wizard/terms-of-use
-      sla_url: https://documents.egi.eu/document/2733
-      access_policies_url: https://documents.egi.eu/public/ShowDocument?docid=2635
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*researchers, *research_organisations, *business]
-      domain: *otherOther
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: Setup and run parameter studies in the cloud with a few clicks.
-      platforms: [*eoscHub, *aodp]
-      description: |
-        The WS-PGRADE Portal (Web Services Parallel Grid Runtime and Developer Environment Portal)
-        is the Liferay-based web portal (WS-PGRADE web application) of gUSE high level middleware system.
-        This WS-PGRADE deployment is operated within the EGI ‘Applications on Demand’ service and provides
-        an easy to use 'Job Wizard' environment for users. Through the Job Wizard one can define with
-        a few clicks computational jobs that WS-PGRADE will execute on Infrastructure as a Service
-        clouds pre-configured by EGI. WS-PGRADE takes care of all aspects of job management in the cloud,
-        including instantiation of Virtual Machine images and retrieval of outputs. Jobs can be single processor
-        applications or 'parameter study' type applications where each instance
-        of the job takes different input parameters.
-
-        ### Features:
-
-          - Federated authentication through the EGI Applications on Demand service.
-          - Graphical interfaces for job definition, job execution, inspection of results.
-          - Web based access.
-          - Interoperability with most widely used IaaS cloud technologies
-          - Job wizard interface to streamline analytical steps.
-          - Use of ‘per-user subproxies’ from EGI to access X.509-protected resources on the users’ behalf.
-      offers:
-          1:
-            name: WS Demo
-            description: |
-              demo
-    CSC ePouta:
-      name: &cscEpouta CSC ePouta
-      parents: [*processingAndAnalysisParent, *computeParent]
-      providers: [*csc]
-      logo: ePouta-logo.jpg
-      open_access: false
-      webpage_url: https://research.csc.fi/epouta
-      manual_url: https://research.csc.fi/pouta-user-guide
-      helpdesk_url:
-      training_information_url:
-      terms_of_use_url: https://research.csc.fi/pouta-user-policy
-      sla_url: https://research.csc.fi/documents/48467/0/ePouta+SLA/cbac49af-f069-4a8b-9636-e519b1ee331d
-      access_policies_url: https://research.csc.fi/pricing-of-computing-services
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*researchers, *research_organisations, *research_groups, *providers]
-      domain: [*otherSocialSciences, *otherHumanities, *otherOther, *philosophy]
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: Secure and cost-effective cloud computing for processing sensitive data
-      platforms: [*eudatPlatform, *elixirPlatform]
-      description: |
-        This service provides a infrastructure as a-service for running analysis on sensitive data.
-        The ePouta Virtual Private Cloud service allows customers to provision virtual machines and
-        storage resources directly to their own internal networks. It provides an easy to use admin web interface and
-        a programmable API for managing virtual machines, networks and storage. CSC ePouta meets elevated information
-        security level regulations and is targeted for sensitive data processing
-      offers:
-          1:
-            name: CSC Demo
-            description: |
-              demo
-    TDS:
-      name: &tds TDS
-      parents: [*processingAndAnalysisParent, *storageParent]
-      providers: [*uioProider]
-      #logo: panFaas.png TODO: nologo
-      open_access: false
-      webpage_url: https://www.uio.no/english/services/it/research/sensitive-data/
-      manual_url:
-      helpdesk_url: https://www.uio.no/english/services/it/research/sensitive-data/
-      training_information_url:
-      terms_of_use_url:
-      sla_url:
-      access_policies_url:
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*researchers]
-      domain: *otherOther
-      #restrictions: *notSpecified
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: Services for sensitive data
-      platforms: [*eudatPlatform, *nird]
-      description: |
-        This service provides researchers with a desktop with secure storage and software
-        to run your collection and analysis of sensitive data. The system is built on the idea
-        that having a robust firewall around a system that provides a full separation of projects, is the best policy.
-        A two-step authentication is needed to gain access to the system. Inside the system,
-        every project has its own VLAN and its own virtual file system.
-        This means that projects cannot find any information about any other project on the system.
-      offers:
-          1:
-            name: TDS Demo
-            description: |
-              demo
-    Elastic Cloud Compute Cluster (EC3):
-      name: &ec3Service Elastic Cloud Compute Cluster (EC3)
-      parents: *processingAndAnalysisParent
-      providers: [*grycap]
-      logo: ec3.png
-      open_access: false
-      webpage_url: https://servproject.i3m.upv.es/ec3-ltos/index.php
-      manual_url: https://ec3.readthedocs.io/en/devel/
-      helpdesk_url: https://wiki.egi.eu/wiki/GGUS:EC3_FAQ
-      training_information_url: https://github.com/grycap/ec3
-      terms_of_use_url: https://servproject.i3m.upv.es/ec3-ltos/terms.html
-      sla_url: https://documents.egi.eu/document/2733
-      access_policies_url:  https://documents.egi.eu/public/ShowDocument?docid=2635
-      geographical_availabilities: *poland
-      language_availability: *english
-      target_users: [*researchers, *research_organisations, *business]
-      domain: *otherOther
-      restrictions: Research affiliation needed
-      trl: *trl_9
-      life_cycle_status: *prod
-      tagline: Deploy a virtual cluster on top of IaaS infrastructures with a few clicks.
-      platforms: [*eoscHub, *aodp]
-      description: |
-        The Elastic Cloud Computing Cluster (EC3) is a platform that allows creating elastic virtual clusters
-        on top of Infrastructure as a Service (IaaS) providers, either public (such as Amazon Web Services,
-        Google Cloud or Microsoft Azure) or on-premises (such as OpenNebula and OpenStack).
-        Through a 'job wizard' interface, the user can configure the virtual cluster with a predefined set
-        of applications that will be deployed in the clouds underpinning the EGI Applications On Demand infrastructure.
-        The installation and the configuration of the cluster are performed by means of the execution
-        of Ansible receipts. The cluster configured by EC3 is private: as soon as it is configured
-        the user will have root access to the environment, and can setup and configure the cluster
-        installing additional libraries and software to their needs.
-
-        ### Features:
-
-          - Federated authentication through the EGI Applications on Demand service.
-          - Web based access.
-          - Interoperability with most widely used IaaS cloud technologies
-          - Wizard interface to streamline the configuration and the deployment of the virtual cluster on top of Infrastructure as a Service (IaaS) providers.
-          - Several Ansible receipts are available to deploy applications and tools in the cluster nodes.
-          - Nodes of the clusters will be self-managed by CLUES. Working nodes will be undeployed when they are idle.
-          - Use of ‘per-user subproxies’ from EGI to access X.509-protected resources on the users’ behalf.
-      offers:
-          1:
-              name: EC3 Demo
-              description: |
-                  demo
+        - Federated authentication through the EGI Applications on Demand service.
+        - Web based access.
+        - Interoperability with most widely used IaaS cloud technologies
+        - Wizard interface to streamline the configuration and the deployment of the virtual cluster on top of Infrastructure as a Service (IaaS) providers.
+        - Several Ansible receipts are available to deploy applications and tools in the cluster nodes.
+        - Nodes of the clusters will be self-managed by CLUES. Working nodes will be undeployed when they are idle.
+        - Use of ‘per-user subproxies’ from EGI to access X.509-protected resources on the users’ behalf.
+    offers:
+      1:
+        name: EC3 Demo
+        description: |
+          demo
 
 
 relations:
@@ -5842,24 +5887,24 @@ relations:
     source: *cfi
     target: *gepHRCM
   cfiToRasdamanDatacube:
-      both: false
-      source: *cfi
-      target: *rasdamanDatacube
+    both: false
+    source: *cfi
+    target: *rasdamanDatacube
   cfiToSentinelHub:
-      both: false
-      source: *cfi
-      target: *sentinelHub
+    both: false
+    source: *cfi
+    target: *sentinelHub
   EObrowserToSentinelHub:
-      both: true
-      source: *cfdrsEOB
-      target: *sentinelHub
+    both: true
+    source: *cfdrsEOB
+    target: *sentinelHub
 
 
 
-#  amberToEgiWM:
-#    both: false
-#    source: *amber
-#    target: *egiWM
+  #  amberToEgiWM:
+  #    both: false
+  #    source: *amber
+  #    target: *egiWM
   csRosetaToEgiCloud:
     both: false
     source: *csRoseta
@@ -5872,10 +5917,10 @@ relations:
     both: false
     source: *csRoseta
     target: *checkIn
-#  csRosetaToEgiWM:
-#    both: false
-#    source: *csRoseta
-#    target: *egiWM
+  #  csRosetaToEgiWM:
+  #    both: false
+  #    source: *csRoseta
+  #    target: *egiWM
   disVisToEgiCloud:
     both: false
     source: *disVis
@@ -5888,10 +5933,10 @@ relations:
     both: false
     source: *disVis
     target: *checkIn
-#  disVisToEgiWM:
-#    both: false
-#    source: *disVis
-#    target: *egiWM
+  #  disVisToEgiWM:
+  #    both: false
+  #    source: *disVis
+  #    target: *egiWM
   fantenToEgiCloud:
     both: false
     source: *fanten
@@ -5904,10 +5949,10 @@ relations:
     both: false
     source: *fanten
     target: *checkIn
-#  fantenToEgiWM:
-#    both: false
-#    source: *fanten
-#    target: *egiWM
+  #  fantenToEgiWM:
+  #    both: false
+  #    source: *fanten
+  #    target: *egiWM
   haddockToEgiCloud:
     both: false
     source: *haddock
@@ -5920,10 +5965,10 @@ relations:
     both: false
     source: *haddock
     target: *checkIn
-#  haddockToEgiWM:
-#    both: false
-#    source: *haddock
-#    target: *egiWM
+  #  haddockToEgiWM:
+  #    both: false
+  #    source: *haddock
+  #    target: *egiWM
   powerFitToEgiCloud:
     both: false
     source: *powerFit
@@ -5936,10 +5981,10 @@ relations:
     both: false
     source: *powerFit
     target: *checkIn
-#  powerFitToEgiWM:
-#    both: false
-#    source: *powerFit
-#    target: *egiWM
+  #  powerFitToEgiWM:
+  #    both: false
+  #    source: *powerFit
+  #    target: *egiWM
   spotOnToEgiCloud:
     both: false
     source: *spotOn
@@ -5968,14 +6013,14 @@ relations:
     both: true
     source: *egiCloud
     target: *alien
-#  egiToOpenAire:
-#    both: true
-#    source: *egiCloud
-#    target: *openAIRE
-#  alienToOpenAire:
-#    both: true
-#    source: *alien
-#    target: *openAIRE
+  #  egiToOpenAire:
+  #    both: true
+  #    source: *egiCloud
+  #    target: *openAIRE
+  #  alienToOpenAire:
+  #    both: true
+  #    source: *alien
+  #    target: *openAIRE
   lifewatchERICPlantsToEgiCloud:
     both: true
     source: *lifewatchERICPlants
@@ -5985,45 +6030,45 @@ relations:
     source: *egiCloud
     target: *checkIn
   panDataToPanFaas:
-      both: true
-      source: *panData
-      target: *panFaas
+    both: true
+    source: *panData
+    target: *panFaas
   panDataToPanGitlab:
-      both: true
-      source: *panData
-      target: *panGitlab
+    both: true
+    source: *panData
+    target: *panGitlab
   panDataToPanNotebook:
-      both: true
-      source: *panData
-      target: *panNotebook
+    both: true
+    source: *panData
+    target: *panNotebook
   panFaasToPanNotebook:
-      both: true
-      source: *panFaas
-      target: *panNotebook
+    both: true
+    source: *panFaas
+    target: *panNotebook
   panFaasToPanGitlab:
-      both: true
-      source: *panFaas
-      target: *panGitlab
+    both: true
+    source: *panFaas
+    target: *panGitlab
   panNotebookToPanGitlab:
-      both: true
-      source: *panNotebook
-      target: *panGitlab
+    both: true
+    source: *panNotebook
+    target: *panGitlab
   chipsterToCheckin:
-      both: false
-      source: *chipster
-      target: *checkIn
+    both: false
+    source: *chipster
+    target: *checkIn
   WSPtoCheckIn:
-      both: false
-      source: *wsPgrade
-      target: *checkIn
+    both: false
+    source: *wsPgrade
+    target: *checkIn
   ePoutaToTDS:
-      both: true
-      source: *cscEpouta
-      target: *tds
+    both: true
+    source: *cscEpouta
+    target: *tds
   EC3ToTDS:
-      both: true
-      source: *ec3Service
-      target: *tds
+    both: true
+    source: *ec3Service
+    target: *tds
 
 
 

--- a/db/migrate/20211025064757_add_status_to_providers.rb
+++ b/db/migrate/20211025064757_add_status_to_providers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddStatusToProviders < ActiveRecord::Migration[6.1]
+  def up
+    add_column :providers, :status, :string
+    execute("UPDATE providers set status = 'published'")
+  end
+
+  def down
+    remove_column :providers, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_073915) do
+ActiveRecord::Schema.define(version: 2021_10_25_064757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -404,6 +404,7 @@ ActiveRecord::Schema.define(version: 2021_10_05_073915) do
     t.string "national_roadmaps", default: [], array: true
     t.integer "upstream_id"
     t.datetime "synchronized_at"
+    t.string "status"
     t.index ["name"], name: "index_providers_on_name", unique: true
   end
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -47,6 +47,7 @@ namespace :dev do
       provider.city = hash["city"]
       provider.country = Country.for(hash["country_alpha2"])
       provider.pid = provider.abbreviation
+      provider.status = hash["status"]
 
       io, extension = ImageHelper.base_64_to_blob_stream(hash["image_base_64"])
       provider.logo.attach(

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     sequence(:city) { |n| "city #{n}" }
     sequence(:country) { |n| "N/E" }
     sequence(:pid) { |n| "provider-pid#{n}" }
+    sequence(:status) { :published }
 
     public_contacts { [build(:public_contact)] }
     main_contact { build(:main_contact) }

--- a/spec/policies/backoffice/provider_policy_spec.rb
+++ b/spec/policies/backoffice/provider_policy_spec.rb
@@ -5,7 +5,26 @@ require "rails_helper"
 RSpec.describe Backoffice::ProviderPolicy do
   subject { described_class }
 
-  permissions :index?, :show?, :new?, :create?, :edit?, :destroy? do
+  permissions :edit?, :destroy? do
+    it "grants access for service portfolio manager" do
+      expect(subject).
+        to permit(build(:user, roles: [:service_portfolio_manager]), build(:provider))
+    end
+
+    it "denies for deleted provider" do
+      expect(subject).
+        to_not permit(
+                 build(:user, roles: [:service_portfolio_manager]),
+                 build(:provider, status: :deleted)
+               )
+    end
+
+    it "denies for other users" do
+      expect(subject).to_not permit(build(:user), build(:provider))
+    end
+  end
+
+  permissions :index?, :show?, :new?, :create? do
     it "grants access for service portfolio manager" do
       expect(subject).
         to permit(build(:user, roles: [:service_portfolio_manager]))

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -2,31 +2,35 @@
 
 require "rails_helper"
 
-RSpec.describe ServicePolicy do
+RSpec.describe ProviderPolicy do
   let(:user) { create(:user) }
   let(:stranger) { create(:user) }
   let(:data_administrator) { create(:data_administrator, email: user.email) }
   let(:provider) { create(:provider, data_administrators: [data_administrator]) }
-  let(:service) { create(:service, resource_organisation: provider) }
-
   subject { described_class }
 
   def resolve
-    subject::Scope.new(user, Service).resolve
+    subject::Scope.new(user, Provider).resolve
+  end
+
+  it "should deny removed provider" do
+    create(:provider, status: :deleted)
+
+    expect(resolve.count).to eq(0)
   end
 
   permissions :data_administrator? do
     it "grants access when data administrator" do
-      expect(subject).to permit(user, service)
+      expect(subject).to permit(user, provider)
     end
 
     it "denies when not data administrator" do
-      expect(subject).to_not permit(stranger, service)
+      expect(subject).to_not permit(stranger, provider)
     end
 
     it "denies when data administrator of another resource" do
-      other_service = create(:service)
-      expect(subject).to_not permit(user, other_service)
+      other_provider = create(:provider)
+      expect(subject).to_not permit(user, other_provider)
     end
   end
 end


### PR DESCRIPTION
- [x] hide a provider with status `deleted` on /providers page 
- [x] remove the provider with status `deleted` from searching
- [x] the provider with status `deleted` can't be removed/updated/edited
- [x] URL in resource description providing to the provider with `deleted` status should be disabled
- [x] A new provider created in Backoffice has the status `published`
- [x] Filter out the providers with status deleted/draft from /services sidebar (Providers multi-select)
- [x] Add status field validation (require)
- [x] Update JMS and PcCreateOrUpdate to use Providers statuses
- [x] When exists service with a status different than delete and is resource organization of the provider, the provider can't be removed 
- [x] secure all subpages od /provider and /backoffice/provider endpoints
- [x] filter out soft-deleted providers from back-office forms
- [x] filter out soft-deleted providers from a list in resource views (`Provided by:`)
- [ ] ~~Add errored status on creating invalid Provider~~

closes: #2354, #2147