### PR TITLE
[#2412] Correct publisher outbound topic name

### DIFF
--- a/app/services/jms/publisher.rb
+++ b/app/services/jms/publisher.rb
@@ -57,7 +57,7 @@ class Jms::Publisher
     end
 
     def msg_destination
-      "/topic/#{@topic}.>"
+      "/topic/#{@topic}"
     end
 
     def msg_headers


### PR DESCRIPTION
Remove the trailing `.>`, which hold no meaning when publishing.

When subscribing it matches all topic hierarchy.