### PR TITLE
Change text for ARGO report link

### DIFF
--- a/app/views/components/presentable/sidebar_component/_monitoring.html.haml
+++ b/app/views/components/presentable/sidebar_component/_monitoring.html.haml
@@ -17,6 +17,6 @@
     %strong.status-info{ class: "#{monitoring_status_class(object.monitoring_status)}" }
       .big-dot &#8226;
       = t("components.presentable.sidebar_component.fields.monitoring_data.#{object.monitoring_status}")
-  = link_to _("Read full monitoring on ARGO"),
+  = link_to _("Show more details"),
     "https://monitoring.eosc-portal.eu/eosc/report-ar-group-details/Default/SERVICEGROUPS/" + |
       "#{object.pid.to_s.partition(".").last}/details" |


### PR DESCRIPTION
Change text from "Read full monitoring on ARGO" to "Show more details"
in the link to the ARGO website