### PR TITLE
[#2880] research steps, horizontal, providers pid  in the rs dump

### DIFF
--- a/app/serializers/recommender/provider_serializer.rb
+++ b/app/serializers/recommender/provider_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Recommender::ProviderSerializer < ActiveModel::Serializer
-  attributes :id, :name
+  attributes :id, :pid, :name
 end

--- a/app/serializers/recommender/service_serializer.rb
+++ b/app/serializers/recommender/service_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Recommender::ServiceSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :tagline, :countries, :order_type, :rating, :status
+  attributes :id, :pid, :name, :description, :tagline, :countries, :order_type, :rating, :status, :horizontal
   attribute :category_ids, key: :categories
   attribute :provider_ids, key: :providers
   attribute :resource_organisation_id, key: :resource_organisation
@@ -14,9 +14,7 @@ class Recommender::ServiceSerializer < ActiveModel::Serializer
   attribute :trl_ids, key: :trls
   attribute :life_cycle_status_ids, key: :life_cycle_statuses
   attribute :required_service_ids, key: :required_services
-  attribute :horizontal
   attribute :related_services
-  attribute :pid
 
   def countries
     object.geographical_availabilities.map(&:alpha2)

--- a/app/serializers/recommender/vocabulary/research_step_serializer.rb
+++ b/app/serializers/recommender/vocabulary/research_step_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recommender::Vocabulary::ResearchStepSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description
+end

--- a/lib/recommender/serialize_db.rb
+++ b/lib/recommender/serialize_db.rb
@@ -20,7 +20,9 @@ module RecommenderLib
           Vocabulary::AccessType.all.map { |s| Recommender::Vocabulary::AccessTypeSerializer.new(s).as_json },
         trls: Vocabulary::Trl.all.map { |s| Recommender::Vocabulary::TrlSerializer.new(s).as_json },
         life_cycle_statuses:
-          Vocabulary::LifeCycleStatus.all.map { |s| Recommender::Vocabulary::LifeCycleStatusSerializer.new(s).as_json }
+          Vocabulary::LifeCycleStatus.all.map { |s| Recommender::Vocabulary::LifeCycleStatusSerializer.new(s).as_json },
+        research_steps:
+          Vocabulary::ResearchStep.all.map { |s| Recommender::Vocabulary::ResearchStepSerializer.new(s).as_json }
       }.as_json
     end
   end

--- a/spec/serializers/recommender/service_serializer_spec.rb
+++ b/spec/serializers/recommender/service_serializer_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Recommender::ServiceSerializer do
         access_types: create_list(:access_type, 2),
         trl: [create(:trl)],
         life_cycle_status: [create(:life_cycle_status)],
-        pid: "pid"
+        pid: "pid",
+        horizontal: true,
+        research_steps: create_list(:research_step, 2)
       )
 
     serialized = described_class.new(service).as_json
@@ -48,5 +50,7 @@ RSpec.describe Recommender::ServiceSerializer do
     expect(serialized[:access_types]).to match_array(service.access_type_ids)
     expect(serialized[:trls]).to match_array(service.trl_ids)
     expect(serialized[:life_cycle_statuses]).to match_array(service.life_cycle_status_ids)
+    expect(serialized[:horizontal]).to eq(service.horizontal)
+    expect(serialized[:research_steps]).to match_array(service.research_step_ids)
   end
 end


### PR DESCRIPTION
closes #2880 

This PR adds to the RS dump:
1) research_steps and horizontal,
2) providers' pids.