### PR TITLE
[#2390] Push new questions to outbound JMS queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - New conversation labels, which now reflect the identity of the author (@wujuu)
 - "New message" visual notifications (@wujuu)
 - JMS publisher for pushing information to PC (@danielkryska, @jswk)
+- Push new questions to providers and resources to an outbound JMS queue (@jswk)
 
 ### Changed
 - Fix RWD CSS Styles (@jarekzet)

--- a/app/controllers/providers/questions_controller.rb
+++ b/app/controllers/providers/questions_controller.rb
@@ -19,10 +19,7 @@ class Providers::QuestionsController < ApplicationController
                                      provider: @provider)
     respond_to do |format|
       if @question.valid? && verify_recaptcha(model: @question, attribute: :verified_recaptcha)
-        @provider.public_contacts.each  do |contact|
-          ProviderMailer.new_question(contact.email, @question.author, @question.email,
-                                     @question.text, @provider).deliver_later
-        end
+        Provider::Question::Deliver.new(@question).call
         format.html { redirect_to provider_path(@provider) }
         flash[:notice] = "Your message was successfully sent"
       else

--- a/app/controllers/services/questions_controller.rb
+++ b/app/controllers/services/questions_controller.rb
@@ -21,10 +21,7 @@ class Services::QuestionsController < ApplicationController
                                       service: @service)
     respond_to do |format|
       if @question.valid? && verify_recaptcha(model: @question, attribute: :verified_recaptcha)
-        @service.public_contacts.each do |contact|
-          ServiceMailer.new_question(contact.email, @question.author, @question.email,
-                                     @question.text, @service).deliver_later
-        end
+        Service::Question::Deliver.new(@question).call
         format.html { redirect_to service_path(@service) }
         flash[:notice] = "Your message was successfully sent"
       else

--- a/app/services/provider/question/deliver.rb
+++ b/app/services/provider/question/deliver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Provider::Question::Deliver
+  def initialize(provider_question)
+    @provider_question = provider_question
+    @provider = @provider_question.provider
+  end
+
+  def call
+    @provider.public_contacts.each  do |contact|
+      ProviderMailer.new_question(contact.email, @provider_question.author, @provider_question.email,
+                                  @provider_question.text, @provider).deliver_later
+    end
+
+    Jms::PublishJob.perform_later(jms_message) if publish_to_jms?
+  end
+
+  private
+    def publish_to_jms?
+      @provider.upstream&.eosc_registry?
+    end
+
+    def jms_message
+      {
+        message_type: "provider_question",
+        timestamp: Time.now.utc.iso8601,
+        provider: @provider.pid,
+        author: @provider_question.author,
+        email: @provider_question.email,
+        text: @provider_question.text,
+      }
+    end
+end

--- a/app/services/service/question/deliver.rb
+++ b/app/services/service/question/deliver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Service::Question::Deliver
+  def initialize(service_question)
+    @service_question = service_question
+    @service = @service_question.service
+  end
+
+  def call
+    @service.public_contacts.each do |contact|
+      ServiceMailer.new_question(contact.email, @service_question.author, @service_question.email,
+                                 @service_question.text, @service).deliver_later
+    end
+
+    Jms::PublishJob.perform_later(jms_message) if publish_to_jms?
+  end
+
+  private
+    def publish_to_jms?
+      @service.upstream&.eosc_registry?
+    end
+
+    def jms_message
+      {
+        message_type: "service_question",
+        timestamp: Time.now.utc.iso8601,
+        resource: @service.pid,
+        author: @service_question.author,
+        email: @service_question.email,
+        text: @service_question.text,
+      }
+    end
+end

--- a/spec/factories/provider_sources.rb
+++ b/spec/factories/provider_sources.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :provider_source do
     source_type { ProviderSource.source_types.keys.sample }
     sequence(:eid) { |n| n }
+
+    factory :eosc_registry_provider_source do
+      source_type { :eosc_registry }
+    end
   end
 end

--- a/spec/factories/service_sources.rb
+++ b/spec/factories/service_sources.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :service_source do
     source_type { ServiceSource.source_types.keys.sample }
     sequence(:eid) { |n| n }
+
+    factory :eosc_registry_service_source do
+      source_type { :eosc_registry }
+    end
   end
 end


### PR DESCRIPTION
Don't do it for non :eosc_registry services and providers, as they won't
exist on the EOSC Registry side.

Closes: #2390.