### PR TITLE
[#2472] Fix clearing a resource form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Fixed
 - Adding providers with improper data to the resource (@goreck888)
+- Clear a resource form if clicked on Preview button on an empty form (@goreck888)
 
 ### Security
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -106,6 +106,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
       render :preview
     else
       render error_view, status: :bad_request
+      session.delete(preview_session_key)
     end
   end
 

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -121,6 +121,34 @@ RSpec.feature "Services in backoffice" do
       expect(page).to have_content(life_cycle_status.name)
     end
 
+    scenario "I can create a service after clicking `preview` in an empty form" do
+      resource_organisation = create(:provider)
+      scientific_domain = create(:scientific_domain)
+
+      visit new_backoffice_service_path
+
+      click_on "Preview"
+
+      expect(page).to have_content("Please review the problems below:")
+
+      fill_in "Name", with: "service name"
+      select resource_organisation.name, from: "Resource organisation"
+      fill_in "Description", with: "service description"
+      fill_in "Tagline", with: "service tagline"
+      select scientific_domain.name, from: "Scientific domains"
+      select "Poland", from: "Geographical availabilities"
+
+      click_on "Create Resource"
+
+      expect(page).to have_content("New resource created successfully")
+
+      expect(page).to have_content("service name")
+      expect(page).to have_content("service description")
+      expect(page).to have_content("service tagline")
+      expect(page).to have_content(scientific_domain.name)
+      expect(page).to have_content(resource_organisation.name)
+    end
+
     scenario "I can add additional public contacts", js: true do
       service = create(:service)
 


### PR DESCRIPTION
Click on a `Preview` button when the form is empty
caused saving empty attributes in a session.
Then after filling the form and click on
"Create Resource" the priority was in session attributes
Fixes #2472