### PR TITLE
[#2330] Fix contact fields in the resource form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Clear a resource form if clicked on Preview button on an empty form (@goreck888)
 - Resource's reviews counters (@goreck888)
 - Providers section on the home page to not show draft or deleted (@kmarszalek)
+- Contact fields visibility in the resource form on error (@goreck888)
 
 ### Security
 

--- a/app/controllers/backoffice/services_controller.rb
+++ b/app/controllers/backoffice/services_controller.rb
@@ -105,6 +105,7 @@ class Backoffice::ServicesController < Backoffice::ApplicationController
       end
       render :preview
     else
+      add_missing_nested_models
       render error_view, status: :bad_request
       session.delete(preview_session_key)
     end


### PR DESCRIPTION
Fix problem with contact fields
when clicked preview on an empty resource template
Fixes #2330