### PR TITLE
[HOTFIX] Fix EGI Notebooks backoffice page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Fix researching resources from nth page of resources (@danielkryska)
 - Don't depend on offer when determining whether a Project Item is a bundle (@jswk)
 - Fix displaying statistics of the resource for executive role (@goreck888)
+- Missing partial in the EGI Notebooks resource page (@goreck888)
 
 ### Security
 

--- a/app/components/presentable/description_component.html.haml
+++ b/app/components/presentable/description_component.html.haml
@@ -4,7 +4,7 @@
 
       = markdown(@object.description)
       - if @object.pid == (ENV["OPENAIRE_NOTEBOOKS__ACTIVATION_PID"] || "egi-fed.notebook")
-        = render "notebook_openaire_explore"
+        = render "services/notebook_openaire_explore"
 
       = description_panels
     %sidebar.col-12.col-xl-3{ "data-shepherd-tour-target": "service-classification" }

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -881,5 +881,20 @@ RSpec.feature "Services in backoffice" do
 
       expect(page).to have_content("New offer created successfully")
     end
+
+    scenario "I can see OpenAIRE explore integration for EGI Notebooks" do
+      notebook_service = create(:service, pid: "egi-fed.notebook", owners: [user])
+      other_service_with_pid = create(:service, pid: "other.pid", owners: [user])
+      other_service_without_pid = create(:service, pid: nil, owners: [user])
+
+      visit backoffice_service_path(notebook_service)
+      expect(page).to have_text("See Jupyter notebooks compatible with the EGI Notebook service")
+
+      visit backoffice_service_path(other_service_with_pid)
+      expect(page).not_to have_text("See Jupyter notebooks compatible with the EGI Notebook service")
+
+      visit backoffice_service_path(other_service_without_pid)
+      expect(page).not_to have_text("See Jupyter notebooks compatible with the EGI Notebook service")
+    end
   end
 end

--- a/spec/features/ordering_configuration_spec.rb
+++ b/spec/features/ordering_configuration_spec.rb
@@ -29,6 +29,26 @@ RSpec.feature "Services in ordering_configuration panel" do
       expect(page).to have_link("Set parameters and offers")
     end
 
+    scenario "I can see OpenAIRE explore integration for EGI Notebooks" do
+      notebook_service = create(:service, pid: "egi-fed.notebook", resource_organisation: provider)
+      other_service_with_pid = create(:service, pid: "other.pid", resource_organisation: provider)
+
+      notebook_source = create(:eosc_registry_service_source, service: notebook_service)
+      other_source = create(:eosc_registry_service_source, service: other_service_with_pid)
+
+      notebook_service.update!(upstream: notebook_source)
+      other_service_with_pid.update!(upstream: other_source)
+
+      visit service_ordering_configuration_path(notebook_service)
+      expect(page).to have_text("See Jupyter notebooks compatible with the EGI Notebook service")
+
+      visit service_ordering_configuration_path(other_service_with_pid)
+      expect(page).not_to have_text("See Jupyter notebooks compatible with the EGI Notebook service")
+
+      visit service_ordering_configuration_path(service)
+      expect(page).not_to have_text("See Jupyter notebooks compatible with the EGI Notebook service")
+    end
+
     scenario "I can edit offer parameters", js: true do
       visit service_ordering_configuration_path(service)
 


### PR DESCRIPTION
Add missing direct path to the `notebook_openaire_explore`
partial. Now it's impossible to see EGI Notebooks page
in the backoffice