### PR TITLE
[#2685] Configuration for pc_subscriber queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Move Structure Types from `Other` to `Classification` section in the Resource Profile 4.0 (@goreck888)
 - `Multimedia` and `UseCases` urls specified in the Resource Profile 4.0 with backward compatibility (@goreck888)
 - Replace `OpenAIRE Explore` banner with the `EOSC Explore` one for `EOSC` tagged resources (@goreck888)
+- Limit `pc_subscriber` queue to only one thread (@goreck888)
 
 ### Deprecated
 - `OPENAIRE_NOTEBOOKS__HARDCODED_LINK` environmental variable (@goreck888) 

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem "google-apis-analyticsreporting_v4", "~> 0.5"
 
 gem "redis-rails"
 gem "sidekiq"
+gem "sidekiq-limit_fetch", "~>4.2.0"
 
 gem "stomp"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -526,6 +526,9 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sidekiq-limit_fetch (4.2.0)
+      redis (>= 4.6.0)
+      sidekiq (>= 4)
     signet (0.16.1)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.0)
@@ -696,6 +699,7 @@ DEPENDENCIES
   sentry-sidekiq
   shoulda-matchers
   sidekiq
+  sidekiq-limit_fetch (~> 4.2.0)
   simple_form
   simple_token_authentication
   spring

--- a/app/jobs/test/thread_time_test_job.rb
+++ b/app/jobs/test/thread_time_test_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Test::ThreadTimeTestJob < ApplicationJob
+  def perform
+    puts "Perform 30 seconds job in queue #{queue_name}"
+    sleep(30)
+    puts "ThreadTimeTestJob completed."
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -20,3 +20,9 @@ staging:
   - default
   - pc_publisher
   - ess_update
+
+:limits:
+  pc_subscriber: 1
+
+:process_limits:
+  pc_subscriber: 1

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :sidekiq do
+  desc "Test for concurency of threads in the sidekiq queue"
+
+  task thread_test: :environment do
+    5.times do
+      Test::ThreadTimeTestJob.set(queue: :default).perform_later
+      Test::ThreadTimeTestJob.set(queue: :pc_subscriber).perform_later
+    end
+  end
+end


### PR DESCRIPTION
Add limit to 1 worker for `pc_subscriber` sidekiq queue.
According to the documentation https://github.com/deanpcmad/sidekiq-limit_fetch
configuration in this PR should solve the problem.
Fixes #2685