### PR TITLE
Make related_platforms searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - New conversation labels, which now reflect the identity of the author (@wujuu)
+- Related platforms are now searchable (@jswk)
 
 ### Changed
 - Fix RWD CSS Styles (@jarekzet)

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -76,8 +76,8 @@ module Service::Searchable
 
     def common_params
       {
-          fields: [ "name^7", "tagline^3", "description", "offer_names", "provider_names",
-                    "resource_organisation_name"],
+          fields: %w[name^7 tagline^3 description offer_names provider_names resource_organisation_name
+                     related_platforms],
           operator: "or",
           match: :word_middle
       }

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -93,6 +93,23 @@ module ServiceHelper
     end
   end
 
+  def related_platforms(service, highlights = nil)
+    not_blank_related_platforms = service.related_platforms.map(&:strip).reject(&:blank?)
+
+    return [] if not_blank_related_platforms.blank?
+    return service.related_platforms if highlights.blank? || highlights[:related_platforms].blank?
+
+    highlighted = sanitize(highlights[:related_platforms]).to_str.strip
+
+    not_blank_related_platforms.map do |related_platform|
+      if highlighted == related_platform
+        sanitize(highlights[:related_platforms], tags: %w[mark])
+      else
+        related_platform
+      end
+    end
+  end
+
   def providers_text(service)
     service.providers
            .reject(&:blank?)

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -99,7 +99,7 @@ module ServiceHelper
     return [] if not_blank_related_platforms.blank?
     return service.related_platforms if highlights.blank? || highlights[:related_platforms].blank?
 
-    highlighted = sanitize(highlights[:related_platforms]).to_str.strip
+    highlighted = sanitize(highlights[:related_platforms], tags: []).to_str.strip
 
     not_blank_related_platforms.map do |related_platform|
       if highlighted == related_platform

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -2662,8 +2662,7 @@ label[data-multicheckbox].small {
     margin: 2px 0 0 0;
   }
 
-  .research,
-  .dedicated {
+  .service-details-header__hide {
     display: none;
   }
 

--- a/app/models/service/search.rb
+++ b/app/models/service/search.rb
@@ -35,7 +35,8 @@ module Service::Search
       source: upstream&.source_type,
       offers: offers.ids,
       offer_names: offers.map(&:name),
-      provider_names: [resource_organisation.name] << providers.map(&:name)
+      provider_names: [resource_organisation.name] << providers.map(&:name),
+      related_platforms: related_platforms
     }
   end
 

--- a/app/models/service/search.rb
+++ b/app/models/service/search.rb
@@ -8,8 +8,8 @@ module Service::Search
     # scope :search_import working with should_indexe?
     # and define which services are indexed in elasticsearch
     searchkick word_middle: [:name, :tagline, :description, :offer_names,
-                             :resource_organisation_name, :provider_names],
-      highlight: [:name, :tagline, :resource_organisation_name, :provider_names]
+                             :resource_organisation_name, :provider_names, :related_platforms],
+      highlight: [:name, :tagline, :resource_organisation_name, :provider_names, :related_platforms]
   end
 
   # search_data are definition which

--- a/app/views/services/_categorization.html.haml
+++ b/app/views/services/_categorization.html.haml
@@ -12,10 +12,18 @@
         = _("Provided by") + ":"
     %dd.x-small
       %mr-4= active_providers
-%dl.mb-0.research
+%dl.mb-0.service-details-header__hide
   %dt.x-small
     %span
       = _("Scientific domain") + ":"
   %dd.x-small
     %mr-4= safe_join(scientific_domains_text(service), ", ")
+- related_platforms = safe_join(related_platforms(service, highlights), ", ")
+- if related_platforms.present?
+  %dl.mb-0.service-details-header__hide
+    %dt.x-small
+      %span
+        = _("Related platforms") + ":"
+    %dd.x-small
+      %mr-4= related_platforms
 %span.clearfix

--- a/db/data.yml
+++ b/db/data.yml
@@ -5121,6 +5121,7 @@ services:
     life_cycle_status: *prod
     tagline: Learn how to manage IT services with a pragmatic and lightweight standard
     platforms: [ *egiPlatform ]
+    related_platforms: [ "Scopus", "European Language Grid" ]
     description: |
       FitSM is a lightweight standards family aimed at facilitating service management in IT service provision,
       including federated scenarios. FitSM training aims at providing those involved in operating
@@ -5217,6 +5218,10 @@ services:
       A web-based, collaborative working environment enacting to predict the spread of an invasive species
       (possibly alien) in a new environment
     platforms: [ *egiPlatform, *gbif, *obis, *d4sciencePlatform, *gCube, *seaDataCloud ]
+    related_platforms:
+      - "https://eliademy.com/opensciencemooc"
+      - "GBIF Integrate Data from more than 1700 institutions (https://www.gbif.org/publisher/search) "
+      - "The NOMAD Laboratory https://nomad-coe.eu/"
     description: |
       Alien and Invasive Species Virtual Research Environment (VRE) is a web-based, comprehensive,
       collaborative working environment supporting decision makers and scientists in predicting the spread

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -97,6 +97,7 @@ namespace :dev do
       domain = ScientificDomain.where(name: hash["domain"])
       resource_organisation = Provider.find_by(name: "not specified yet")
       platforms = Platform.where(name: hash["platforms"])
+      related_platforms = hash["related_platforms"]
       funding_bodies = Vocabulary::FundingBody.where(eid: hash["funding_bodies"])
       funding_programs = Vocabulary::FundingProgram.where(eid: hash["funding_programs"])
       service = Service.find_or_initialize_by(name: hash["name"])
@@ -131,6 +132,7 @@ namespace :dev do
                       categories: categories,
                       tag_list: hash["tags"],
                       platforms: platforms,
+                      related_platforms: related_platforms,
                       status: :published)
       service.save(validate: false)
 

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -20,6 +20,39 @@ RSpec.describe ServiceHelper, type: :helper do
     expect(get_providers_list.order(:created_at)).to eq(list)
   end
 
+  context "#related_platforms" do
+    it "for empty returns empty" do
+      service = double(related_platforms: [])
+      expect(related_platforms(service)).to eq([])
+    end
+
+    it "rejects entries which are empty after trim" do
+      service = double(related_platforms: ["  ", "\t\n"])
+      expect(related_platforms(service)).to eq([])
+    end
+
+    it "returns same if no highlights" do
+      service = double(related_platforms: ["abc"])
+      expect(related_platforms(service)).to eq(["abc"])
+    end
+
+    it "returns same if no matching highlights" do
+      service = double(related_platforms: ["abc"])
+      expect(related_platforms(service, { related_platforms: "<mark>ab</mark>" })).to eq(["abc"])
+    end
+
+    it "returns highlights if matching highlights" do
+      service = double(related_platforms: ["abc", "bc"])
+      expect(related_platforms(service, { related_platforms: "<mark>abc</mark>" })).to eq(["<mark>abc</mark>", "bc"])
+    end
+
+    it "returns highlights if matching highlights but stripping tags other than <mark>" do
+      service = double(related_platforms: ["abc"])
+      expect(related_platforms(service, { related_platforms: "<mark><strong>abc</strong></mark>" }))
+        .to eq(["<mark>abc</mark>"])
+    end
+  end
+
   it "return trl description" do
     service = create(:service)
     expect(trl_description_text(service)).to eq("Super description")


### PR DESCRIPTION
Add related_platforms to Service::search_data.

Add example related_platforms to dev:prime data.

Search by related_platforms.

Show releated_platforms in search results:
Generalize the class which hides some service header fields in
`.service-details-header`.

Add service_helper::related_platforms test.

(Note: the commits are to be squashed later on.)

## How to test

Example results with related_platforms: https://marketplace-5.docker-fid.grid.cyf-kr.edu.pl/services?object_id=&type=&anchor=&sort=_score&q=gbif.

Other services to check with: "EGI Check-In", "da|ra", "SeaDataNet".

![image](https://user-images.githubusercontent.com/583197/142414265-7071533d-1e65-41b7-a219-62678be39750.png)


Closes: #2391.