### PR TITLE
[#2549] Fix resources statistics for executive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
-
 ## [3.33.0-milestone]
 
 ### Added
@@ -27,6 +26,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Fix resource subpages add to favourite button (@danielkryska)
 - Fix researching resources from nth page of resources (@danielkryska)
 - Don't depend on offer when determining whether a Project Item is a bundle (@jswk)
+- Fix displaying statistics of the resource for executive role (@goreck888)
 
 ### Security
 

--- a/app/models/concerns/offerable.rb
+++ b/app/models/concerns/offerable.rb
@@ -4,6 +4,8 @@ module Offerable
   extend ActiveSupport::Concern
 
   included do
+    scope :orderable, -> { where(order_type: :order_required, internal: true) }
+
     enum order_type: {
            open_access: "open_access",
            fully_open_access: "fully_open_access",

--- a/app/views/services/_analytics.html.haml
+++ b/app/views/services/_analytics.html.haml
@@ -13,8 +13,10 @@
     %span
       = _("Total occurrences in project") + ":"
     %strong.text-dark= service.project_items_count
-  - if service.offers.order_required.present?
+  - if service.offers.any?(&:orderable?)
     %li.list-group-item
-      %span
+      %span{ "data-toggle": "tooltip", "data-trigger": "hover",
+             title: "A number of created Project Items that use EOSC Portal
+                                         as the order management platform" }
         = _("Total orders") + ":"
-      %strong.text-dark= service.project_items.order_required.size
+      %strong.text-dark= service.project_items.orderable.size


### PR DESCRIPTION
Add `orderable` scope for `offers` and `project_items`
for proper displaying and counting ordered (only internal `order_required`) resources.


Fixes #2549 