### PR TITLE
[#2621] Publish model changes to JMS databus

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ We are currently using the following ENV variables:
   * `MP_STOMP_PUBLISHER_ENABLED` (Optional) - turn on publishing with JMS if set to `true` (default `false`)
   * `MP_STOMP_PUBLISHER_LOGGER_PATH` (Optional) - path to the JMS log file (default `"RAILS_ROOT/log/jms.publisher.log"`)
   * `MP_STOMP_PUBLISHER_TOPIC` (Optional) - topic of a new message to be published (default `credentials.stomp.publisher.topic`)
-  * `MP_STOMP_PUBLISHER_DATABUS_TOPIC` (Optional) - topic of a databus queue (default `databus`)
+  * `MP_STOMP_PUBLISHER_MP_DB_EVENTS_TOPIC` (Optional) - topic for publishing database create, update and destroy events (default `mp_db_events`)
+  * `MP_STOMP_PUBLISHER_USER_ACTIONS_TOPIC` (Optional) - topic for publishing user actions events(default `user_actions`)
   * `USER_ACTIONS_TARGET` (Optional) - target to which user_actions should be published (options: `all, recommender, databus`) (default `all`)
     * For the `databus` target to work you must also enable JMS publishing, i.e. set `MP_STOMP_PUBLISHER_ENABLED=true`.  
   * `ESS_UPDATE_ENABLED` (Optional) - turn on updating ESS if set to `true` (default `false`)

--- a/app/controllers/user_action_controller.rb
+++ b/app/controllers/user_action_controller.rb
@@ -23,16 +23,15 @@ class UserActionController < ApplicationController
     is_recommendation_panel = params[:source]["root"]["type"] != "other"
     request_body[:source]["root"]["panel_id"] = "v1" if is_recommendation_panel
 
-    # We're publish user actions to both JMS under the "recommender" topic
-    # as well as to Recommender server directly for now
-    # Recommender cannot receive JMS messages yet
+    # We publish user actions to both JMS under the "user_actions" topic
+    # as well as to the recommender server directly for now
 
     if %w[all recommender].include? Mp::Application.config.user_actions_target
       Probes::ProbesJob.perform_later(request_body.to_json)
     end
 
-    if %w[all databus].include? Mp::Application.config.user_actions_target
-      Jms::PublishJob.perform_later(request_body.to_json, :databus)
+    if %w[all jms].include? Mp::Application.config.user_actions_target
+      Jms::PublishJob.perform_later(request_body.to_json, :user_actions)
     end
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,6 +6,7 @@ class Category < ApplicationRecord
 
   include Parentable
   include LogoAttachable
+  include Publishable
 
   # This callback need to be defined byfore dependent: :destroy
   # relation, because in this case project_item matter. This callback need to be

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Publishable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create :send_to_databus_create
+    after_update :send_to_databus_update
+    after_destroy :send_to_databus_destroy
+
+    private
+
+    def send_to_databus_create
+      payload = payload_for(:create)
+      publish(payload)
+    end
+
+    def send_to_databus_update
+      payload = payload_for(:update)
+      publish(payload)
+    end
+
+    def send_to_databus_destroy
+      payload = payload_for(:destroy)
+      publish(payload)
+    end
+
+    def publish(payload)
+      Jms::PublishJob.perform_later(payload, :mp_db_events)
+    end
+
+    def payload_for(cud_type)
+      { cud: cud_type, model: self.class.name, record: serialize_for_databus, timestamp: Time.current.iso8601 }.as_json
+    end
+
+    def serialize_for_databus
+      serializer = "Recommender::#{self.class}Serializer".constantize
+      serializer.new(self).as_json
+    end
+  end
+end

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Platform < ApplicationRecord
+  include Publishable
+
   include Parentable
 
   has_many :service_related_platforms, dependent: :destroy

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -3,6 +3,7 @@
 class Provider < ApplicationRecord
   include LogoAttachable
   include ImageHelper
+  include Publishable
 
   extend FriendlyId
   friendly_id :pid

--- a/app/models/scientific_domain.rb
+++ b/app/models/scientific_domain.rb
@@ -3,6 +3,7 @@
 class ScientificDomain < ApplicationRecord
   include Parentable
   include LogoAttachable
+  include Publishable
 
   has_one_attached :logo
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,6 +5,7 @@ class Service < ApplicationRecord
 
   include Service::Search
   include LogoAttachable
+  include Publishable
 
   extend FriendlyId
   friendly_id :name, use: :slugged

--- a/app/models/target_user.rb
+++ b/app/models/target_user.rb
@@ -2,6 +2,7 @@
 
 class TargetUser < ApplicationRecord
   include Parentable
+  include Publishable
 
   has_many :service_target_users, dependent: :destroy
   has_many :services, through: :service_target_users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :rememberable, :trackable, :omniauthable, omniauth_providers: %i[checkin]
 
+  include Publishable
   include RoleModel
   roles :admin, :service_portfolio_manager, :executive
 

--- a/app/models/vocabulary/access_mode.rb
+++ b/app/models/vocabulary/access_mode.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Vocabulary::AccessMode < Vocabulary
+  include Publishable
 end

--- a/app/models/vocabulary/access_type.rb
+++ b/app/models/vocabulary/access_type.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Vocabulary::AccessType < Vocabulary
+  include Publishable
 end

--- a/app/models/vocabulary/life_cycle_status.rb
+++ b/app/models/vocabulary/life_cycle_status.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Vocabulary::LifeCycleStatus < Vocabulary
+  include Publishable
 end

--- a/app/models/vocabulary/trl.rb
+++ b/app/models/vocabulary/trl.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Vocabulary::Trl < Vocabulary
+  include Publishable
 end

--- a/app/serializers/recommender/category_serializer.rb
+++ b/app/serializers/recommender/category_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::CategorySerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/recommender/platform_serializer.rb
+++ b/app/serializers/recommender/platform_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::PlatformSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/recommender/provider_serializer.rb
+++ b/app/serializers/recommender/provider_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::ProviderSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/recommender/scientific_domain_serializer.rb
+++ b/app/serializers/recommender/scientific_domain_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::ScientificDomainSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/recommender/target_user_serializer.rb
+++ b/app/serializers/recommender/target_user_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::TargetUserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description
+end

--- a/app/serializers/recommender/vocabulary/access_mode_serializer.rb
+++ b/app/serializers/recommender/vocabulary/access_mode_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::Vocabulary::AccessModeSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description
+end

--- a/app/serializers/recommender/vocabulary/access_type_serializer.rb
+++ b/app/serializers/recommender/vocabulary/access_type_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::Vocabulary::AccessTypeSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description
+end

--- a/app/serializers/recommender/vocabulary/life_cycle_status_serializer.rb
+++ b/app/serializers/recommender/vocabulary/life_cycle_status_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::Vocabulary::LifeCycleStatusSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description
+end

--- a/app/serializers/recommender/vocabulary/trl_serializer.rb
+++ b/app/serializers/recommender/vocabulary/trl_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::Vocabulary::TrlSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description
+end

--- a/app/serializers/recommender/vocabulary_serializer.rb
+++ b/app/serializers/recommender/vocabulary_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::VocabularySerializer < ActiveModel::Serializer
+  attributes :id, :name, :description
+end

--- a/app/services/jms/publish.rb
+++ b/app/services/jms/publish.rb
@@ -32,14 +32,25 @@ class Jms::Publish
   end
 
   def publisher_disabled?
-    ENV["MP_STOMP_PUBLISHER_ENABLED"] != "true"
+    !Mp::Application.config.mp_stomp_publisher_enabled
+  end
+
+  def destination(stomp_config)
+    case @destination
+    when :mp_db_events
+      stomp_config["mp-db-events-topic"]
+    when :user_actions
+      stomp_config["user-actions-topic"]
+    else
+      stomp_config["topic"]
+    end
   end
 
   def publisher
     stomp_config = Mp::Application.config_for(:stomp_publisher)
 
     Jms::Publisher.new(
-      @destination == :databus ? stomp_config["databus-topic"] : stomp_config["topic"],
+      destination(stomp_config),
       stomp_config["login"],
       stomp_config["password"],
       stomp_config["host"],

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,5 +78,12 @@ module Mp
     config.user_actions_target = ENV["USER_ACTIONS_TARGET"].present? ? ENV["USER_ACTIONS_TARGET"] : "all"
 
     config.profile_4_enabled = ENV["PROFILE_4_ENABLED"].present? ? ENV["PROFILE_4_ENABLED"] : false
+
+    config.mp_stomp_publisher_enabled =
+      if ENV["MP_STOMP_PUBLISHER_ENABLED"].present?
+        ENV["MP_STOMP_PUBLISHER_ENABLED"]
+      else
+        Rails.env.test?
+      end
   end
 end

--- a/config/stomp_publisher.yml
+++ b/config/stomp_publisher.yml
@@ -5,10 +5,14 @@ default: &default
   host: <%= ENV["MP_STOMP_HOST"] || Rails.application.credentials.stomp.dig(:host) || "''" %>
   ssl-enabled: <%= ENV["MP_STOMP_SSL"] || false %>
   topic: <%= ENV["MP_STOMP_PUBLISHER_TOPIC"] || Rails.application.credentials.stomp.dig(:publisher, :topic) || "''" %>
-  databus-topic: <%= ENV["MP_STOMP_PUBLISHER_DATABUS_TOPIC"] || "databus" %>
+  mp-db-events-topic: <%= ENV["MP_STOMP_PUBLISHER_MP_DB_EVENTS_TOPIC"] || "mp_db_events" %>
+  user-actions-topic: <%= ENV["MP_STOMP_PUBLISHER_USER_ACTIONS_TOPIC"] || "user_actions" %>
 
 test:
   <<: *default
+  login: <%= ENV["TEST_STOMP_LOGIN"] || "admin" %>
+  password: <%= ENV["TEST_STOMP_PASS"] ||  "admin" %>
+  host: <%= ENV["TEST_STOMP_HOST"] || "localhost" %>
 
 development:
   <<: *default

--- a/config/stomp_subscriber.yml
+++ b/config/stomp_subscriber.yml
@@ -4,10 +4,15 @@ default: &default
   password: <%= ENV["MP_STOMP_PASS"] || Rails.application.credentials.stomp.dig(:password) || "''" %>
   host: <%= ENV["MP_STOMP_HOST"] || Rails.application.credentials.stomp.dig(:host) || "''" %>
   destination: <%= ENV["MP_STOMP_DESTINATION"] || Rails.application.credentials.stomp.dig(:subscriber, :destination) || "''" %>
+  mp-db-events-destination: <%= ENV["MP_STOMP_PUBLISHER_MP_DB_EVENTS_TOPIC"] || "mp_db_events" %>
+  user-actions-destination: <%= ENV["MP_STOMP_PUBLISHER_USER_ACTIONS_TOPIC"] || "user_actions" %>
   ssl-enabled: <%= ENV["MP_STOMP_SSL"] || false %>
 
 test:
   <<: *default
+  login: <%= ENV["TEST_STOMP_LOGIN"] || "admin" %>
+  password: <%= ENV["TEST_STOMP_PASS"] ||  "admin" %>
+  host: <%= ENV["TEST_STOMP_HOST"] || "localhost" %>
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,12 @@ services:
       - "127.0.0.1:6379:6379"
     networks:
       - mp-local
+  active_mq:
+    image: rmohr/activemq
+    ports:
+      - "127.0.0.1:61613:61613"
+    networks:
+      - mp-local
 
 volumes:
   db-data:

--- a/lib/recommender/serialize_db.rb
+++ b/lib/recommender/serialize_db.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Recommender
+module RecommenderLib
   class SerializeDb
     def initialize; end
 
@@ -8,16 +8,18 @@ module Recommender
       {
         services: Service.all.map { |s| Recommender::ServiceSerializer.new(s).as_json },
         users: User.all.map { |s| Recommender::UserSerializer.new(s).as_json },
-        categories: Category.all.as_json(only: %i[id name]),
-        providers: Provider.all.as_json(only: %i[id name]),
-        scientific_domains: ScientificDomain.all.as_json(only: %i[id name]),
-        platforms: Platform.all.as_json(only: %i[id name]),
-        target_users: TargetUser.all.as_json(only: %i[id name description]),
-        access_modes: Vocabulary.where(type: "Vocabulary::AccessMode").as_json(only: %i[id name description]),
-        access_types: Vocabulary.where(type: "Vocabulary::AccessType").as_json(only: %i[id name description]),
-        trls: Vocabulary.where(type: "Vocabulary::Trl").as_json(only: %i[id name description]),
+        categories: Category.all.map { |s| Recommender::CategorySerializer.new(s).as_json },
+        providers: Provider.all.map { |s| Recommender::ProviderSerializer.new(s).as_json },
+        scientific_domains: ScientificDomain.all.map { |s| Recommender::ScientificDomainSerializer.new(s).as_json },
+        platforms: Platform.all.map { |s| Recommender::PlatformSerializer.new(s).as_json },
+        target_users: TargetUser.all.map { |s| Recommender::TargetUserSerializer.new(s).as_json },
+        access_modes:
+          Vocabulary::AccessMode.all.map { |s| Recommender::Vocabulary::AccessModeSerializer.new(s).as_json },
+        access_types:
+          Vocabulary::AccessType.all.map { |s| Recommender::Vocabulary::AccessTypeSerializer.new(s).as_json },
+        trls: Vocabulary::Trl.all.map { |s| Recommender::Vocabulary::TrlSerializer.new(s).as_json },
         life_cycle_statuses:
-          Vocabulary.where(type: "Vocabulary::LifeCycleStatus").as_json(only: %i[id name description])
+          Vocabulary::LifeCycleStatus.all.map { |s| Recommender::Vocabulary::LifeCycleStatusSerializer.new(s).as_json }
       }.as_json
     end
   end

--- a/lib/tasks/recommender.rake
+++ b/lib/tasks/recommender.rake
@@ -7,7 +7,7 @@ namespace :recommender do
   desc "serialize database for recommender system"
   task serialize_db: :environment do
     puts "Generating database dump..."
-    serialized_db = Recommender::SerializeDb.new.call.to_json
+    serialized_db = RecommenderLib::SerializeDb.new.call.to_json
     puts "Database dump generated successfully!"
 
     begin
@@ -32,7 +32,7 @@ namespace :recommender do
 
   task update: :environment do
     puts "Generating database dump..."
-    serialized_db = Recommender::SerializeDb.new.call.to_json
+    serialized_db = RecommenderLib::SerializeDb.new.call.to_json
     puts "Database dump generated successfully!"
 
     begin
@@ -57,7 +57,7 @@ namespace :recommender do
 
   task serialize_db_to_file: :environment do
     puts "Generating database dump..."
-    serialized_db = Recommender::SerializeDb.new.call.to_json
+    serialized_db = RecommenderLib::SerializeDb.new.call.to_json
     puts "Database dump generated successfully!"
 
     path = Rails.root.join("data.json")

--- a/spec/controllers/user_action_controller_spec.rb
+++ b/spec/controllers/user_action_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UserActionController, type: :controller do
   it "sends a probe and jms publish jobs if user_actions_target is set to all" do
     allow(Mp::Application.config).to receive(:user_actions_target).and_return("all")
 
-    expect(Jms::PublishJob).to receive(:perform_later).with(any_args, :databus)
+    expect(Jms::PublishJob).to receive(:perform_later).with(any_args, :user_actions)
     expect(Probes::ProbesJob).to receive(:perform_later)
 
     post :create, params: user_action_params
@@ -28,10 +28,10 @@ RSpec.describe UserActionController, type: :controller do
     post :create, params: user_action_params
   end
 
-  it "sends a JMS (databus) job only if user_actions_target is set to databus" do
-    allow(Mp::Application.config).to receive(:user_actions_target).and_return("databus")
+  it "sends a JMS job to the user_actions topic only if user_actions_target is set to jms" do
+    allow(Mp::Application.config).to receive(:user_actions_target).and_return("jms")
 
-    expect(Jms::PublishJob).to receive(:perform_later).with(any_args, :databus)
+    expect(Jms::PublishJob).to receive(:perform_later).with(any_args, :user_actions)
     expect(Probes::ProbesJob).not_to receive(:perform_later)
 
     post :create, params: user_action_params

--- a/spec/features/provider_question_spec.rb
+++ b/spec/features/provider_question_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Question about provider" do
         expect(page).to have_content("Your message was successfully sent")
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
 
-      expect(Jms::PublishJob).to have_been_enqueued
+      expect(Jms::PublishJob).to have_been_enqueued.with(hash_including(message_type: "provider_question"))
     end
 
     scenario "I cannot send message about service with empty message", js: true do
@@ -45,7 +45,7 @@ RSpec.feature "Question about provider" do
 
       expect(page).to have_content("Text Question cannot be blank")
 
-      expect(Jms::PublishJob).not_to have_been_enqueued
+      expect(Jms::PublishJob).not_to have_been_enqueued.with(hash_including(:message_type))
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.feature "Question about provider" do
         expect(page).to have_content("Your message was successfully sent")
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
 
-      expect(Jms::PublishJob).to have_been_enqueued
+      expect(Jms::PublishJob).to have_been_enqueued.with(hash_including(message_type: "provider_question"))
     end
 
     scenario "I cannot send message about provider with empty fields", js: true do
@@ -85,7 +85,7 @@ RSpec.feature "Question about provider" do
       expect(page).to have_content("Email can't be blank and Email is not a valid email address")
       expect(page).to have_content("Text Question cannot be blank")
 
-      expect(Jms::PublishJob).not_to have_been_enqueued
+      expect(Jms::PublishJob).not_to have_been_enqueued.with(hash_including(:message_type))
     end
   end
 end

--- a/spec/features/service_question_spec.rb
+++ b/spec/features/service_question_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Question about service" do
         expect(page).to have_content("Your message was successfully sent")
       end.to change { ActionMailer::Base.deliveries.count }.by(3)
 
-      expect(Jms::PublishJob).to have_been_enqueued
+      expect(Jms::PublishJob).to have_been_enqueued.with(hash_including(message_type: "service_question"))
     end
 
     scenario "I cannot send message about service with empty message", js: true do
@@ -54,7 +54,7 @@ RSpec.feature "Question about service" do
 
       expect(page).to have_content("Text Question cannot be blank")
 
-      expect(Jms::PublishJob).not_to have_been_enqueued
+      expect(Jms::PublishJob).not_to have_been_enqueued.with(hash_including(:message_type))
     end
   end
 
@@ -78,7 +78,7 @@ RSpec.feature "Question about service" do
         expect(page).to have_content("Your message was successfully sent")
       end.to change { ActionMailer::Base.deliveries.count }.by(3)
 
-      expect(Jms::PublishJob).to have_been_enqueued
+      expect(Jms::PublishJob).to have_been_enqueued.with(hash_including(message_type: "service_question"))
     end
 
     scenario "I cannot send message about service with empty fields", js: true do
@@ -95,7 +95,7 @@ RSpec.feature "Question about service" do
       expect(page).to have_content("Email can't be blank and Email is not a valid email address")
       expect(page).to have_content("Text Question cannot be blank")
 
-      expect(Jms::PublishJob).not_to have_been_enqueued
+      expect(Jms::PublishJob).not_to have_been_enqueued.with(hash_including(:message_type))
     end
   end
 end

--- a/spec/lib/recommender_lib/serialize_db_spec.rb
+++ b/spec/lib/recommender_lib/serialize_db_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "recommender/serialize_db"
 
-describe Recommender::SerializeDb do
+describe RecommenderLib::SerializeDb do
   it "properly serializes the database" do
     create_list(:service, 2)
     create_list(:user, 2)

--- a/spec/models/access_mode_spec.rb
+++ b/spec/models/access_mode_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "publishable"
 
 RSpec.describe Vocabulary::AccessMode do
   subject { Vocabulary::AccessMode.new(name: "Access Mode", description: "description", eid: "access_mode-am") }

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "publishable"
 
 RSpec.describe Category do
+  include_examples "publishable"
+
   describe "validations" do
     it { should validate_presence_of(:name) }
 

--- a/spec/models/platform_spec.rb
+++ b/spec/models/platform_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "publishable"
 
 RSpec.describe Platform, type: :model do
+  include_examples "publishable"
+
   describe "validations" do
     it { should validate_presence_of(:name) }
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "publishable"
 
 RSpec.describe Provider, type: :model do
+  include_examples "publishable"
+
   describe "validations" do
     it { should validate_presence_of(:name) }
     it { should validate_length_of(:legal_statuses) }

--- a/spec/models/publishable.rb
+++ b/spec/models/publishable.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+shared_examples "publishable" do
+  context "publishable integration tests" do
+    before(:all) do
+      stomp_config = Mp::Application.config_for(:stomp_subscriber)
+      @client = Stomp::Client.new(stomp_config["login"], stomp_config["password"], stomp_config["host"])
+      @received = []
+
+      @client.subscribe("/topic/#{stomp_config["mp-db-events-destination"]}") do |msg|
+        @received.push(JSON.parse(msg.body))
+      end
+    end
+
+    after(:all) { @client.close }
+
+    before(:each) do
+      # mock the Time.now call for consistency
+      allow(Time).to receive(:current).and_return(Time.new(1997, 3, 9))
+    end
+
+    after(:each) { clear_enqueued_jobs }
+
+    it "should enqueue JMS job after create" do
+      perform_enqueued_jobs { create(described_class.name.underscore.to_sym) }
+
+      # Sadly there's no way to synchronously wait for messages
+      # (At least in the "stomp" gem which we're using)
+      # So I'm just waiting 1 second here and then check for received messages
+      #
+      # Since the active MQ should be run on the same host as the test
+      # I'm expecting the message to be able to be received during that time
+      @client.join(1)
+      expect(@received).to include(
+        hash_including(
+          "record",
+          "cud" => "create",
+          "model" => described_class.name,
+          "timestamp" => Time.new(1997, 3, 9).iso8601
+        )
+      )
+    end
+
+    it "should enqueue JMS job after update" do
+      obj = create(described_class.name.underscore.to_sym)
+
+      # best approximation of field that exists on almost all models
+      field_name_to_update = obj.attributes.keys.include?("name") ? :name : :first_name
+
+      obj.send("#{field_name_to_update}=", "new value")
+
+      perform_enqueued_jobs { obj.save }
+
+      # Check comment about this "wait" above
+      @client.join(1)
+      expect(@received).to include(
+        hash_including(
+          "record",
+          "cud" => "update",
+          "model" => described_class.name,
+          "timestamp" => Time.new(1997, 3, 9).iso8601
+        )
+      )
+    end
+
+    it "should enqueue JMS job after destroy", :need_queue do
+      obj = create(described_class.name.underscore.to_sym)
+
+      perform_enqueued_jobs { obj.destroy }
+
+      # Check comment about this "wait" above
+      @client.join(1)
+      expect(@received).to include(
+        hash_including(
+          "record",
+          "cud" => "destroy",
+          "model" => described_class.name,
+          "timestamp" => Time.new(1997, 3, 9).iso8601
+        )
+      )
+    end
+  end
+end

--- a/spec/models/scientific_domain_spec.rb
+++ b/spec/models/scientific_domain_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "publishable"
 
 RSpec.describe ScientificDomain, type: :model do
+  include_examples "publishable"
+
   describe "validations" do
     it { should validate_presence_of(:name) }
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "publishable"
 
 RSpec.describe Service do
+  include_examples "publishable"
+
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:description) }
   it { should validate_presence_of(:tagline) }

--- a/spec/models/target_user_spec.rb
+++ b/spec/models/target_user_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "publishable"
 
 RSpec.describe TargetUser, type: :model do
+  include_examples "publishable"
+
   it { should validate_presence_of(:name) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "publishable"
 
 RSpec.describe User do
+  include_examples "publishable"
+
   it { should validate_presence_of(:first_name) }
   it { should validate_presence_of(:last_name) }
   it { should validate_presence_of(:email) }

--- a/spec/services/project_item/create_spec.rb
+++ b/spec/services/project_item/create_spec.rb
@@ -46,14 +46,15 @@ RSpec.describe ProjectItem::Create do
     it "enqueues publish jobs" do
       described_class.new(project_item_template).call
 
-      expect(Jms::PublishJob).to have_been_enqueued.twice
+      expect(Jms::PublishJob).to have_been_enqueued.with(hash_including(message_type: "project.resource_addition"))
+      expect(Jms::PublishJob).to have_been_enqueued.with(hash_including(message_type: "project.resource_coexistence"))
     end
   end
 
   it "doesn't enqueue publish jobs" do
     described_class.new(project_item_template).call
 
-    expect(Jms::PublishJob).not_to have_been_enqueued
+    expect(Jms::PublishJob).not_to have_been_enqueued.with(hash_including(:message_type))
   end
 
   context "when open_access service has been added to Project" do


### PR DESCRIPTION
Cetrain models (for now, only the ones that are being used in the Recommender training) now publish to JMS Databus queue after create, update and delete. Based on [this](https://docs.google.com/document/d/1v5v9AuntpMXdJ58RYNpquQ5FI_0EoTMKZIu5nOiar5k/edit#heading=h.jbvt6xz5urxa) spec.

So now we have 2 recomennder-related JMS topics (you can customize the names using env variables, see README):
- user_actions
- mp_db_events

NOTE: Not all model changes are now being published to Databus, but this can be easily expanded, just `include Publishable` in your model and write a serializer for the model under the `Recommender` namespace