### PR TITLE
[#2643] Remove presence validation in vocabularies `eid`

### DIFF
--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -10,5 +10,4 @@ class Vocabulary < ApplicationRecord
 
   validates :name, presence: true
   validates :type, presence: true
-  validates :eid, presence: true
 end

--- a/db/migrate/20220615201039_change_not_null_from_eid_in_vocabularies.rb
+++ b/db/migrate/20220615201039_change_not_null_from_eid_in_vocabularies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeNotNullFromEidInVocabularies < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null(:vocabularies, :eid, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_27_114805) do
+ActiveRecord::Schema.define(version: 2022_06_15_201039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -736,7 +736,7 @@ ActiveRecord::Schema.define(version: 2022_05_27_114805) do
   end
 
   create_table "vocabularies", force: :cascade do |t|
-    t.string "eid", null: false
+    t.string "eid"
     t.string "name", null: false
     t.text "description"
     t.string "type", null: false

--- a/spec/models/access_mode_spec.rb
+++ b/spec/models/access_mode_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe Vocabulary::AccessMode do
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:type) }
-  it { should validate_presence_of(:eid) }
+  it { should_not validate_presence_of(:eid) }
 end

--- a/spec/models/access_type_spec.rb
+++ b/spec/models/access_type_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe Vocabulary::AccessType do
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:type) }
-  it { should validate_presence_of(:eid) }
+  it { should_not validate_presence_of(:eid) }
 end

--- a/spec/models/funding_body_spec.rb
+++ b/spec/models/funding_body_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe Vocabulary::FundingBody do
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:type) }
-  it { should validate_presence_of(:eid) }
+  it { should_not validate_presence_of(:eid) }
 end

--- a/spec/models/funding_program_spec.rb
+++ b/spec/models/funding_program_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe Vocabulary::FundingProgram do
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:type) }
-  it { should validate_presence_of(:eid) }
+  it { should_not validate_presence_of(:eid) }
 end


### PR DESCRIPTION
Remove not null constraint in the database
and in the vocabulary model
Fixes #2643