### PR TITLE
[#2769] Adjust user actions

### DIFF
--- a/app/javascript/app/user_action.js
+++ b/app/javascript/app/user_action.js
@@ -2,6 +2,8 @@ import Rails from "@rails/ujs";
 import Cookies from "js-cookie";
 import { v1 as uuidv1 } from "uuid";
 
+const ROOT_KNOWN_LABELS = ["recommendation-panel"];
+
 const WINDOW_EVENTS_HANDLERS = {
   beforeunload: async () => {
     if (history.length !== 1) {
@@ -262,19 +264,22 @@ function get_source_by(element, pageIdOverride) {
 }
 
 function get_source_root_by(element) {
+  const resource_type_object = { resource_type: "service" };
   if (!element) {
-    return { type: "other" };
+    return { ...resource_type_object, type: "other" };
   }
 
-  const is_recommendation_panel = element.getAttribute("data-probe") === "recommendation-panel";
-  if (is_recommendation_panel) {
-    return {
-      type: "recommendation_panel",
-      service_id: parseInt(element.getAttribute("data-service-id")),
-    };
-  }
+  // We can add other labels if we need to determine more root types
+  const dataProbeLabel = element.getAttribute("data-probe");
+  const dataProbeType = ROOT_KNOWN_LABELS.includes(dataProbeLabel) ? dataProbeLabel : "other";
 
-  return { type: "other" };
+  const serviceId = parseInt(element.getAttribute("data-service-id"));
+
+  return {
+    type: dataProbeType,
+    ...(!Number.isNaN(serviceId) && { resource_id: serviceId }),
+    ...resource_type_object,
+  };
 }
 
 function get_target_url(element) {

--- a/app/views/comparisons/_service.html.haml
+++ b/app/views/comparisons/_service.html.haml
@@ -8,6 +8,6 @@
       %span.middle
         = service.name.truncate(25, separator: " ")
     .comparison-link.float-right
-      %a{ value: "#{service.slug}", "data-probe": "", "data-e2e": "delete-service-btn",
+      %a{ value: "#{service.slug}", "data-probe": "", "data-service-id": service.id, "data-e2e": "delete-service-btn",
       "data-action": "click->comparison#update" }
         %i.far.fa-trash-alt

--- a/app/views/comparisons/show.html.haml
+++ b/app/views/comparisons/show.html.haml
@@ -22,12 +22,12 @@
                 = image_tag service.logo.variant(resize: "100x100")
             = link_to comparisons_services_path(slug: service.slug, fromc: params[:fromc], params: @query_params),
             method: :delete,
-              "data-e2e": "delete-service-btn", "data-probe": "" do
+              "data-e2e": "delete-service-btn", "data-probe": "", "data-service-id": service.id do
               %i.far.fa-trash-alt
             .service-title
               = link_to service.name.truncate(30, separator: " "),
               service_path(service, fromc: params[:fromc], comp_link: true),
-              "data-probe": ""
+              "data-probe": "", "data-service-id": service.id
             .service-description
               = service.description.truncate(80, separator: " ")
         - i.times do

--- a/app/views/components/presentable/header_component/_order_buttons.html.haml
+++ b/app/views/components/presentable/header_component/_order_buttons.html.haml
@@ -4,6 +4,7 @@
                   class: "btn btn-primary d-block mb-3",
                   "data-e2e": "access-service-btn",
                   "data-probe": "",
+                  "data-service-id": service.id,
                   "data-target": local_assigns[:preview] ? "preview.link" : ""
   - if user_signed_in? && show_manage_button?(service)
     = render "components/presentable/header_component/service_drop_down_menu", service: service

--- a/app/views/components/presentable/header_component/_service_drop_down_menu.html.haml
+++ b/app/views/components/presentable/header_component/_service_drop_down_menu.html.haml
@@ -10,14 +10,14 @@
         Mp::Application.config.providers_dashboard_url +
         "/dashboard/#{catalogue_pid(service)}/" +
         "#{resource_organisation_pid(service)}/resource-dashboard/#{service.pid}/stats",
-        target: :_blank, "data-probe": "" }
+        target: :_blank, "data-probe": "", "data-service-id": service.id }
         = _("Resource dashboard")
     - if catalogue_pid(service) == "eosc"
       %li
         %a.dropdown-item.dropdown-details{ href:
                   Mp::Application.config.providers_dashboard_url +
                   "/provider/#{resource_organisation_pid(service)}/resource/update/#{service.pid}",
-                  target: :_blank, "data-probe": "" }
+                  target: :_blank, "data-probe": "", "data-service-id": service.id }
           = _("Edit resource details")
     %li
       %a.dropdown-item.dropdown-offers{ href: service_ordering_configuration_path(service, anchor: "offers",

--- a/app/views/favourites/_service.html.haml
+++ b/app/views/favourites/_service.html.haml
@@ -9,6 +9,7 @@
                   class: "form-check-input",
                   disabled: !checked?(service.slug) && comparison_enabled,
                   "data-probe": "",
+                  "data-service-id": service.id,
                   "data-target": "comparison.checkbox",
                   "data-action": "click->comparison#update"
             %span

--- a/app/views/layouts/order.html.haml
+++ b/app/views/layouts/order.html.haml
@@ -12,7 +12,7 @@
           -# TODO: refactor dynamic translation
           = link_to @offer&.orderable? ? _("Cancel order and quit") : _("Cancel and quit"),
             service_cancel_path(@service),
-            method: :delete, class: "text-uppercase align-middle", "data-probe": ""
+            method: :delete, class: "text-uppercase align-middle", "data-probe": "", "data-service-id": @service.id
           .ml-3.d-inline
             %button.btn.btn-primary{ form: "order-form", type: "submit", "data-probe": "summary" }= next_title
       = render "layouts/flash"
@@ -27,7 +27,8 @@
           - if prev_visible_step_key
             = link_to prev_title, url_for([@service, prev_visible_step_key]), class: "text-uppercase", "data-probe": ""
         .ml-3.d-inline
-          %button.btn.btn-primary{ form: "order-form", type: "submit", "data-probe": "summary" }= next_title
+          %button.btn.btn-primary{ form: "order-form", type: "submit",
+            "data-probe": "summary", "data-service-id": @service.id }= next_title
 
   %eosc-common-main-footer
   = render "layouts/modal"

--- a/app/views/services/_bundle_box.html.haml
+++ b/app/views/services/_bundle_box.html.haml
@@ -14,6 +14,6 @@
     .card-button.text-center
       %label
         = link_to service_offers_path(offer.service, customizable_project_item: { offer_id: offer.iid }),
-        "data-probe": "", method: :put do
+        "data-probe": "", "data-service-id": offer.service.id, method: :put do
           %span.btn.btn-primary.font-webtn-linkight-bold
             = _("Select a bundle")

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -9,7 +9,7 @@
     .card-button.text-center
       %label
         = link_to service_offers_path(offer.service, customizable_project_item: { offer_id: offer.iid }),
-        "data-probe": "", "data-e2e": "select-offer-btn", "data-target": local_assigns[:preview] ? "preview.link" : "",
-        method: :put do
+        "data-probe": "", "data-service-id": offer.service.id, "data-e2e": "select-offer-btn",
+        "data-target": local_assigns[:preview] ? "preview.link" : "", method: :put do
           %span.btn.btn-primary.font-weight-bold
             = _("Select an offer")

--- a/app/views/services/_offers_box.html.haml
+++ b/app/views/services/_offers_box.html.haml
@@ -3,4 +3,4 @@
     %li
       %span= link_to highlighted_for(:offer_name, offer, h),
         service_path(service, anchor: "offer-#{ offer.id }"),
-        "data-probe": ""
+        "data-probe": "", "data-service-id": service.id

--- a/app/views/services/_service.html.haml
+++ b/app/views/services/_service.html.haml
@@ -4,17 +4,19 @@
   - if service.horizontal
     %span.badge.badge-success Horizontal service
   = link_to highlighted_for(:name, service, highlights[service.id]),
-    service_path(service, category.present? ? { fromc: category.slug } : nil), "data-e2e": "service-name"
+    service_path(service, category.present? ? { fromc: category.slug } : nil),
+      "data-e2e": "service-name", "data-probe": "", "data-service-id": service.id
   - content_for :comparison_checkbox do
     .mt-3.compare
       %label{ options(service.slug, comparison_enabled) }
         = check_box_tag "comparison", service.slug, checked?(service.slug), id: "comparison-#{service.id}",
-                class: "form-check-input",
-                disabled: !checked?(service.slug) && comparison_enabled,
-                "data-probe": "",
-                "data-e2e": "comparison-checkbox",
-                "data-target": "comparison.checkbox",
-                "data-action": "click->comparison#update"
+              class: "form-check-input",
+              disabled: !checked?(service.slug) && comparison_enabled,
+              "data-probe": "",
+              "data-service-id": service.id,
+              "data-e2e": "comparison-checkbox",
+              "data-target": "comparison.checkbox",
+              "data-action": "click->comparison#update"
         %span
           = _("Add to comparison")
   - content_for :favourite_checkbox do

--- a/app/views/services/_tabs.haml
+++ b/app/views/services/_tabs.haml
@@ -6,32 +6,34 @@
       - if local_assigns[:preview]
         %li.nav-item
           %a.nav-link.active.text-uppercase{ "data-probe": "",
+                                             "data-service-id": service.id,
                                              "data-target": "preview.tab",
                                              "data-action": "click->preview#toggle",
                                              "data-value": "about" }
             = _("About")
         %li.nav-item
           %a.nav-link.text-uppercase{ "data-probe": "",
+                                      "data-service-id": service.id,
                                       "data-target": "preview.tab preview.details",
                                       "data-action": "click->preview#toggle",
                                       "data-value": "details" }
             = _("Details")
         %li.nav-item
-          %a.nav-link.disabled.text-uppercase{ "data-probe" => "" }
+          %a.nav-link.disabled.text-uppercase{ "data-probe" => "", "data-service-id" => service.id }
             = _("Reviews (%{ssoc})") % { ssoc: service.service_opinion_count }
       - else
         %li.nav-item
           = link_to _("About"),
             from.blank? ? service_path(service) : about_link(service, from),
             class: "nav-link text-uppercase #{"active" if about_active }", role: "tab",
-            "data-probe": "", "data-e2e": "service-about-btn"
+            "data-probe": "", "data-service-id": service.id, "data-e2e": "service-about-btn"
         %li.nav-item{ "data-shepherd-tour-target": "service-details-tab" }
           = link_to _("Details"), service_details_path(service, from.present? ? { from: from } : nil),
             class: "nav-link text-uppercase #{"active" if controller.controller_name == "details"}", role: "tab",
-            "data-probe": "", "data-e2e": "service-details-btn"
+            "data-probe": "", "data-service-id": service.id, "data-e2e": "service-details-btn"
         %li.nav-item
           = link_to _("Reviews (%{ssoc})") % { ssoc: service.service_opinion_count },
             service_opinions_path(service, from.present? ? { from: from } : nil),
             class: "nav-link text-uppercase #{"active" if controller.controller_name == "opinions"}", role: "tab",
-            "data-probe": "", "data-e2e": "service-reviews-btn"
+            "data-probe": "", "data-service-id": service.id, "data-e2e": "service-reviews-btn"
 


### PR DESCRIPTION
Closes #2769.

Not every user-action probe sends information about the service id. It's not how the user actions were originally designed. The original use case involved constructing a tree out of user acitons where the service id would be in the root user action. We do not have access to service object in each of the views or sometimes it is not clear which service.id should be sent.

Alternative approach would be to redesign user action system, where each user action would be independent. "root" key in "source" would be changed to context, to add information about what situation the user action was clicked