### PR TITLE
feat: Guidelines link from external landing

### DIFF
--- a/app/helpers/landing_page_helper.rb
+++ b/app/helpers/landing_page_helper.rb
@@ -7,7 +7,8 @@ module LandingPageHelper
     publication: "Publications",
     dataset: "Data",
     "data-source": "Data Sources",
-    training: "Training Materials"
+    training: "Training Materials",
+    guideline: "Interoperability Guidelines"
   }.freeze
 
   def external_search_base_url

--- a/app/helpers/presentable/details_helper.rb
+++ b/app/helpers/presentable/details_helper.rb
@@ -259,7 +259,7 @@ module Presentable::DetailsHelper
   end
 
   def guidelines
-    { name: "guidelines", template: "links", fields: ["guidelines"], type: "guideline" }
+    { name: "Supported Interoperability Guidelines", template: "links", fields: ["guidelines"], type: "guideline" }
   end
 
   def statuses

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -5499,13 +5499,13 @@ abbr[title] {
       }
 
       .solutions-box {
-        display: flex;
-        flex-direction: row;
+        //display: flex;
+        //flex-direction: row;
         align-items: center;
         gap: 16px;
 
         a {
-          font-size: 13px;
+          font-size: 10px;
           color: $palette-white;
           border: 1px solid $palette-white;
           padding: 1px 8px;


### PR DESCRIPTION
Added guidelines link to landing page. Size of the font had to be changed in order not to have line wrapping in link buttons.

<img width="796" alt="image" src="https://user-images.githubusercontent.com/13235269/235161496-02aa0418-9d4e-469b-968b-35b454543d1a.png">


Also - changed name of the guidelines in service's details

<img width="401" alt="image" src="https://user-images.githubusercontent.com/13235269/235161414-d95f364d-144a-4a80-91b4-120366edddb4.png">

