### PR TITLE
[#1785] Add MP API link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [3.39.0-milestone]
 
 ### Added
+- Marketplace API link under the "My EOSC Marketplace" menu (@goreck888)
 
 ### Changed
 - Date format in parameters from `mm-d-yyyy` to `d-mm-yyyy` (@goreck888)

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -15,6 +15,9 @@
           %li
             %a.simple-item{ href: "/profile" }
               = _("Profile")
+          %li
+            %a.dropdown-item.dropdown-profile{ href: "/api_docs", "data-e2e": "marketplace-api" }
+              = _("Marketplace API")
           - if policy([:backoffice, :backoffice]).show?
             %li
               %a.simple-item{ href: backoffice_path }
@@ -87,6 +90,9 @@
             %li
               %a.dropdown-item.dropdown-profile{ href: "/profile", "data-e2e": "profile" }
                 = _("Profile")
+            %li
+              %a.dropdown-item.dropdown-profile{ href: "/api_docs", "data-e2e": "marketplace-api" }
+                = _("Marketplace API")
             - if show_administrative_sections?
               .border-top
             - if policy([:backoffice, :backoffice]).show?


### PR DESCRIPTION
Add link to the `/api_docs` page under the
right `My EOSC Marketplace` menu
Closes #1785