### PR TITLE
[#2686] Add Hosting Legal entity to the BO

### DIFF
--- a/app/controllers/backoffice/vocabularies_controller.rb
+++ b/app/controllers/backoffice/vocabularies_controller.rb
@@ -41,6 +41,10 @@ class Backoffice::VocabulariesController < Backoffice::ApplicationController
       name: "Area of Activity",
       klass: Vocabulary::AreaOfActivity
     },
+    hosting_legal_entity: {
+      name: "Hosting Legal Entity",
+      klass: Vocabulary::HostingLegalEntity
+    },
     esfri_domain: {
       name: "ESFRI Domain",
       klass: Vocabulary::EsfriDomain

--- a/app/policies/backoffice/vocabulary/hosting_legal_entity_policy.rb
+++ b/app/policies/backoffice/vocabulary/hosting_legal_entity_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Backoffice::Vocabulary::HostingLegalEntityPolicy < Backoffice::VocabularyPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/views/backoffice/vocabularies/_nav.html.haml
+++ b/app/views/backoffice/vocabularies/_nav.html.haml
@@ -19,6 +19,8 @@
     %li
       = link_to _("Areas of Activity"), backoffice_areas_of_activity_path
     %li
+      = link_to _("Hosting Legal Entities"), backoffice_hosting_legal_entities_path
+    %li
       = link_to _("ESFRI Types"), backoffice_esfri_types_path
     %li
       = link_to _("ESFRI Domains"), backoffice_esfri_domains_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
       resources :life_cycle_statuses, controller: "vocabularies", type: "life_cycle_status"
       resources :provider_life_cycle_statuses, controller: "vocabularies", type: "provider_life_cycle_status"
       resources :areas_of_activity, controller: "vocabularies", type: "area_of_activity"
+      resources :hosting_legal_entities, controller: "vocabularies", type: "hosting_legal_entity"
       resources :esfri_types, controller: "vocabularies", type: "esfri_type"
       resources :esfri_domains, controller: "vocabularies", type: "esfri_domain"
       resources :legal_statuses, controller: "vocabularies", type: "legal_status"


### PR DESCRIPTION
Add Hosting Legal entity to the backoffice
No additional changelog entry,
it's missing part of adding Hosting Legal Entity
to vocabularies
Closes #2686