### PR TITLE
[#2716] Add project to recommender dump

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,7 @@
 class Project < ApplicationRecord
   include Eventable
   include Messageable
+  include Publishable
 
   CUSTOMER_TYPOLOGIES = {
     single_user: "single_user",

--- a/app/serializers/recommender/project_serializer.rb
+++ b/app/serializers/recommender/project_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Recommender::ProjectSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :user_id
+  attribute :services
+
+  def services
+    Service.joins(:project_items).where("project_items.project_id = ?", object.id).pluck(:id)
+  end
+end

--- a/lib/recommender/serialize_db.rb
+++ b/lib/recommender/serialize_db.rb
@@ -8,6 +8,7 @@ module RecommenderLib
       {
         services: Service.all.map { |s| Recommender::ServiceSerializer.new(s).as_json },
         users: User.all.map { |s| Recommender::UserSerializer.new(s).as_json },
+        projects: Project.all.map { |s| Recommender::ProjectSerializer.new(s).as_json },
         categories: Category.all.map { |s| Recommender::CategorySerializer.new(s).as_json },
         providers: Provider.all.map { |s| Recommender::ProviderSerializer.new(s).as_json },
         scientific_domains: ScientificDomain.all.map { |s| Recommender::ScientificDomainSerializer.new(s).as_json },

--- a/spec/lib/recommender_lib/serialize_db_spec.rb
+++ b/spec/lib/recommender_lib/serialize_db_spec.rb
@@ -16,6 +16,7 @@ describe RecommenderLib::SerializeDb do
     create_list(:access_mode, 2)
     create_list(:trl, 2)
     create_list(:life_cycle_status, 2)
+    create_list(:project, 2)
 
     serialized = described_class.new.call
 
@@ -25,6 +26,8 @@ describe RecommenderLib::SerializeDb do
     expect(serialized["services"].map { |x| x["description"] }).to match_array(expected_services.pluck(:description))
 
     expect(serialized["users"].map { |x| x["id"] }).to match_array(User.all.pluck(:id))
+
+    expect(serialized["projects"].map { |x| x["id"] }).to match_array(Project.all.pluck(:id))
 
     expect(serialized["categories"].map { |x| x["id"] }).to match_array(Category.all.pluck(:id))
     expect(serialized["categories"].map { |x| x["name"] }).to match_array(Category.all.pluck(:name))

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -2,6 +2,7 @@
 
 require "rails_helper"
 require_relative "messageable"
+require_relative "publishable"
 
 RSpec.describe Project do
   subject { create(:project, name: "New Project") }
@@ -20,6 +21,7 @@ RSpec.describe Project do
   it { should_not allow_value("blah").for(:email) }
 
   include_examples "messageable"
+  include_examples "publishable"
 
   describe "#department" do
     before { subject.department = "a" * 256 }

--- a/spec/models/publishable.rb
+++ b/spec/models/publishable.rb
@@ -30,7 +30,7 @@ shared_examples "publishable" do
       #
       # Since the active MQ should be run on the same host as the test
       # I'm expecting the message to be able to be received during that time
-      @client.join(1)
+      @client.join(2)
       expect(@received).to include(
         hash_including(
           "record",

--- a/spec/serializers/recommender/project_serializer_spec.rb
+++ b/spec/serializers/recommender/project_serializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Recommender::ProjectSerializer do
+  it "properly serializes a project" do
+    service1 = create(:service)
+    service2 = create(:service)
+
+    create(:service) # additional service for sanity check
+
+    project =
+      create(
+        :project,
+        project_items: [
+          create(:project_item, offer: create(:offer, service: service1)),
+          create(:project_item, offer: create(:offer, service: service1)),
+          create(:project_item, offer: create(:offer, service: service2))
+        ]
+      )
+
+    serialized = described_class.new(project).as_json
+
+    expect(serialized[:id]).to eq(project.id)
+    expect(serialized[:user_id]).to eq(project.user_id)
+    expect(serialized[:services]).to match_array([service1.id, service1.id, service2.id])
+  end
+
+  it "properly serializes a project without project items" do
+    create(:service) # additional service for sanity check
+
+    project = create(:project)
+
+    serialized = described_class.new(project).as_json
+
+    expect(serialized[:id]).to eq(project.id)
+    expect(serialized[:user_id]).to eq(project.user_id)
+    expect(serialized[:services]).to match_array([])
+  end
+end


### PR DESCRIPTION
As the title says. Added project_id, user_id and ids of services used in a project to the serializer.

NOTE: If a service is included more than one time in a project, (for example it has two offers with the same service), it is serialized as many times as it appears in the project - this is to provide additional data to the recommender team.