### PR TITLE
[#2590] Fix REST import of Providers and Resources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,8 @@ Metrics/BlockNesting:
   Enabled: true
   Exclude:
     - 'app/controllers/users/omniauth_callbacks_controller.rb'
+    - 'lib/import/resources.rb'
+    - 'lib/import/providers.rb'
 
 Metrics/PerceivedComplexity:
   Enabled: true
@@ -46,6 +48,8 @@ Metrics/PerceivedComplexity:
     - 'app/services/project_item/create.rb'
     - 'app/services/service/pc_create_or_update.rb'
     - 'lib/import/vocabularies.rb'
+    - 'lib/import/resources.rb'
+    - 'lib/import/providers.rb'
     - 'lib/jira/console_checker.rb'
 
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ### Fixed
 - Fix saving areas of activity of provider (@danielkryska)
 - JMS handling of Provider messages (@kmarszalek)
+- REST import for Resources and Providers (@kmarszalek)
 
 ### Security
 

--- a/lib/import/resources.rb
+++ b/lib/import/resources.rb
@@ -28,8 +28,7 @@ module Import
 
       begin
         token = Importers::Token.new(faraday: @faraday).receive_token
-        response =
-          Importers::Request.new(@eosc_registry_base_url, "resource/rich", faraday: @faraday, token: token).call
+        response = Importers::Request.new(@eosc_registry_base_url, "infraService", faraday: @faraday, token: token).call
       rescue Errno::ECONNREFUSED, Importers::Token::RequestError => e
         abort("import exited with errors - could not connect to #{@eosc_registry_base_url} \n #{e.message}")
       end
@@ -51,56 +50,54 @@ module Import
           synchronized_at = service_data["metadata"]["modifiedAt"].to_i
           image_url = service["logo"]
           service = Importers::Service.new(service, synchronized_at, @eosc_registry_base_url, @token, "rest").call
+          service["status"] = service_data["active"] ? :published : :draft
+          if (service_source = ServiceSource.find_by(eid: service[:pid], source_type: "eosc_registry")).nil?
+            created += 1
+            log "Adding [NEW] service: #{service[:name]}, eid: #{service[:pid]}"
+            unless @dry_run
+              service = Service.new(service)
+              if service.valid?
+                service = Service::Create.new(service).call
+                service_source =
+                  ServiceSource.create!(service_id: service.id, eid: service.pid, source_type: "eosc_registry")
+                update_from_eosc_registry(service, service_source, true)
 
-          begin
-            if (service_source = ServiceSource.find_by(eid: service[:pid], source_type: "eosc_registry")).nil?
-              created += 1
-              log "Adding [NEW] service: #{service[:name]}, eid: #{service[:pid]}"
-              unless @dry_run
-                service = Service.new(service)
-                if service.valid?
-                  service = Service::Create.new(service).call
-                  service_source =
-                    ServiceSource.create!(service_id: service.id, eid: service.pid, source_type: "eosc_registry")
-                  update_from_eosc_registry(service, service_source, true)
-
-                  Importers::Logo.new(service, image_url).call
-                  service.save!
-                else
-                  service.status = "errored"
-                  service.save(validate: false)
-                  service_source =
-                    ServiceSource.create!(service_id: service.id, eid: service.pid, source_type: "eosc_registry")
-                  update_from_eosc_registry(service, service_source, false)
-                  log "Service #{service.name}, eid: #{service.pid} saved with errors: #{service.errors.full_messages}"
-
-                  Importers::Logo.new(service, image_url).call
-                  service.save(validate: false)
-                end
-              end
-            else
-              existing_service = Service.find_by(id: service_source.service_id)
-              if existing_service.upstream_id == service_source.id
-                updated += 1
-                log "Updating [EXISTING] service #{service[:name]}, id: #{service_source.id}, eid: #{service[:pid]}"
-                unless @dry_run
-                  Service::Update.call(existing_service, service)
-
-                  Importers::Logo.new(existing_service, image_url).call
-                  existing_service.save!
-                end
+                Importers::Logo.new(service, image_url).call
+                service.save!
               else
-                not_modified += 1
-                log "Service upstream is not set to EOSC Registry," \
-                      " not updating #{existing_service.name}, id: #{service_source.id}"
+                service.status = service_data["active"] ? :errored : :draft
+                service.save(validate: false)
+                service_source =
+                  ServiceSource.create!(service_id: service.id, eid: service.pid, source_type: "eosc_registry")
+                update_from_eosc_registry(service, service_source, false)
+                log "Service #{service.name}, eid: #{service.pid} saved with errors: #{service.errors.full_messages}"
+
+                Importers::Logo.new(service, image_url).call
+                service.save(validate: false)
               end
             end
-          rescue ActiveRecord::RecordInvalid => e
-            log "ERROR - #{e}! #{service[:name]} (eid: #{service[:pid]}) " \
-                  "will NOT be created (please contact catalog manager)"
-          rescue StandardError => e
-            log "ERROR - Unexpected #{e}! #{service[:name]} (eid: #{service[:pid]}) will NOT be created!"
+          else
+            existing_service = Service.find_by(id: service_source.service_id)
+            if existing_service.upstream_id == service_source.id
+              updated += 1
+              log "Updating [EXISTING] service #{service[:name]}, id: #{service_source.id}, eid: #{service[:pid]}"
+              unless @dry_run
+                Service::Update.call(existing_service, service)
+
+                Importers::Logo.new(existing_service, image_url).call
+                existing_service.save!
+              end
+            else
+              not_modified += 1
+              log "Service upstream is not set to EOSC Registry," \
+                    " not updating #{existing_service.name}, id: #{service_source.id}"
+            end
           end
+        rescue ActiveRecord::RecordInvalid => e
+          log "ERROR - #{e}! #{name(service_data)} (eid: #{eid(service_data)}) " \
+                "will NOT be created (please contact catalog manager)"
+        rescue StandardError => e
+          log "ERROR - Unexpected #{e}! #{name(service_data)} (eid: #{eid(service_data)}) will NOT be created!"
         end
       log "PROCESSED: #{total_service_count}, CREATED: #{created}, UPDATED: #{updated}, NOT MODIFIED: #{not_modified}"
 
@@ -110,6 +107,14 @@ module Import
     end
 
     private
+
+    def name(service_data)
+      service_data.dig("service", "name")
+    end
+
+    def eid(service_data)
+      service_data.dig("service", "id")
+    end
 
     def update_from_eosc_registry(service, service_source, validate)
       if @default_upstream == :eosc_registry

--- a/spec/factories/eosc_registry_providers_response.rb
+++ b/spec/factories/eosc_registry_providers_response.rb
@@ -11,88 +11,132 @@ FactoryBot.define do
         "to" => 2,
         "results" => [
           {
-            "id" => "bluebridge",
-            "name" => "BlueBRIDGE",
-            "website" => "https://www.bluebridge-vres.eu/",
-            "catalogueOfResources" => nil,
-            "publicDescOfResources" => nil,
-            "logo" => "https://about.west-life.eu/network/west-life/about/templates/westlife/images/west-life.png",
-            "additionalInfo" => "-",
-            "contactInformation" => nil,
+            "metadata" => {
+              "registeredBy" => "John Doe",
+              "registeredAt" => "1549033448415",
+              "modifiedBy" => "John Doe",
+              "modifiedAt" => "1549624107536",
+              "source" => "EOSC",
+              "originalId" => nil
+            },
             "active" => true,
-            "status" => "approved",
-            "abbreviation" => "BlueBRIDGE",
-            "description" => "test",
-            "location" => {
-              "streetNameAndNumber" => "street",
-              "postalCode" => "00-000",
-              "city" => "test",
-              "region" => "WW",
-              "country" => "N/E"
+            "provider" => {
+              "id" => "bluebridge",
+              "name" => "BlueBRIDGE",
+              "website" => "https://www.bluebridge-vres.eu/",
+              "catalogueOfResources" => nil,
+              "publicDescOfResources" => nil,
+              "logo" => "https://about.west-life.eu/network/west-life/about/templates/westlife/images/west-life.png",
+              "additionalInfo" => "-",
+              "contactInformation" => nil,
+              "active" => true,
+              "status" => "approved",
+              "abbreviation" => "BlueBRIDGE",
+              "description" => "test",
+              "location" => {
+                "streetNameAndNumber" => "street",
+                "postalCode" => "00-000",
+                "city" => "test",
+                "region" => "WW",
+                "country" => "N/E"
+              }
             }
           },
           {
-            "id" => "phenomenal",
-            "name" => "Phenomenal",
-            "website" => "http://phenomenal-h2020.eu/home/",
-            "catalogueOfResources" => nil,
-            "publicDescOfResources" => nil,
-            "logo" => "http://phenomenal-h2020.eu/home/wp-content/uploads/2016/06/PhenoMeNal_logo.png",
-            "additionalInfo" => "-",
-            "contactInformation" => "",
+            "metadata" => {
+              "registeredBy" => "John Doe",
+              "registeredAt" => "1549033448415",
+              "modifiedBy" => "John Doe",
+              "modifiedAt" => "1549624107536",
+              "source" => "EOSC",
+              "originalId" => nil
+            },
             "active" => true,
-            "status" => "approved",
-            "abbreviation" => "Phenomenal",
-            "description" => "test",
-            "location" => {
-              "streetNameAndNumber" => "street",
-              "postalCode" => "00-000",
-              "city" => "test",
-              "region" => "WW",
-              "country" => "N/E"
+            "provider" => {
+              "id" => "phenomenal",
+              "name" => "Phenomenal",
+              "website" => "http://phenomenal-h2020.eu/home/",
+              "catalogueOfResources" => nil,
+              "publicDescOfResources" => nil,
+              "logo" => "http://phenomenal-h2020.eu/home/wp-content/uploads/2016/06/PhenoMeNal_logo.png",
+              "additionalInfo" => "-",
+              "contactInformation" => "",
+              "active" => true,
+              "status" => "approved",
+              "abbreviation" => "Phenomenal",
+              "description" => "test",
+              "location" => {
+                "streetNameAndNumber" => "street",
+                "postalCode" => "00-000",
+                "city" => "test",
+                "region" => "WW",
+                "country" => "N/E"
+              }
             }
           },
           {
-            "id" => "West-Life",
-            "name" => "World-wide E-infrastructure for structural biology",
-            "website" => "https://west-life.eu",
-            "catalogueOfResources" => "https://bio.tools/",
-            "publicDescOfResources" => "https://about.west-life.eu/network/west-life/services",
-            "logo" => "https://about.west-life.eu/network/west-life/about/templates/westlife/images/west-life.png",
-            "additionalInfo" =>
-              "https://about.west-life.eu/network/west-life/about/project. For more information contact chris.morris@stfc.ac.uk",
-            "contactInformation" => "+44 1925 603689",
+            "metadata" => {
+              "registeredBy" => "John Doe",
+              "registeredAt" => "1549033448415",
+              "modifiedBy" => "John Doe",
+              "modifiedAt" => "1549624107536",
+              "source" => "EOSC",
+              "originalId" => nil
+            },
             "active" => true,
-            "status" => "approved",
-            "abbreviation" => "West-Life",
-            "description" => "test",
-            "location" => {
-              "streetNameAndNumber" => "street",
-              "postalCode" => "00-000",
-              "city" => "test",
-              "region" => "WW",
-              "country" => "N/E"
+            "provider" => {
+              "id" => "West-Life",
+              "name" => "World-wide E-infrastructure for structural biology",
+              "website" => "https://west-life.eu",
+              "catalogueOfResources" => "https://bio.tools/",
+              "publicDescOfResources" => "https://about.west-life.eu/network/west-life/services",
+              "logo" => "https://about.west-life.eu/network/west-life/about/templates/westlife/images/west-life.png",
+              "additionalInfo" =>
+                "https://about.west-life.eu/network/west-life/about/project. For more information contact chris.morris@stfc.ac.uk",
+              "contactInformation" => "+44 1925 603689",
+              "active" => true,
+              "status" => "approved",
+              "abbreviation" => "West-Life",
+              "description" => "test",
+              "location" => {
+                "streetNameAndNumber" => "street",
+                "postalCode" => "00-000",
+                "city" => "test",
+                "region" => "WW",
+                "country" => "N/E"
+              }
             }
           },
           {
-            "id" => "awesome",
-            "name" => "Awesome provider",
-            "website" => "https://www.osom-prov.eu/",
-            "catalogueOfResources" => nil,
-            "publicDescOfResources" => nil,
-            "logo" => "https://about.west-life.eu/network/west-life/about/templates/westlife/images/west-life.png",
-            "additionalInfo" => "Nothing, cause I'm avesome",
-            "contactInformation" => nil,
+            "metadata" => {
+              "registeredBy" => "John Doe",
+              "registeredAt" => "1549033448415",
+              "modifiedBy" => "John Doe",
+              "modifiedAt" => "1549624107536",
+              "source" => "EOSC",
+              "originalId" => nil
+            },
             "active" => true,
-            "status" => "approved",
-            "abbreviation" => "Awesome provider",
-            "description" => "test",
-            "location" => {
-              "streetNameAndNumber" => "street",
-              "postalCode" => "00-000",
-              "city" => "test",
-              "region" => "WW",
-              "country" => "N/E"
+            "provider" => {
+              "id" => "awesome",
+              "name" => "Awesome provider",
+              "website" => "https://www.osom-prov.eu/",
+              "catalogueOfResources" => nil,
+              "publicDescOfResources" => nil,
+              "logo" => "https://about.west-life.eu/network/west-life/about/templates/westlife/images/west-life.png",
+              "additionalInfo" => "Nothing, cause I'm avesome",
+              "contactInformation" => nil,
+              "active" => true,
+              "status" => "approved",
+              "abbreviation" => "Awesome provider",
+              "description" => "test",
+              "location" => {
+                "streetNameAndNumber" => "street",
+                "postalCode" => "00-000",
+                "city" => "test",
+                "region" => "WW",
+                "country" => "N/E"
+              }
             }
           }
         ],
@@ -114,24 +158,35 @@ FactoryBot.define do
     end
     initialize_with do
       {
-        "id" => eid,
-        "name" => name,
-        "website" => "http://beta.providers.eosc-portal.eu",
-        "catalogueOfResources" => "http://no.i.dont",
-        "publicDescOfResources" => "http://no.i.dont",
-        "logo" => "https://cdn.shopify.com/s/files/1/0553/3925/products/logo_developers_grande.png?v=1432756867",
-        "additionalInfo" => "no",
-        "contactInformation" => "test phone number",
+        "metadata" => {
+          "registeredBy" => "John Doe",
+          "registeredAt" => "1549033448415",
+          "modifiedBy" => "John Doe",
+          "modifiedAt" => "1549624107536",
+          "source" => "EOSC",
+          "originalId" => nil
+        },
         "active" => true,
-        "status" => "approved",
-        "abbreviation" => "test",
-        "description" => "test",
-        "location" => {
-          "streetNameAndNumber" => "street",
-          "postalCode" => "00-000",
-          "city" => "test",
-          "region" => "WW",
-          "country" => "N/E"
+        "provider" => {
+          "id" => eid,
+          "name" => name,
+          "website" => "http://beta.providers.eosc-portal.eu",
+          "catalogueOfResources" => "http://no.i.dont",
+          "publicDescOfResources" => "http://no.i.dont",
+          "logo" => "https://cdn.shopify.com/s/files/1/0553/3925/products/logo_developers_grande.png?v=1432756867",
+          "additionalInfo" => "no",
+          "contactInformation" => "test phone number",
+          "active" => true,
+          "status" => "approved",
+          "abbreviation" => "test",
+          "description" => "test",
+          "location" => {
+            "streetNameAndNumber" => "street",
+            "postalCode" => "00-000",
+            "city" => "test",
+            "region" => "WW",
+            "country" => "N/E"
+          }
         }
       }
     end

--- a/spec/lib/import/providers_spec.rb
+++ b/spec/lib/import/providers_spec.rb
@@ -59,7 +59,7 @@ describe Import::Providers do
   def expect_responses(test_url, providers_response = nil)
     unless providers_response.nil?
       allow_any_instance_of(Faraday::Connection).to receive(:get)
-        .with("#{test_url}/provider/all?quantity=10000&from=0")
+        .with("#{test_url}/provider/bundle/all?quantity=10000&from=0")
         .and_return(providers_response)
     end
   end

--- a/spec/lib/import/resources_spec.rb
+++ b/spec/lib/import/resources_spec.rb
@@ -59,7 +59,7 @@ describe Import::Resources do
   def expect_responses(test_url, services_response = nil)
     unless services_response.nil?
       allow_any_instance_of(Faraday::Connection).to receive(:get)
-        .with("#{test_url}/resource/rich/all?quantity=10000&from=0")
+        .with("#{test_url}/infraService/all?quantity=10000&from=0")
         .and_return(services_response)
     end
   end


### PR DESCRIPTION
*change API endpoint to newer that consist of status
and active flag in response
*adapt code to diff return value

USE:
* import resource/resources
bundle exec rake import:resources IDS=<RESOURCE_IDS> MP_IMPORT_TOKEN=<TOKEN>
* import provider/providers
bundle exec rake import:providers IDS=<RESOURCE_IDS> MP_IMPORT_TOKEN=<TOKEN>
IDS => comma separated PC ids
TOKEN => token with epot role.

Fixes #2590 