### PR TITLE
[HOTFIX] Date parameter format

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@
 en:
   date:
     formats:
-      default: "%e-%m-%Y"
+      default: "%d-%m-%Y"
   time:
     formats:
       default: "%e.%m.%Y %k:%M"


### PR DESCRIPTION
Date parameter format code `%e` isn't interpretted
as a one digit number (1 instead of 01) day
Changed `%e` to `%d`