### PR TITLE
[#2390] Push resource (co)existence info to outbound JMS queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - "New message" visual notifications (@wujuu)
 - JMS publisher for pushing information to PC (@danielkryska, @jswk)
 - Push new questions to providers and resources to an outbound JMS queue (@jswk)
+- Push information about resource coexistence to an outbound JMS queue (@jswk)
 
 ### Changed
 - Fix RWD CSS Styles (@jarekzet)

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ApplicationService
+  def self.call(*args, **kwargs, &block)
+    new(*args, **kwargs, &block).call
+  end
+
+  def initialize
+    raise "Should be implemented in descendent class"
+  end
+
+  def call
+    raise "Should be implemented in descendent class"
+  end
+end

--- a/app/services/project_item/on_created/publish_addition.rb
+++ b/app/services/project_item/on_created/publish_addition.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ProjectItem::OnCreated::PublishAddition < ApplicationService
+  def initialize(project, added_project_items)
+    @project = project
+    @added_project_items = added_project_items
+  end
+
+  def call
+    @added_project_items.map(&:service)
+                        .uniq
+                        .filter_map { |s| jms_message(s) if publish_to_jms?(s) }
+                        .each { |msg| Jms::PublishJob.perform_later(msg) }
+  end
+
+  private
+    def publish_to_jms?(service)
+      service.upstream&.eosc_registry?
+    end
+
+    def jms_message(service)
+      {
+        message_type: "project.resource_addition",
+        timestamp: Time.now.utc.iso8601,
+        project_digest: project_digest,
+        resource: service.pid,
+      }
+    end
+
+    def project_digest
+      Digest::MD5.hexdigest(@project.id.to_s)
+    end
+end

--- a/app/services/project_item/on_created/publish_coexistence.rb
+++ b/app/services/project_item/on_created/publish_coexistence.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ProjectItem::OnCreated::PublishCoexistence < ApplicationService
+  def initialize(project)
+    @project = project
+  end
+
+  def call
+    coexisting_resources = resources
+    if coexisting_resources.present?
+      Jms::PublishJob.perform_later(jms_message(coexisting_resources))
+    end
+  end
+
+  private
+    def resources
+      @project.project_items.map(&:service).uniq.filter_map { |s| s.pid if publish_to_jms?(s) }
+    end
+
+    def publish_to_jms?(service)
+      service.upstream&.eosc_registry?
+    end
+
+    def jms_message(coexisting_resources)
+      {
+        message_type: "project.resource_coexistence",
+        timestamp: Time.now.utc.iso8601,
+        project_digest: project_digest,
+        coexisting_resources: coexisting_resources.sort,
+      }
+    end
+
+    def project_digest
+      Digest::MD5.hexdigest(@project.id.to_s)
+    end
+end

--- a/spec/services/project_item/create_spec.rb
+++ b/spec/services/project_item/create_spec.rb
@@ -33,6 +33,28 @@ RSpec.describe ProjectItem::Create do
     expect(ProjectItem::RegisterJob).to have_been_enqueued.with(project_item, nil)
   end
 
+  context "for service with :eosc_registry upstream" do
+    let(:service) { create(:service, pid: "foo") }
+    let(:upstream) { build(:eosc_registry_service_source) }
+
+    before do
+      upstream.update!(service: service)
+      service.update!(upstream: upstream)
+    end
+
+    it "enqueues publish jobs" do
+      described_class.new(project_item_template).call
+
+      expect(Jms::PublishJob).to have_been_enqueued.twice
+    end
+  end
+
+  it "doesn't enqueue publish jobs" do
+    described_class.new(project_item_template).call
+
+    expect(Jms::PublishJob).not_to have_been_enqueued
+  end
+
   context "when open_access service has been added to Project" do
     let(:service) { create(:open_access_service) }
 

--- a/spec/services/project_item/on_created/publish_addition_spec.rb
+++ b/spec/services/project_item/on_created/publish_addition_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ProjectItem::OnCreated::PublishAddition do
+  it "doesn't enqueue if empty" do
+    project = double(Project)
+    allow(Jms::PublishJob).to receive(:perform_later)
+
+    described_class.call(project, [])
+
+    expect(Jms::PublishJob).not_to have_received(:perform_later)
+  end
+
+  it "doesn't enqueue if services not :eosc_registry" do
+    project = double(Project)
+    pi1 = double(ProjectItem, service: double(Service, upstream: nil))
+    pi2 = double(ProjectItem, service: double(Service, upstream: nil))
+    allow(Jms::PublishJob).to receive(:perform_later)
+
+    described_class.call(project, [pi1, pi2])
+
+    expect(Jms::PublishJob).not_to have_received(:perform_later)
+  end
+
+  it "enqueues if service with upstream.eosc_registry?" do
+    project = double(Project, id: 1)
+    pi1 = double(ProjectItem,
+                 service: double(Service,
+                                 pid: "foo",
+                                 upstream: double(ServiceSource, eosc_registry?: true)))
+    allow(Jms::PublishJob).to receive(:perform_later)
+
+    described_class.call(project, [pi1])
+
+    expect(Jms::PublishJob).to have_received(:perform_later)
+  end
+
+  it "de-duplicates services" do
+    project = double(Project, id: 1)
+    service = double(Service, pid: "foo", upstream: double(ServiceSource, eosc_registry?: true))
+    pi1 = double(ProjectItem, service: service)
+    pi2 = double(ProjectItem, service: service)
+    allow(Jms::PublishJob).to receive(:perform_later) do |message|
+      expect(message[:resource]).to eq("foo")
+    end
+
+    described_class.call(project, [pi1, pi2])
+
+    expect(Jms::PublishJob).to have_received(:perform_later)
+  end
+end

--- a/spec/services/project_item/on_created/publish_coexistence_spec.rb
+++ b/spec/services/project_item/on_created/publish_coexistence_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ProjectItem::OnCreated::PublishCoexistence do
+  it "doesn't enqueue if empty" do
+    project = double(Project)
+    expect(project).to receive(:project_items).and_return([])
+    allow(Jms::PublishJob).to receive(:perform_later)
+
+    described_class.call(project)
+
+    expect(Jms::PublishJob).not_to have_received(:perform_later)
+  end
+
+  it "doesn't enqueue if services not :eosc_registry" do
+    project = double(Project)
+    pi1 = double(ProjectItem, service: double(Service, upstream: nil))
+    pi2 = double(ProjectItem, service: double(Service, upstream: nil))
+    expect(project).to receive(:project_items).and_return([pi1, pi2])
+    allow(Jms::PublishJob).to receive(:perform_later)
+
+    described_class.call(project)
+
+    expect(Jms::PublishJob).not_to have_received(:perform_later)
+  end
+
+  it "enqueues if service with upstream.eosc_registry?" do
+    project = double(Project, id: 1)
+    pi1 = double(ProjectItem,
+                 service: double(Service,
+                                 pid: "foo",
+                                 upstream: double(ServiceSource, eosc_registry?: true)))
+    expect(project).to receive(:project_items).and_return([pi1])
+    allow(Jms::PublishJob).to receive(:perform_later)
+
+    described_class.call(project)
+
+    expect(Jms::PublishJob).to have_received(:perform_later)
+  end
+
+  it "de-duplicates services" do
+    project = double(Project, id: 1)
+    service = double(Service, pid: "foo", upstream: double(ServiceSource, eosc_registry?: true))
+    pi1 = double(ProjectItem, service: service)
+    pi2 = double(ProjectItem, service: service)
+    expect(project).to receive(:project_items).and_return([pi1, pi2])
+    allow(Jms::PublishJob).to receive(:perform_later) do |message|
+      expect(message[:coexisting_resources]).to eq(["foo"])
+    end
+
+    described_class.call(project)
+
+    expect(Jms::PublishJob).to have_received(:perform_later)
+  end
+end


### PR DESCRIPTION
Don't do it for non :eosc_registry services, as they won't exist on the EOSC Registry side.

Closes: #2389.