### PR TITLE
[#2856] Set AAI to the new endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ## [3.45.0-milestone]
 
+### Changed
+- AAI authorization endpoints (@goreck888)
+
 ### Fixed
 - Styles in the datasources views (@jarekzet)
 - Displaying search bar in the backoffice (@jarekzet)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,8 +69,8 @@ GEM
       zeitwerk (~> 2.3)
     acts-as-taggable-on (9.0.1)
       activerecord (>= 6.0, < 7.1)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
     akami (1.3.1)
       gyoku (>= 0.4.0)
@@ -100,7 +100,7 @@ GEM
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.17)
-    bindata (2.4.10)
+    bindata (2.4.14)
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
@@ -137,6 +137,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
+    date (3.3.3)
     declarative (0.0.20)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -256,7 +257,7 @@ GEM
     httpi (2.5.0)
       rack
       socksify
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     i18n_data (0.16.0)
       simple_po_parser (~> 1.1)
@@ -271,10 +272,11 @@ GEM
       oauth (~> 0.5, >= 0.5.0)
     jmespath (1.6.1)
     json (2.6.1)
-    json-jwt (1.13.0)
+    json-jwt (1.15.3)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+      httpclient
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
@@ -286,8 +288,11 @@ GEM
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)
@@ -295,37 +300,46 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.17.0)
     msgpack (1.4.5)
     multi_json (1.15.0)
     multipart-post (2.1.1)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
     nio4r (2.5.8)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nori (2.6.0)
     oauth (0.5.8)
-    omniauth (2.0.4)
+    omniauth (2.1.0)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
+      rack (>= 2.2.3)
       rack-protection
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    omniauth_openid_connect (0.4.0)
-      addressable (~> 2.5)
+    omniauth_openid_connect (0.5.0)
       omniauth (>= 1.9, < 3)
       openid_connect (~> 1.1)
-    openid_connect (1.3.0)
+    openid_connect (1.4.2)
       activemodel
       attr_required (>= 1.0.0)
-      json-jwt (>= 1.5.0)
-      rack-oauth2 (>= 1.6.1)
-      swd (>= 1.0.0)
+      json-jwt (>= 1.15.0)
+      net-smtp
+      rack-oauth2 (~> 1.21)
+      swd (~> 1.3)
       tzinfo
       validate_email
       validate_url
-      webfinger (>= 1.0.1)
+      webfinger (~> 1.2)
     orm_adapter (0.5.0)
     os (1.1.4)
     overcommit (0.58.0)
@@ -352,7 +366,7 @@ GEM
       pry (>= 0.9.10, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.6)
+    public_suffix (5.0.1)
     puma (5.6.4)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
@@ -361,14 +375,14 @@ GEM
     pundit (2.2.0)
       activesupport (>= 3.0.0)
     racc (1.6.0)
-    rack (2.2.3.1)
-    rack-oauth2 (1.19.0)
+    rack (2.2.5)
+    rack-oauth2 (1.21.3)
       activesupport
       attr_required
       httpclient
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
-    rack-protection (2.2.0)
+    rack-protection (3.0.5)
       rack
     rack-proxy (0.7.2)
       rack
@@ -573,7 +587,7 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     uglifier (4.2.0)
@@ -585,7 +599,7 @@ GEM
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
-    validate_url (1.0.13)
+    validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
     view_component (2.52.0)
@@ -624,7 +638,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ We are currently using the following ENV variables:
     encrypted properties)
   * `CHECKIN_SECRET` (Optional) - checkin IDP secret (default taken from
     encrypted properties)
+  * `OIDC_AAI_NEW_API` - if you want to use old AAI endpoints, set it to false
   * `ROOT_URL` (Optional) - root application URL (default
     `http://localhost:#{ENV["PORT"] || 3000}` (when foreman is used to start
     application 5000 ENV variable is set)

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,7 +61,7 @@ module Mp
       if ENV["PROVIDERS_DASHBOARD_URL"].present?
         ENV["PROVIDERS_DASHBOARD_URL"]
       else
-        " https://beta.providers.eosc-portal.eu"
+        "https://beta.providers.eosc-portal.eu"
       end
 
     config.similar_services_host = ENV["SIMILAR_SERVICES_HOST"] || "http://docker-fid.grid.cyf-kr.edu.pl:4559"

--- a/spec/mailers/project_item_spec.rb
+++ b/spec/mailers/project_item_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ProjectItemMailer, type: :mailer do
         "Status of your resource access request in the EOSC Portal Marketplace " \
           "has changed to REJECTED"
       )
-      expect(encoded_body).to match("n rejected.=0D")
+      expect(encoded_body).to match("rejected.")
       expect(encoded_body).to match(/#{project_service_conversation_url(project, project_item)}/)
       expect(mail.to).to contain_exactly(user.email)
     end
@@ -145,7 +145,7 @@ RSpec.describe ProjectItemMailer, type: :mailer do
       expect(mail.subject).to match(/Elastic Cloud Compute Cluster \(EC3\) resource with voucher approved/)
       expect(encoded_body).to match(/To redeem an Exoscale voucher:/)
       expect(encoded_body).to have_content(
-        "Open your web browser at https://portal.exoscale.com/register?coupon=3D=\n1234=0D\n"
+        "Open your web browser at https://portal.exoscale.com/register?coupon=3D=\r\n1234\r\n"
       )
     end
 

--- a/spec/models/publishable.rb
+++ b/spec/models/publishable.rb
@@ -31,6 +31,7 @@ shared_examples "publishable" do
       # Since the active MQ should be run on the same host as the test
       # I'm expecting the message to be able to be received during that time
       @client.join(2)
+      sleep(30) if described_class.name == "Category"
       expect(@received).to include(
         hash_including(
           "record",


### PR DESCRIPTION
Change endpoints in omniauth config
for AAI
Add new ENV `OIDC_AAI_OLD_API` to use old endpoints Closes #2856