### PR TITLE
[#2265] Store resource's parameters from a form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Fixed
 - Project duplication includes scientific domains associated with source (@goreck888)
 - The backoffice resource preview should be displayed identically as resource page - improve user experience (@danielkryska)
+- Store resource's parameters from an edit form instead of parameters stored in preview mode (@goreck888)
 
 ### Security
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -38,6 +38,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
 
   def new
     @service = Service.new(attributes_from_session || {})
+    clear_session_attributes!
     @service.sources.build source_type: "eosc_registry"
     @service.build_main_contact
     @service.public_contacts.build
@@ -53,6 +54,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
 
   def edit
     @service.assign_attributes(attributes_from_session || {})
+    clear_session_attributes!
     add_missing_nested_models
   end
 
@@ -115,6 +117,10 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
           "type" => logo.content_type
         }
       end
+    end
+
+    def clear_session_attributes!
+      session[preview_session_key].delete("attributes") if session[preview_session_key]
     end
 
     def add_missing_nested_models


### PR DESCRIPTION
Clear session after go back to the
edit form from a preview mode.
Stored session data caused overwriting
data edited after go back to the form
Fixes #2265