### PR TITLE
Making offer ordering bulletproof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.27.0-milestone]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Logic for multiple ordering of bundle and bundled offers (@kmarszalek)
+
+### Security
+
 ## [3.26.0-milestone]
 
 ### Added

--- a/app/models/project_item/project_validation.rb
+++ b/app/models/project_item/project_validation.rb
@@ -12,7 +12,10 @@ module ProjectItem::ProjectValidation
     def one_per_project
       return if project.blank?
 
-      offer_duplicated = project.project_items.count { |pi| pi.offer.id == offer.id }
+      offer_duplicated = project
+                           .project_items
+                           .reject { |pi| pi.parent.present? }
+                           .count { |pi| pi.offer.id == offer.id }
 
       errors.add(:project, :repeated_in_project) if offer_duplicated.positive?
     end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -220,7 +220,7 @@ RSpec.feature "Service ordering" do
     scenario "I can order bundle resource and its bundled resource" do
       service = create(:service)
       service2 = create(:service)
-      bundled = create(:offer, service: service2, internal: true,
+      bundled = create(:offer, service: service2, internal: false,
                        order_type: service2.order_type, order_url: service2.order_url)
       _bundle = create(:offer, service: service, internal: true,
                        order_type: service.order_type, order_url: service.order_url, bundled_offers: [bundled])
@@ -246,7 +246,7 @@ RSpec.feature "Service ordering" do
       select "Services", from: "customizable_project_item_project_id"
 
       expect do
-        click_on "Send access request", match: :first
+        click_on "Pin!", match: :first
       end.to change { ProjectItem.count }.by(1)
     end
 


### PR DESCRIPTION
Add condition that enables ordering of bundled offer
irrespectively of the offer type.
You can order bundle offer and then order bundled offer
separately regardless of her type