### PR TITLE
[#2597] Rewrite jms handle of Provider msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.35.0-milestone]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- JMS handling of Provider messages (@kmarszalek)
+
+### Security
+
 ## [3.34.0] 2022-03-22
 
 ## [3.33.0] 2022-03-07

--- a/app/services/provider/pc_create_or_update.rb
+++ b/app/services/provider/pc_create_or_update.rb
@@ -12,9 +12,10 @@ class Provider::PcCreateOrUpdate
     provider_hash = Importers::Provider.new(@eosc_registry_provider, @modified_at).call
     mapped_provider =
       Provider.joins(:sources).find_by("provider_sources.source_type": "eosc_registry", "provider_sources.eid": @eid)
-    if mapped_provider.nil? && @is_active
+    if mapped_provider.nil?
       mapped_provider = Provider.new(provider_hash)
       mapped_provider.set_default_logo
+      mapped_provider.status = @is_active ? "published" : "draft"
       if mapped_provider.save!
         provider_source =
           ProviderSource.create!(provider_id: mapped_provider.id, source_type: "eosc_registry", eid: @eid)
@@ -22,7 +23,7 @@ class Provider::PcCreateOrUpdate
     else
       mapped_provider.update(provider_hash)
       provider_source = mapped_provider.sources.find_by(source_type: "eosc_registry")
-      mapped_provider.status = "draft" unless @is_active
+      mapped_provider.status = @is_active ? "published" : "draft"
     end
     mapped_provider.update(upstream_id: provider_source.id) if provider_source.present?
 

--- a/spec/factories/jms_providers_response.rb
+++ b/spec/factories/jms_providers_response.rb
@@ -130,7 +130,7 @@ FactoryBot.define do
       }
     end
   end
-  factory :jms_provider_response, class: Hash do
+  factory :jms_published_provider_response, class: Hash do
     skip_create
     transient do
       eid { "tp" }
@@ -147,6 +147,48 @@ FactoryBot.define do
         "additionalInfo" => "no",
         "contactInformation" => "test phone number",
         "active" => true,
+        "status" => "approved",
+        "abbreviation" => "test",
+        "description" => "test",
+        "location" => {
+          "streetNameAndNumber" => "street",
+          "postalCode" => "00-000",
+          "city" => "test",
+          "region" => "WW",
+          "country" => "N/E"
+        },
+        "publicContacts" => {
+          "publicContact" => {
+            "email" => "test@mail.pl"
+          }
+        },
+        "users" => {
+          "user" => {
+            "email" => "test@mail.pl",
+            "name" => "test",
+            "surname" => "test"
+          }
+        }
+      }
+    end
+  end
+  factory :jms_draft_provider_response, class: Hash do
+    skip_create
+    transient do
+      eid { "tp" }
+      name { "Test Provider #{eid}" }
+    end
+    initialize_with do
+      {
+        "id" => eid,
+        "name" => name,
+        "website" => "http://beta.providers.eosc-portal.eu",
+        "catalogueOfResources" => "http://no.i.dont",
+        "publicDescOfResources" => "http://no.i.dont",
+        "logo" => "https://cdn.shopify.com/s/files/1/0553/3925/products/logo_developers_grande.png?v=1432756867",
+        "additionalInfo" => "no",
+        "contactInformation" => "test phone number",
+        "active" => false,
         "status" => "approved",
         "abbreviation" => "test",
         "description" => "test",

--- a/spec/services/jms/manage_message_spec.rb
+++ b/spec/services/jms/manage_message_spec.rb
@@ -79,11 +79,11 @@ describe Jms::ManageMessage do
     $stdout = original_stdout
   end
 
-  it "should do nothing for update rejected provider message" do
+  it "should receive update to update rejected provider message" do
     original_stdout = $stdout
     $stdout = StringIO.new
     resource = parser.parse(rejected_provider_resource["resource"])
-    expect(Provider::PcCreateOrUpdateJob).to_not receive(:perform_later).with(
+    expect(Provider::PcCreateOrUpdateJob).to receive(:perform_later).with(
       resource["providerBundle"]["provider"],
       resource["providerBundle"]["active"],
       Time.at(resource["providerBundle"]["metadata"]["modifiedAt"].to_i&./ 1000)


### PR DESCRIPTION
All providers in all statuses should be in mp db, with proper mp status for showing them in FO.

Fixes #2597 