### PR TITLE
[#2446] Fix updating resources with invalid providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.29.0-milestone]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Adding providers with improper data to the resource (@goreck888)
+
+### Security
+
 ## [3.28.0] 2021-12-22
 
 ### Changed

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -163,7 +163,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
     if Service::Update.new(@service, attributes).call
       update_logo_from_session!
       session.delete(preview_session_key)
-      redirect_to backoffice_service_path(@service), notice: "Service updated correctly"
+      redirect_to backoffice_service_path(@service), notice: "Resource updated correctly"
     else
       add_missing_nested_models
       render :edit, status: :bad_request

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -47,7 +47,7 @@ class Service < ApplicationRecord
   has_many :service_scientific_domains, dependent: :destroy
   has_many :scientific_domains, through: :service_scientific_domains
   has_many :service_providers, dependent: :destroy
-  has_many :providers, through: :service_providers
+  has_many :providers, through: :service_providers, validate: false
   has_many :service_related_platforms, dependent: :destroy
   has_many :platforms, through: :service_related_platforms
   has_many :service_vocabularies, dependent: :destroy


### PR DESCRIPTION
This PR fixes adding providers to the resource
even if chosen provider has improper data
Fixes #2446