### PR TITLE
[#2498] Add "engine_version" field in the body of the /recommendations request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - Missing notification about new message in bundled offers (@goreck888)
+- Parameter engine_version in the body of /recommendations request (@Michal-Kolomanski)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ We are currently using the following ENV variables:
     `http://localhost:#{ENV["PORT"] || 3000}` (when foreman is used to start
     application 5000 ENV variable is set)
   * `ELASTICSEARCH_URL` - elasticsearch url
+  * `RECOMMENDER_HOST` - address of the recommender system. For example: `http://127.0.0.1:5001`
+  * `RECOMMENDATION_ENGINE` - the name of the engine that is requested to serve recommendations when a request from MP is sent to the RS `/recommendations` endpoint. We currently support RL and NCF.
   * `STORAGE_DIR` - active storage local dir (default set to
     `RAILS_ROOT/storage`)
   * `S3_STORAGE` - set true to change ActiveStorage to S3

--- a/app/controllers/concerns/service/recommendable.rb
+++ b/app/controllers/concerns/service/recommendable.rb
@@ -77,6 +77,7 @@ module Service::Recommendable
       visit_id: cookies[:targetId],
       page_id: "/service",
       panel_id: "v1",
+      engine_version: Mp::Application.config.recommendation_engine,
       search_data: get_filters_by(@params)
     }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,6 +65,7 @@ module Mp
       end
 
     config.recommender_host = ENV["RECOMMENDER_HOST"]
+    config.recommendation_engine = ENV["RECOMMENDATION_ENGINE"] || "RL"
     config.auth_mock = ENV["AUTH_MOCK"]
     config.eosc_commons_base_url =
       if ENV["EOSC_COMMONS_BASE_URL"].present?

--- a/spec/controllers/concerns/recommendable_spec.rb
+++ b/spec/controllers/concerns/recommendable_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe ApplicationController, type: :controller do
       expect(body["visit_id"].to_i).not_to be_nil
       expect(body["page_id"]).to eq "/service"
       expect(body["panel_id"]).to eq "v1"
+      expect(body["engine_version"]).to eq "RL"
       expect(body["search_phrase"]).to be nil
       expect(body["logged_user"]).to be false
       expect(body["filters"]).to be nil


### PR DESCRIPTION
closes #2498 

By using "engine_version" we can specify which algorithm should be used to serve recommendations.

Changes:
- "engine_version" in the body of the /recommendations request,
- "engine_version" field is set to the environmental variable: RECOMMENDATION_ENGINE if it exists;
 otherwise, it's set to "RL".