### PR TITLE
[#2505] Fix adding parameters to the default offer

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -59,7 +59,7 @@ class Offer < ApplicationRecord
   validate :check_oms_params, if: -> { current_oms.present? }
   validate :same_order_type_as_in_service,
            if: -> {
-             service&.order_type&.present? &&
+             service&.order_type.present? &&
                (
                  (new_record? && service.offers.published.size.zero?) ||
                    (persisted? && service.offers.published.size == 1)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -136,6 +136,7 @@ class Service < ApplicationRecord
   validates :access_policies_url, mp_url: true, if: :access_policies_url?
   validates :sla_url, mp_url: true, if: :sla_url?
   validates :webpage_url, mp_url: true, if: :webpage_url?
+  validates :order_type, presence: true
   validates :status_monitoring_url, mp_url: true, if: :status_monitoring_url?
   validates :maintenance_url, mp_url: true, if: :maintenance_url?
   validates :order_url, mp_url: true, if: :order_url?

--- a/app/services/service/create.rb
+++ b/app/services/service/create.rb
@@ -11,7 +11,7 @@ class Service::Create
       Offer.new(
         name: "Offer",
         description: "#{@service.name} Offer",
-        order_type: @service.order_type || "open_access",
+        order_type: @service.order_type,
         order_url: @service.order_url,
         internal: @service.order_url.blank?,
         status: "published",

--- a/app/services/service/update.rb
+++ b/app/services/service/update.rb
@@ -12,21 +12,18 @@ class Service::Update
     else
       @service.update(@params)
     end
+    order_type = @params[:order_type].presence || @service.order_type.presence
     if @service.offers.published.size == 1
       Offer::Update.new(
         @service.offers.first,
-        {
-          order_type: @params[:order_type] || @service.order_type,
-          order_url: @params[:order_url] || @service.order_url,
-          status: "published"
-        }
+        { order_type: order_type, order_url: @params[:order_url] || @service.order_url, status: "published" }
       ).call
     elsif @service.offers.published.empty?
       Offer::Create.new(
         Offer.new(
           name: "Offer",
           description: "#{@params[:name] || @service.name} Offer",
-          order_type: @params[:order_type] || @service.order_type,
+          order_type: order_type,
           order_url: @params[:order_url] || @service.order_url,
           status: "published",
           service: @service

--- a/db/migrate/20220120112130_set_blank_order_type_in_service.rb
+++ b/db/migrate/20220120112130_set_blank_order_type_in_service.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SetBlankOrderTypeInService < ActiveRecord::Migration[6.1]
+  def change
+    exec_update "UPDATE services SET order_type = 'open_access' WHERE order_type = '' OR order_type IS NULL"
+    change_column :services, :order_type, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_16_143044) do
+ActiveRecord::Schema.define(version: 2022_01_20_112130) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -179,7 +179,7 @@ ActiveRecord::Schema.define(version: 2021_11_16_143044) do
     t.string "author_uid"
     t.index ["author_id"], name: "index_messages_on_author_id"
     t.index ["author_role"], name: "index_messages_on_author_role"
-    t.index ["messageable_type", "messageable_id"], name: "index_messages_on_messageable_type_and_messageable_id"
+    t.index ["messageable_type", "messageable_id"], name: "index_messages_on_messageable"
     t.index ["scope"], name: "index_messages_on_scope"
   end
 
@@ -532,7 +532,7 @@ ActiveRecord::Schema.define(version: 2021_11_16_143044) do
     t.integer "offers_count", default: 0
     t.text "activate_message"
     t.string "slug"
-    t.string "order_type"
+    t.string "order_type", null: false
     t.string "status"
     t.integer "upstream_id"
     t.string "helpdesk_email", default: ""
@@ -573,7 +573,7 @@ ActiveRecord::Schema.define(version: 2021_11_16_143044) do
     t.datetime "updated_at", null: false
     t.string "status", null: false
     t.index ["author_id"], name: "index_statuses_on_author_id"
-    t.index ["status_holder_type", "status_holder_id"], name: "index_statuses_on_status_holder_type_and_status_holder_id"
+    t.index ["status_holder_type", "status_holder_id"], name: "index_statuses_on_status_holder"
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -137,6 +137,7 @@ RSpec.feature "Services in backoffice" do
       fill_in "Tagline", with: "service tagline"
       select scientific_domain.name, from: "Scientific domains"
       select "Poland", from: "Geographical availabilities"
+      select "open_access", from: "Order type"
 
       click_on "Create Resource"
 
@@ -224,6 +225,7 @@ RSpec.feature "Services in backoffice" do
       select provider.name, from: "Providers"
       select "Poland", from: "Geographical availabilities"
       select resource_organisation.name, from: "Resource organisation"
+      select "open_access", from: "Order type"
 
       click_on "Preview"
 


### PR DESCRIPTION
Problem caused by hidden field which is blank
when no order_type is chosen in a service.
Add default "other" order_type in this case
Fixes #2505 #2302