### PR TITLE
[HOTFIX] `catalogue_data` task

### DIFF
--- a/docs/upgrade/3.43.0.md
+++ b/docs/upgrade/3.43.0.md
@@ -1,4 +1,4 @@
-# Upgrade to 3.43.0
+# Upgrade to 3.43.0, 3.43.1
 
 # Standard procedure
 
@@ -11,7 +11,10 @@ All steps run in production scope.
 
 # Special steps
 
-- Run task `rake migration:eids` to set new external ids for providers and services
 - Import vocabularies `rake import:vocabularies`
+- Import catalogues `rake import:catalogues`
+- Run task `rake migration:catalogue_data` to get missing catalogue info
+  (API address depends on `MP_IMPORT_EOSC_REGISTRY_URL` env variable)
+- Run task `rake migration:eids` to set new external ids for providers and services
 - Import providers `rake import:providers`
 - Import services `rake import:services`

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 namespace :migration do
+  desc "Import catalogue info for services and providers"
+  task catalogue_data: :environment do
+    types = [{ clazz: Service, method: "resource" }, { clazz: Provider, method: "provider" }].freeze
+    ActiveRecord::Base.transaction do
+      types.each do |type|
+        url = (ENV["MP_IMPORT_EOSC_REGISTRY_URL"] || "https://beta.providers.eosc-portal.eu/api") + "/#{type[:method]}"
+        type[:clazz].find_each do |obj|
+          r = Faraday.get("#{url}/#{obj.pid}")
+          b = JSON.parse(r.body)
+          obj.catalogue = Catalogue.find_by(pid: b["catalogueId"])
+          obj.save(validate: false)
+        rescue JSON::ParserError, URI::InvalidURIError => e
+          puts "Object #{obj.name} #{obj.pid} could not be updated, enter Catalogue manually. ERROR: #{e.class} #{e}"
+        end
+      end
+    end
+  end
+
   desc "Add catalogue prefix to the existing services and providers sources"
   task eids: :environment do
     source_types = [


### PR DESCRIPTION
Add migration task `rake migration:catalogue_data` 
for import missing catalogue for existing services and providers 

NOTICE!
Task depends on `MP_IMPORT_EOSC_REGISTRY_URL` env variable