### PR TITLE
[#2926] Change link to the User Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ We are currently using the following ENV variables:
   * `PORTAL_BASE_URL` - portal base URL used to generate footer and other static
     links to EOSC portal
   * `PROVIDERS_DASHBOARD_URL` - Provider's Dashboard URL used to create links to the provider's dashboard
+  * `USER_DASHBOARD_URL` User Dashboard URL for links in the landing page. Default is `https://my.eosc-portal.eu/`
   * `ASSET_HOST` and `ASSET_PROTOCOL` - assets mailer config is mandatory
     (e.g. ASSET_HOST = marketplace.eosc-portal.eu/ and ASSET_PROTOCOL = https )
   * `RATE_AFTER_PERIOD` - number of days after which user can rate resource (default is set to 90 days)

--- a/app/helpers/landing_page_helper.rb
+++ b/app/helpers/landing_page_helper.rb
@@ -13,4 +13,8 @@ module LandingPageHelper
   def external_search_base_url
     Rails.configuration.search_service_base_url
   end
+
+  def user_dashboard_url
+    Rails.configuration.user_dashboard_url
+  end
 end

--- a/app/views/pages/landing_page.html.haml
+++ b/app/views/pages/landing_page.html.haml
@@ -138,7 +138,7 @@
           data to support EU open science
     .row.mt-5
       .col-md-3.col-sm-12
-        %a.eosc-info{ href: "#{external_search_base_url}/" }
+        %a.eosc-info{ href: "#{root_url}" }
           .eosc-info-icon
             = image_pack_tag "landing_page/browse-marketplace.svg", alt: "Browse Marketplace"
           .eosc-info-texts
@@ -147,7 +147,7 @@
               Browse through over 3 million research and innovation tools and services, thousands of datasets
               from a wide range of research domains from renowned European service providers.
       .col-md-3.col-sm-12
-        %a.eosc-info{ href: "https://eosc-user-dashboard.docker-fid.grid.cyf-kr.edu.pl/" }
+        %a.eosc-info{ href: user_dashboard_url }
           .eosc-info-icon
             = image_pack_tag "landing_page/dashboard.svg", alt: "My EOSC Dashboard"
           .eosc-info-texts

--- a/config/application.rb
+++ b/config/application.rb
@@ -85,6 +85,7 @@ module Mp
     config.home_page_external_links_enabled =
       ENV["HOME_PAGE_EXTERNAL_LINKS_ENABLED"].present? ? ENV["HOME_PAGE_EXTERNAL_LINKS_ENABLED"] : true
     config.search_service_base_url = ENV.fetch("SEARCH_SERVICE_BASE_URL", "https://search.marketplace.eosc-portal.eu")
+    config.user_dashboard_url = ENV.fetch("USER_DASHBOARD_URL", "https://my.eosc-portal.eu/")
 
     config.mp_stomp_publisher_enabled =
       if ENV["MP_STOMP_PUBLISHER_ENABLED"].present?

--- a/docs/upgrade/3.47.0.md
+++ b/docs/upgrade/3.47.0.md
@@ -1,0 +1,14 @@
+# Upgrade to 3.46.0
+
+# Standard procedure
+
+All steps run in production scope.
+
+- make database dump and all application files.
+- `bundle install --deployment --without development test`
+- `bundle exec rake assets:clean assets:precompile`
+- `rails db:migrate`
+
+# Special steps
+
+- Set `USER_DASHBOARD_URL` to set instance of user dashboard. Default is `https://my.eosc-portal.eu/`


### PR DESCRIPTION
Change hardcoded link to
customizable by ENV `USER_DASHBOARD_URL`
and default `https://my.eosc-portal.eu/`
Closes #2926