### PR TITLE
[#2727] Add catalogue specific links to PC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,20 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ## [3.41.0-milestone]
 
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
 ### Fixed
 - Styles in menus and forms (@jarekzet)
+- Link to the provider/resource dashboard depending on catalogue id (@goreck888)
+
+### Security
+
 
 ## [3.40.0] 2022-07-15
 

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -47,6 +47,10 @@ module ServiceHelper
     )
   end
 
+  def catalogue_pid(object)
+    object.catalogue&.pid || "eosc"
+  end
+
   def resource_organisation_pid(service)
     service.resource_organisation.pid
   end

--- a/app/views/components/presentable/header_component/_provider_drop_down_menu.html.haml
+++ b/app/views/components/presentable/header_component/_provider_drop_down_menu.html.haml
@@ -7,11 +7,12 @@
   %ul
     %li
       %a.dropdown-item.dropdown-details{ href:
-            Mp::Application.config.providers_dashboard_url + "/dashboard/eosc/#{provider.pid}/stats",
-            target: :_blank, "data-probe": "" }
+        Mp::Application.config.providers_dashboard_url + "/dashboard/#{catalogue_pid(provider)}/#{provider.pid}/stats",
+        target: :_blank, "data-probe": "" }
         = _("Provider dashboard")
-    %li
-      %a.dropdown-item.dropdown-details{ href:
-            Mp::Application.config.providers_dashboard_url + "/provider/update/#{provider.pid}",
-            target: :_blank, "data-probe": "" }
-        = _("Edit provider details")
+    - if catalogue_pid(provider) == "eosc"
+      %li
+        %a.dropdown-item.dropdown-details{ href:
+          Mp::Application.config.providers_dashboard_url + "/provider/update/#{provider.pid}",
+          target: :_blank, "data-probe": "" }
+          = _("Edit provider details")

--- a/app/views/components/presentable/header_component/_service_drop_down_menu.html.haml
+++ b/app/views/components/presentable/header_component/_service_drop_down_menu.html.haml
@@ -7,16 +7,18 @@
   %ul
     %li
       %a.dropdown-item.dropdown-details{ href:
-                Mp::Application.config.providers_dashboard_url +
-                "/dashboard/eosc/#{resource_organisation_pid(service)}/resource-dashboard/#{service.pid}/stats",
-                target: :_blank, "data-probe": "" }
+        Mp::Application.config.providers_dashboard_url +
+        "/dashboard/#{catalogue_pid(service)}/" +
+        "#{resource_organisation_pid(service)}/resource-dashboard/#{service.pid}/stats",
+        target: :_blank, "data-probe": "" }
         = _("Resource dashboard")
-    %li
-      %a.dropdown-item.dropdown-details{ href:
-                Mp::Application.config.providers_dashboard_url +
-                "/provider/#{resource_organisation_pid(service)}/resource/update/#{service.pid}",
-                target: :_blank, "data-probe": "" }
-        = _("Edit resource details")
+    - if catalogue_pid(service) == "eosc"
+      %li
+        %a.dropdown-item.dropdown-details{ href:
+                  Mp::Application.config.providers_dashboard_url +
+                  "/provider/#{resource_organisation_pid(service)}/resource/update/#{service.pid}",
+                  target: :_blank, "data-probe": "" }
+          = _("Edit resource details")
     %li
       %a.dropdown-item.dropdown-offers{ href: service_ordering_configuration_path(service, anchor: "offers",
                                                 from: params[:from]) }


### PR DESCRIPTION
Generate links to the Provider/Service dashboard
in PC depending on the catalogue
Fixes #2727