### PR TITLE
[#2066] Fix logic of adding offers to a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Improved conversation view and styles (@jarekzet, @wujuu)
 - More descriptive error when adding open access to the project second time - User Experience improvement (@danielkryska)
 - Disabled possibility to send an empty resource's review (@goreck888)
+- Clearing logic of adding offers to a project (@kmarszalek)
 
 ### Deprecated
 

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -83,18 +83,6 @@ class Offer < ApplicationRecord
     super || service.service_type
   end
 
-  def open_access?
-    offer_type == "open_access"
-  end
-
-  def normal?
-    offer_type == "normal"
-  end
-
-  def catalog?
-    offer_type == "catalog"
-  end
-
   def bundle?
     bundled_offers_count.positive?
   end

--- a/app/models/project_item/wizard.rb
+++ b/app/models/project_item/wizard.rb
@@ -85,7 +85,6 @@ class ProjectItem::Wizard
 
     class SummaryStep < ConfigurationStep
       include ProjectItem::ProjectValidation
-      delegate :properties?, to: :project_item
 
       attr_accessor :additional_comment, :verified_recaptcha
 

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -10,8 +10,14 @@ FactoryBot.define do
     factory :open_access_service do
       sequence(:order_type) { :open_access }
     end
-    factory :fully_open_access_servoce do
+    factory :fully_open_access_service do
       sequence(:order_type) { :fully_open_access }
+    end
+    factory :other_service do
+      sequence(:order_type) { :other }
+    end
+    factory :order_required_service do
+      sequence(:order_type) { :order_required }
     end
     sequence(:webpage_url) { "https://wabpage.url"  }
     sequence(:manual_url) { "https://manual.url"  }


### PR DESCRIPTION
open_access/fully_open_access/other offer can be added only once.
order_required - external can be added only once.
order_required - internal can be added multiple times.
bundled offer (parent and child) can be added multiple times.
child of the bundled offer can be added once if it is oa/foa/oo/or-e offer if it is ordered solo.

Closes #2066 