### PR TITLE
[2488] Add more configurable ENV's for s3 ActiveStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ We are currently using the following ENV variables:
   * `S3_STORAGE` - set true to change ActiveStorage to S3
   * `S3_BUCKET` - active storage S3 bucket
   * `S3_ENDPOINT` - active storage S3 endpoint
+  * `S3_ACCESS_KEY_ID` - active storage S3 access key
+  * `S3_SECRET_ACCESS_KEY` - active storage S3 secret access key
   * `SMTP_ADDRESS` - smtp mail server address
   * `SMTP_USERNAME` - smtp user name or email address
   * `SMTP_PASSWORD` - smtp password
@@ -396,8 +398,8 @@ To use S3 first, you need:
 * `S3_STORAGE`
 * `S3_ENDPOINT`
 * `S3_BUCKET`
-* s3:access_key_id credentials
-* s3:secret_access_key credentials
+* s3:access_key_id credentials or in `S3_ACCESS_KEY_ID`
+* s3:secret_access_key credentials or in `S3_SECRET_ACCESS_KEY`
   
 Store s3 access and secret_access keys in encrypted credentials.
 Set env variables and you should be able to run the app.
@@ -408,8 +410,8 @@ To upload files registered in db from `local` to `S3` you need:
 * working db with registered `local` files
 * `S3_ENDPOINT`
 * `S3_BUCKET`
-* s3:access_key_id credentials
-* s3:secret_access_key credentials
+* s3:access_key_id credentials or in `S3_ACCESS_KEY_ID`
+* s3:secret_access_key credentials or in `S3_SECRET_ACCESS_KEY`
 
 Task: `rake storage:upload_to_s3`
 
@@ -419,8 +421,8 @@ To upload files registered in db from `S3` to `local` you need:
 * working db with registered `local` files
 * `S3_ENDPOINT`
 * `S3_BUCKET`
-* s3:access_key_id credentials
-* s3:secret_access_key credentials
+* s3:access_key_id credentials or in `S3_ACCESS_KEY_ID`
+* s3:secret_access_key credentials or in `S3_SECRET_ACCESS_KEY`
 
 Task: `rake storage:upload_to_local`
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,8 +9,8 @@ local:
 s3:
   service: S3
   endpoint: <%= ENV["S3_ENDPOINT"] || "https://s3.cloud.cyfronet.pl/" %>
-  access_key_id: <%= Rails.application.credentials.dig(:s3, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:s3, :secret_access_key) %>
+  access_key_id: <%= ENV["S3_ACCESS_KEY_ID"] || Rails.application.credentials.dig(:s3, :access_key_id) %>
+  secret_access_key: <%= ENV["S3_SECRET_ACCESS_KEY"] || Rails.application.credentials.dig(:s3, :secret_access_key) %>
   bucket: <%= ENV["S3_BUCKET"] || "marketplace-dev" %>
   region: ack-cyfronet
 

--- a/docs/upgrade/3.29.0.md
+++ b/docs/upgrade/3.29.0.md
@@ -1,0 +1,16 @@
+# Upgrade to 3.29.0
+
+# Standard procedure
+
+All steps run in production scope.
+
+- make database dump and all application files.
+- `bundle install --deployment --without development test`
+- `bundle exec rake assets:clean assets:precompile`
+- `rails db:migrate`
+
+# Special steps
+
+- To set production ActiveStorage with S3 and configure it with ENV:
+  - use 3.15.0 special steps
+  - set S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY environments


### PR DESCRIPTION
Add `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY_ID` as
configurable ENV's for S3 ACtiveStorage.

Closes #2488