### PR TITLE
[#2412] Use default client-id generation scheme and other improvements

### DIFF
--- a/app/jobs/jms/publish_job.rb
+++ b/app/jobs/jms/publish_job.rb
@@ -5,7 +5,9 @@ require "sentry-ruby"
 class Jms::PublishJob < ApplicationJob
   queue_as :pc_publisher
 
-  rescue_from ArgumentError, Jms::Publisher::ConnectionError, Stomp::Error do |e|
+  # stomp gem doesn't use a common custom subclass for its Errors, instead it's necessary
+  # to catch RuntimeError to handle them all.
+  rescue_from ArgumentError, Jms::Publisher::ConnectionError, RuntimeError do |e|
     logger.warn("Exception occurred: #{e}")
     Sentry.capture_exception(e)
   end

--- a/app/services/jms/publish.rb
+++ b/app/services/jms/publish.rb
@@ -40,7 +40,6 @@ class Jms::Publish
                          stomp_config["login"],
                          stomp_config["password"],
                          stomp_config["host"],
-                         stomp_config["client-name"],
                          stomp_config["ssl-enabled"],
                          @logger)
     end

--- a/app/services/jms/publisher.rb
+++ b/app/services/jms/publisher.rb
@@ -7,10 +7,10 @@ class Jms::Publisher
     end
   end
 
-  def initialize(topic, login, pass, host, client_name, ssl_enabled, logger)
+  def initialize(topic, login, pass, host, ssl_enabled, logger)
     @logger = logger
 
-    conf_hash_res = conf_hash(login, pass, host, client_name, ssl_enabled)
+    conf_hash_res = conf_hash(login, pass, host, ssl_enabled)
     @client = Stomp::Client.new(conf_hash_res)
     @topic = topic
 
@@ -27,22 +27,23 @@ class Jms::Publisher
   end
 
   private
-    def conf_hash(login, pass, host, client_name, ssl)
+    def conf_hash(login, pass, host, ssl)
       {
         hosts: [
           {
             login: login,
             passcode: pass,
-            host: "#{host}",
+            host: host,
             port: 61613,
-            ssl: ssl
+            ssl: ssl,
           }
         ],
+        connect_timeout: 5,
+        max_reconnect_attempts: 5,
         connect_headers: {
-          "client-id": client_name,
+          "accept-version": "1.2", # mandatory
+          "host": "localhost", # mandatory
           "heart-beat": "0,20000",
-          "accept-version": "1.2",
-          "host": "localhost"
         }
       }
     end
@@ -52,7 +53,7 @@ class Jms::Publisher
         raise ConnectionError.new("Connection failed!!")
       end
       if @client.connection_frame.command == Stomp::CMD_ERROR
-        raise ConnectionError.new("Connection error: #{@connection.connection_frame.body}")
+        raise ConnectionError.new("Connection error: #{@client.connection_frame.body}")
       end
     end
 
@@ -62,9 +63,10 @@ class Jms::Publisher
 
     def msg_headers
       {
-        "ack": "client-individual",
-        # without persistent, suppress_content_length and content-type the queue truncates messages to 256 chars
         "persistent": true,
+        # Without suppress_content_length ActiveMQ interprets the message as a BytesMessage, instead of a TextMessage.
+        # See https://github.com/stompgem/stomp/blob/v1.4.10/lib/connection/netio.rb#L245
+        # and https://activemq.apache.org/stomp.html.
         "suppress_content_length": true,
         "content-type": "application/json"
       }

--- a/lib/jira/console_checker.rb
+++ b/lib/jira/console_checker.rb
@@ -42,7 +42,7 @@ module Jira
         self.abort!
 
       else
-        puts "ERROR".red + ": Unexpected error ocurred #{e.message}\n\n#{e.backtrace}"
+        puts "ERROR".red + ": Unexpected error occurred #{e.message}\n\n#{e.backtrace}"
         self.abort!
       end
     end

--- a/lib/jms/subscriber.rb
+++ b/lib/jms/subscriber.rb
@@ -48,7 +48,7 @@ module Jms
 
     private
       def error_block(msg, e)
-        @logger.error("Error occured while processing message:\n #{msg}")
+        @logger.error("Error occurred while processing message:\n #{msg}")
         @logger.error(e)
         Sentry.capture_exception(e)
         abort(e.full_message)
@@ -60,11 +60,13 @@ module Jms
             {
               login: login,
               passcode: pass,
-              host:  "#{host_des}",
+              host: host_des,
               port: 61613,
               ssl: ssl
             }
           ],
+          connect_timeout: 5,
+          max_reconnect_attempts: 5,
           connect_headers: {
             "client-id": client_name,
             "heart-beat": "0,20000",

--- a/spec/lib/jira/console_checker_spec.rb
+++ b/spec/lib/jira/console_checker_spec.rb
@@ -35,7 +35,7 @@ describe Jira::ConsoleChecker do
     it "should print FAIL and error type to stdout" do
       expect(con_checker).to receive(:abort!)
       expect { con_checker.error_and_abort!(StandardError.new) }
-        .to output(" FAIL".red + "\n" + "ERROR".red + ": Unexpected error ocurred StandardError\n\n").to_stdout
+        .to output(" FAIL".red + "\n" + "ERROR".red + ": Unexpected error occurred StandardError\n\n").to_stdout
     end
 
     it "should handle Errno::ECONNREFUSED" do


### PR DESCRIPTION
Don't pass a static client-name/id, so that multiple concurrent
connections to the server can take place. Otherwise JMS connections get
corrupted (leaving repeating on_miscerr in logs, or crash the
application if the connection is switched to reliable=false).

Add connect_timeout and max_reconnect_attempts to JMS::Subscriber too,
as having a failed process is more meaningful than a hanged one.

The stomp gem doesn't use a common custom subclass for its Errors,
instead it's necessary to catch RuntimeError to handle them all.

Typo fixes.