### PR TITLE
[#2525] Show manage button on Resource and Provider views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Strip leading and trailing whitespaces from Resource and Provider name (@kmarszalek)
 
 ### Changed
+- Show 'Manage the provider/resource' button only when upstream set to 'eosc_registry' (@kmarszalek)
 
 ### Deprecated
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,4 +53,8 @@ module ApplicationHelper
   def placeholder(variant, text = "Placeholder - link to about", link = about_path)
     render "layouts/placeholder", text: text, link: link, variant: variant
   end
+
+  def show_manage_button?(record)
+    policy(record).data_administrator? && record.upstream&.eosc_registry?
+  end
 end

--- a/app/policies/ordering_configuration/service_context_policy.rb
+++ b/app/policies/ordering_configuration/service_context_policy.rb
@@ -2,6 +2,6 @@
 
 class OrderingConfiguration::ServiceContextPolicy < ServiceContextPolicy
   def show?
-    super && record.service.administered_by?(user)
+    super && record.service.administered_by?(user) && record.service.upstream&.eosc_registry?
   end
 end

--- a/app/views/providers/_header.html.haml
+++ b/app/views/providers/_header.html.haml
@@ -16,7 +16,7 @@
       = link_to _("Browse resources"),
                     services_path(providers: provider.id),
                     class: "btn btn-primary d-block mb-3", "data-e2e": "btn-browse-resource"
-      - if user_signed_in? && policy(provider).data_administrator?
+      - if user_signed_in? && show_manage_button?(provider)
         = render "providers/header/drop_down_menu", provider: provider
 .row.service-links
   .col-12.col-lg-9.row

--- a/app/views/services/_header.html.haml
+++ b/app/views/services/_header.html.haml
@@ -52,7 +52,7 @@
                       "data-e2e": "access-resource-btn",
                       "data-probe": "",
                       "data-target": local_assigns[:preview] ? "preview.link" : ""
-      - if user_signed_in? && policy(service).data_administrator? && !local_assigns[:preview]
+      - if user_signed_in? && show_manage_button?(service) && !local_assigns[:preview]
         %a#dropdown-menu-button.dropdown-toggle.btn.btn-outline-secondary.d-block.mb-3{ "aria-expanded" => "false",
                                                       "aria-haspopup" => "true",
                                                       "data-toggle" => "dropdown",

--- a/spec/features/ordering_configuration_spec.rb
+++ b/spec/features/ordering_configuration_spec.rb
@@ -11,7 +11,14 @@ RSpec.feature "Services in ordering_configuration panel" do
     let(:provider) { create(:provider, data_administrators: [data_administrator]) }
     let(:service) { create(:service, resource_organisation: provider, offers: [create(:offer)]) }
 
-    before { checkin_sign_in_as(user) }
+    before do
+      provider_source = create(:eosc_registry_provider_source, provider: provider)
+      provider.update!(upstream: provider_source)
+
+      service_source = create(:eosc_registry_service_source, service: service)
+      service.update!(resource_organisation: provider, upstream: service_source)
+      checkin_sign_in_as(user)
+    end
 
     scenario "I can see ordering_configuration panel" do
       visit service_ordering_configuration_path(service)
@@ -89,6 +96,8 @@ RSpec.feature "Services in ordering_configuration panel" do
 
     scenario "I can add an offer if none exists", js: true do
       service_without_offers = create(:service, resource_organisation: provider, offers: [])
+      service_source = create(:eosc_registry_service_source, service: service_without_offers)
+      service_without_offers.update!(resource_organisation: provider, upstream: service_source)
 
       visit service_ordering_configuration_path(service_without_offers)
 
@@ -140,6 +149,8 @@ RSpec.feature "Services in ordering_configuration panel" do
       oms1 = create(:oms, name: "OMS1", custom_params: { foo: { mandatory: true, default: "baz" } })
       oms2 = create(:oms, name: "OMS2", custom_params: {})
       service = create(:service, name: "my service", resource_organisation: provider, status: :draft)
+      service_source = create(:eosc_registry_service_source, service: service)
+      service.update!(upstream: service_source)
       offer = create(:offer, name: "offer1", description: "desc", service: service, internal: false)
       create(:offer, service: service)
 
@@ -177,6 +188,8 @@ RSpec.feature "Services in ordering_configuration panel" do
       oms1 = create(:oms, name: "OMS1", custom_params: { foo: { mandatory: true, default: "baz" } })
       oms2 = create(:oms, name: "OMS2", custom_params: {})
       service = create(:service, name: "my service", resource_organisation: provider, status: :draft)
+      service_source = create(:eosc_registry_service_source, service: service)
+      service.update!(upstream: service_source)
       offer = create(:offer, name: "offer1", description: "desc", service: service, internal: false)
 
       service.reload
@@ -216,7 +229,14 @@ RSpec.feature "Services in ordering_configuration panel" do
       let(:provider) { create(:provider) }
       let(:service) { create(:service, resource_organisation: provider, offers: [create(:offer)]) }
 
-      before { checkin_sign_in_as(user) }
+      before do
+        provider_source = create(:eosc_registry_provider_source, provider: provider)
+        provider.update!(upstream: provider_source)
+
+        service_source = create(:eosc_registry_service_source, service: service)
+        service.update!(resource_organisation: provider, upstream: service_source)
+        checkin_sign_in_as(user)
+      end
 
       scenario "I am#{authorized ? nil : " not"} authorized to see the ordering_configuration panel" do
         visit service_ordering_configuration_path(service)

--- a/spec/features/provider_spec.rb
+++ b/spec/features/provider_spec.rb
@@ -47,11 +47,14 @@ RSpec.feature "Provider browsing" do
     expect(body).to_not have_content "Recently added resources"
   end
 
-  scenario "I can see 'Manage the resource' button if i am an admin provider" do
+  scenario "I can see 'Manage the resource' button if i am an admin provider and its eosc_registry" do
     admin = create(:user)
     data_admin =
       create(:data_administrator, first_name: admin.first_name, last_name: admin.last_name, email: admin.email)
     provider = create(:provider, data_administrators: [data_admin])
+    provider_source = create(:eosc_registry_provider_source, provider: provider)
+    provider.upstream = provider_source
+    provider.save!
 
     checkin_sign_in_as(admin)
 
@@ -61,13 +64,30 @@ RSpec.feature "Provider browsing" do
     expect(page).to have_content("Manage the provider")
   end
 
-  scenario "I cannnot see 'Manage the resource' button if i am not an admin provider" do
+  scenario "I cannnot see 'Manage the resource' button if it is 'eosc_registry' resource and i am not an admin" do
     user, admin = create_list(:user, 2)
     data_admin =
       create(:data_administrator, first_name: admin.first_name, last_name: admin.last_name, email: admin.email)
     provider = create(:provider, data_administrators: [data_admin])
+    provider_source = create(:eosc_registry_provider_source, provider: provider)
+    provider.upstream = provider_source
+    provider.save!
 
     checkin_sign_in_as(user)
+
+    visit provider_path(provider)
+
+    expect(page).to have_link("Browse resources")
+    expect(page).to_not have_content("Manage the provider")
+  end
+
+  scenario "I cannnot see 'Manage the resource' button if it not eosc_registry provider and i am an admin" do
+    admin = create(:user)
+    data_admin =
+      create(:data_administrator, first_name: admin.first_name, last_name: admin.last_name, email: admin.email)
+    provider = create(:provider, data_administrators: [data_admin])
+
+    checkin_sign_in_as(admin)
 
     visit provider_path(provider)
 

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -12,11 +12,14 @@ RSpec.feature "Service browsing" do
   end
 
   context "with JS:" do
-    scenario "I can see 'Manage the resource' button if i am an admin provider", js: true do
+    scenario "I can see 'Manage the resource' button if i am an admin provider and it is an eosc_registry", js: true do
       user = create(:user)
       admin = create(:data_administrator, first_name: user.first_name, last_name: user.last_name, email: user.email)
       provider = create(:provider, data_administrators: [admin])
       service = create(:service, resource_organisation: provider)
+      service_source = create(:eosc_registry_service_source, service: service)
+      service.upstream = service_source
+      service.save!
       offer1 = create(:offer, service: service)
 
       checkin_sign_in_as(user)
@@ -94,10 +97,28 @@ RSpec.feature "Service browsing" do
       expect(page.body).not_to have_content("Service offers")
     end
 
-    scenario "I cannot see 'Manage the resource' button if i am not an admin provider" do
+    scenario "I cannot see 'Manage the resource' button if i am not an admin provider and it's an eosc_registry" do
       service = create(:service)
       offer1 = create(:offer, service: service)
+      service_source = create(:eosc_registry_service_source, service: service)
+      service.upstream = service_source
+      service.save!
 
+      visit service_path(service)
+
+      expect(page).to have_link("Access the resource")
+      expect(page).to_not have_content("Manage the resource")
+      expect(page).to_not have_content(offer1.name)
+    end
+
+    scenario "I cannot see 'Manage the resource' button if i am an admin provider but it's not eosc_registry" do
+      user = create(:user)
+      admin = create(:data_administrator, first_name: user.first_name, last_name: user.last_name, email: user.email)
+      provider = create(:provider, data_administrators: [admin])
+      service = create(:service, resource_organisation: provider)
+      offer1 = create(:offer, service: service)
+
+      checkin_sign_in_as(user)
       visit service_path(service)
 
       expect(page).to have_link("Access the resource")

--- a/test/system/cypress/integration/regression_tests/backoffice/providers/providers.spec.ts
+++ b/test/system/cypress/integration/regression_tests/backoffice/providers/providers.spec.ts
@@ -65,8 +65,6 @@ describe("Providers", () => {
           .click();
         cy.contains("h2", value)
           .should("be.visible");
-        cy.contains("div", "Manage the provider")
-          .should("be.visible");
         cy.get("[data-e2e='btn-browse-resource']")
           .click();
         cy.location("href")


### PR DESCRIPTION
Show button 'Manage the..' o Resource and Provider views only when
upstream is set to 'eosc_registry'

Fixes #2525 