### PR TITLE
[#2375] Disable box-shadow on focused btn

### DIFF
--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -82,6 +82,7 @@ $btn-info-hover: #a1acaf;
 
 $btn-focus-width: 0;
 $btn-border-width: 0;
+$btn-focus-box-shadow: none;
 
 $btn-border-radius: 2rem;
 $btn-border-radius-sm: 2rem;


### PR DESCRIPTION
A change introduced between bootstrap 4.4.1 and 4.6.1 made focused
buttons have an extra box-shadow on focus.
Disable adding of the shadow by setting `$btn-focus-box-shadow: none;`.

Not adding changelog as this corrects an unreleased regression introduced in #2366.
Fixes: #2375.