### PR TITLE
feat: Back to search query

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,10 +56,6 @@ module ApplicationHelper
 
   def eosc_commons_profile_links
     links = []
-    links.push({ href: "/projects", caption: _("My projects") })
-    links.push({ href: "/favourites", caption: _("Favourite resources"), "data-e2e": "favourites" })
-    links.push({ href: "/profile", caption: _("Profile"), "data-e2e": "profile" })
-    links.push({ href: "/api_docs", caption: _("Marketplace API"), "data-e2e": "marketplace-api" })
 
     # if show_administrative_sections?
     #   .border-top
@@ -73,9 +69,16 @@ module ApplicationHelper
     links.to_json
   end
 
-  def external_search_url
+  def external_search_url(include_query: false)
     if Rails.configuration.enable_external_search && Rails.configuration.search_service_base_url.present?
-      Rails.configuration.search_service_base_url
+      query = ""
+      if include_query
+        category = request.query_parameters["pv"] || "search/all"
+        q = request.query_parameters["q"] || "*"
+        query = "/#{category}?q=#{q}"
+      end
+
+      Rails.configuration.search_service_base_url + query
     end
   end
 

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -65,7 +65,7 @@
   .container.eosc-back-search-bar
     .eosc-back-link
       .chevron-left
-      %a{ href: external_search_url }
+      %a{ href: external_search_url(include_query: true) }
         Go to Search
 - else
   .container

--- a/app/views/layouts/_sections.html.haml
+++ b/app/views/layouts/_sections.html.haml
@@ -15,6 +15,7 @@
                                             current_user&.first_name.to_s + " " + current_user&.last_name.to_s
                                             : "",
                                             "profile-links": eosc_commons_profile_links,
+                                            "show-eosc-links": "true",
                                             "login-url": user_checkin_omniauth_authorize_url,
                                             "(on-logout)": "document.getElementById('hidden_logout').click()" }
   = link_to "logout",

--- a/test/system/cypress/integration/regression_tests/service-page/favourites/favourites.spec.ts
+++ b/test/system/cypress/integration/regression_tests/service-page/favourites/favourites.spec.ts
@@ -1,6 +1,7 @@
 import { UserFactory} from "../../../../factories/user.factory";
 
-describe("Favourites", () => {
+// favourites has been removed until they are migrated to dashboard
+describe.skip("Favourites", () => {
 const user = UserFactory.create();
 
   beforeEach(() => {

--- a/test/system/cypress/integration/regression_tests/service-page/my_eosc_marketplace/my-profile.spec.ts
+++ b/test/system/cypress/integration/regression_tests/service-page/my_eosc_marketplace/my-profile.spec.ts
@@ -8,9 +8,7 @@ describe("My profile", () => {
   });
 
   it("should add and remove Additional information", () => {
-    cy.openUserDropdown();
-    cy.get("[data-e2e='profile']")
-      .click();
+    cy.visit("/profile")
     cy.location("href")
       .should("contain", "/profile");
     cy.get("[data-e2e='additional-inf-edit']")

--- a/test/system/cypress/integration/regression_tests/service-page/my_eosc_marketplace/my-project.spec.ts
+++ b/test/system/cypress/integration/regression_tests/service-page/my_eosc_marketplace/my-project.spec.ts
@@ -13,8 +13,7 @@ describe("My project", () => {
   const openAccessResource = "DisVis";
 
   it("should add new project, pin a service and add review", () => {
-   cy.get('a[data-e2e="goToProjectsBtn"]')
-     .click();
+    cy.visit("/projects");
    cy.location('pathname')
      .should('equal', '/projects');
    cy.get('a[data-e2e="go-to-create-project-form-btn"]')


### PR DESCRIPTION
* Add queryiest to back to search link in navbar, so category and query is preserved
* Update commons header params to use default eosc-commons links