### PR TITLE
[#2220] Fix date in /events OMS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Removed
 
 ### Fixed
+- Date parsing on /events endpoint in OMS API (@kmarszalek)
 
 ### Security
 

--- a/app/controllers/api/v1/omses/events_controller.rb
+++ b/app/controllers/api/v1/omses/events_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::OMSes::EventsController < Api::V1::ApplicationController
+  include DateHelper
   before_action :find_and_authorize_oms
   before_action :validate_from_timestamp, only: :index
   before_action :validate_limit, only: :index
@@ -19,7 +20,7 @@ class Api::V1::OMSes::EventsController < Api::V1::ApplicationController
 
   def validate_from_timestamp
     params.require(:from_timestamp)
-    @from_timestamp = params[:from_timestamp].to_datetime
+    @from_timestamp = from_timestamp(params[:from_timestamp])
   rescue ActionController::ParameterMissing, ArgumentError => e
     render json: { error: e }, status: 400
   end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DateHelper
+  # e.g. date format: 2001-02-03T04:05:06.123456Z [optional .123456]
+  def from_timestamp(date)
+    unless date.match("^20\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.{1}\\d{1,6})?Z$")
+      raise ArgumentError, "invalid date"
+    end
+    date.to_datetime
+  end
+end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DateHelper, type: :helper do
+  it "converts date from proper date formatted string" do
+    date = "2001-02-03T04:05:06Z"
+    date_utc = "2001-02-03T04:05:06.000000Z"
+    expect(from_timestamp(date)).to eq(date_utc)
+  end
+
+  it "converts date from proper date formatted string with milisec" do
+    date = "2001-02-03T04:05:06.123456Z"
+    date_utc = "2001-02-03T04:05:06.123456Z"
+    expect(from_timestamp(date)).to eq(date_utc)
+  end
+
+  it "converts date from proper date UTC" do
+    date = "2017-09-27T16:46:41Z"
+    date_utc = "2017-09-27T16:46:41.000000+00:00"
+    expect(from_timestamp(date)).to eq(date_utc)
+  end
+
+  it "converts date from proper date UTC with milisec" do
+    date = "2017-09-27T16:46:41.003456Z"
+    date_utc = "2017-09-27T16:46:41.003456+00:00"
+    expect(from_timestamp(date)).to eq(date_utc)
+  end
+
+  it "converts date from proper date UTC with some milisec" do
+    date = "2017-09-27T16:46:41.1234Z"
+    date_utc = "2017-09-27T16:46:41.123400+00:00"
+    expect(from_timestamp(date)).to eq(date_utc)
+  end
+
+  it "raise error when string integer as date" do
+    expect { from_timestamp("100") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when negative string integer as date" do
+    expect { from_timestamp("-100") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when string as date" do
+    expect { from_timestamp("asd") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when date of wrong format" do
+    expect { from_timestamp("2022-02-10T08:13:06") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when string date with minus" do
+    expect { from_timestamp("-2001-02-03T04:05:06+07:00") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when date of wrong format - wrong zone" do
+    expect { from_timestamp("2022-02-10T04:05:06+022:00") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when date of wrong format - wrong zone2" do
+    expect { from_timestamp("2022-02-10T04:05:06+07:00jjj") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when date of wrong format - wrong zone3" do
+    expect { from_timestamp("2022-02-10T04:05:06+77790:00") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when date of wrong format - wrong zone4" do
+    expect { from_timestamp("2022-02-10T04:05:06.123456Zyyy") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when date of wrong date" do
+    expect { from_timestamp("1235322022-02-10T04:05:06.123456Zyyy") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when date of wrong format - wrong end" do
+    expect { from_timestamp("2022-02-10T04:05:4yuuu") }.to raise_error(ArgumentError)
+  end
+
+  it "raise error when date of wrong date2" do
+    expect { from_timestamp("2022-02-30T04:05:04Z") }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/requests/api/v1/omses/events_controller_spec.rb
+++ b/spec/requests/api/v1/omses/events_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::OMSes::EventsController, swagger_doc: "v1/ordering_swagg
                 in: :query,
                 type: :string,
                 required: true,
-                description: "List events after, ISO8601 format"
+                description: "List events after, ISO8601 format, e.g. 2021-04-07T15:31:46.123456Z"
       parameter name: :limit, in: :query, type: :integer, required: false, description: "number of returned elements"
 
       response 200, "events found" do
@@ -40,7 +40,7 @@ RSpec.describe Api::V1::OMSes::EventsController, swagger_doc: "v1/ordering_swagg
 
         let(:oms_id) { oms.id }
         let(:"X-User-Token") { oms_admin.authentication_token }
-        let(:from_timestamp) { "2001-04-07T15:31:46+02:00" }
+        let(:from_timestamp) { CGI.escape("2000-04-07T15:31:46.09Z") }
         let(:limit) { 4 }
 
         run_test! do |response|
@@ -76,7 +76,7 @@ RSpec.describe Api::V1::OMSes::EventsController, swagger_doc: "v1/ordering_swagg
 
         let(:oms_id) { oms.id }
         let(:"X-User-Token") { oms_admin.authentication_token }
-        let(:from_timestamp) { "2000-04-07T15:31:46+02:00" }
+        let(:from_timestamp) { CGI.escape("2000-04-07T15:31:46.30Z") }
 
         run_test! do |response|
           data = JSON.parse(response.body)
@@ -85,17 +85,19 @@ RSpec.describe Api::V1::OMSes::EventsController, swagger_doc: "v1/ordering_swagg
       end
 
       response 400, "bad request" do
-        schema "$ref" => "error.json"
-        let(:oms_admin) { create(:user) }
-        let(:oms) { create(:oms, administrators: [oms_admin]) }
+        %w[100 asd].each do |val|
+          schema "$ref" => "error.json"
+          let(:oms_admin) { create(:user) }
+          let(:oms) { create(:oms, administrators: [oms_admin]) }
 
-        let(:oms_id) { oms.id }
-        let(:"X-User-Token") { oms_admin.authentication_token }
-        let(:from_timestamp) { "asd" }
+          let(:oms_id) { oms.id }
+          let(:"X-User-Token") { oms_admin.authentication_token }
+          let(:from_timestamp) { val }
 
-        run_test! do |response|
-          data = JSON.parse(response.body)
-          expect(data).to eq({ error: "invalid date" }.stringify_keys)
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data).to eq({ error: "invalid date" }.stringify_keys)
+          end
         end
       end
 
@@ -103,7 +105,7 @@ RSpec.describe Api::V1::OMSes::EventsController, swagger_doc: "v1/ordering_swagg
         schema "$ref" => "error.json"
         let(:oms_id) { 1 }
         let(:"X-User-Token") { "asdasdasd" }
-        let(:from_timestamp) { "2000-04-07T15:31:46+02:00" }
+        let(:from_timestamp) { CGI.escape("2000-04-07T15:31:46+02:00") }
 
         run_test! do |response|
           data = JSON.parse(response.body)
@@ -119,7 +121,7 @@ RSpec.describe Api::V1::OMSes::EventsController, swagger_doc: "v1/ordering_swagg
 
         let(:oms_id) { oms.id }
         let(:"X-User-Token") { user.authentication_token }
-        let(:from_timestamp) { "2000-04-07T15:31:46+02:00" }
+        let(:from_timestamp) { CGI.escape("2000-04-07T15:31:46+02:00") }
 
         run_test! do |response|
           data = JSON.parse(response.body)
@@ -133,7 +135,7 @@ RSpec.describe Api::V1::OMSes::EventsController, swagger_doc: "v1/ordering_swagg
 
         let(:oms_id) { 9999 }
         let(:"X-User-Token") { user.authentication_token }
-        let(:from_timestamp) { "2000-04-07T15:31:46+02:00" }
+        let(:from_timestamp) { CGI.escape("2000-04-07T15:31:46+02:00") }
 
         run_test! do |response|
           data = JSON.parse(response.body)

--- a/swagger/v1/ordering_swagger.json
+++ b/swagger/v1/ordering_swagger.json
@@ -31,7 +31,7 @@
             "name": "from_timestamp",
             "in": "query",
             "required": true,
-            "description": "List events after, ISO8601 format",
+            "description": "List events after, ISO8601 format, e.g. 2021-04-07T15:31:46.123456Z",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
Fix parsing date for /events endpoint
date format: 
* 2021-04-07T15:31:46Z
* 2001-02-03T04:05:06.123456Z
* 2017-09-27T23:46:46.003Z

no acceptable:
* asd
* 100
* -100
* -2021-04-07T15:31:46+02:00
* 2022-02-10T08:13

Fixes #2220 