### PR TITLE
[#2754] Add similar services recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.42.0-milestone]
+
+### Added
+- Similar services recommendations in the service details page (@goreck888)
+
 ## [3.41.0] 2020-08-29
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "nori"
 
 gem "uglifier", ">= 1.3.0"
 gem "webpacker", "~> 5.0"
-gem "view_component", require: "view_component/engine"
+gem "view_component"
 gem "haml-rails"
 gem "turbolinks", "~> 5", require: false
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -42,13 +42,13 @@ class ServicesController < ApplicationController
   end
 
   def show
-    @service = Service.includes(:offers, :target_relationships).friendly.find(params[:id])
+    @service = Service.includes(:offers).friendly.find(params[:id])
 
     authorize(ServiceContext.new(@service, params.key?(:from) && params[:from] == "backoffice_service"))
     @offers = policy_scope(@service.offers.published).order(:created_at).select { |o| o.bundle? == false }
     @bundles = policy_scope(@service.offers.published).order(:created_at).select(&:bundle?)
-    @related_services = @service.target_relationships
-    @related_services_title = "Suggested compatible resources"
+    @related_services = fetch_similar(@service.id)
+    @related_services_title = "Similar services"
 
     @service_opinions = ServiceOpinion.joins(project_item: :offer).where(offers: { service_id: @service })
     @question = Service::Question.new(service: @service)

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,7 @@ module Mp
         " https://beta.providers.eosc-portal.eu"
       end
 
+    config.similar_services_host = ENV["SIMILAR_SERVICES_HOST"] || "http://docker-fid.grid.cyf-kr.edu.pl:4559"
     config.recommender_host = ENV["RECOMMENDER_HOST"]
     config.recommendation_engine = ENV["RECOMMENDATION_ENGINE"] || "RL"
     config.auth_mock = ENV["AUTH_MOCK"]

--- a/spec/features/service_spec.rb
+++ b/spec/features/service_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Service browsing" do
 
       visit service_path(service)
 
-      expect(page.body).to have_content "Suggested compatible resources"
+      expect(page.body).to have_content "Similar services"
       expect(page.body).to have_content related.name
     end
 


### PR DESCRIPTION
Add recommendations to the service `show` page
You can set similar_services_host
using SIMILAR_SERVICES_HOST env variable
Closes #2754