### PR TITLE
fix:[#2979] Remove "Add new bundle" from OC

### DIFF
--- a/app/controllers/services/ordering_configuration/bundles_controller.rb
+++ b/app/controllers/services/ordering_configuration/bundles_controller.rb
@@ -17,7 +17,7 @@ class Services::OrderingConfiguration::BundlesController < Services::OrderingCon
     @bundle = Bundle::Create.call(template)
 
     if @bundle.persisted?
-      redirect_to backoffice_service_path(@service), notice: "New bundle created successfully"
+      redirect_to service_ordering_configuration_path(@service), notice: "New bundle created successfully"
     else
       render :new, status: :bad_request
     end
@@ -28,7 +28,7 @@ class Services::OrderingConfiguration::BundlesController < Services::OrderingCon
   def update
     template = permitted_attributes(Bundle.new)
     if Bundle::Update.call(@bundle, transform_attributes(template))
-      redirect_to backoffice_service_path(@service), notice: "Bundle updated successfully"
+      redirect_to service_ordering_configuration_path(@service), notice: "Bundle updated successfully"
     else
       render :edit, status: :bad_request
     end
@@ -37,7 +37,7 @@ class Services::OrderingConfiguration::BundlesController < Services::OrderingCon
   def destroy
     @bundle = @service.bundles.find_by(iid: params[:id])
     Offer::Destroy.call(@offer)
-    redirect_to backoffice_service_path(@service), notice: "Bundle removed successfully"
+    redirect_to service_ordering_configuration_path(@service), notice: "Bundle removed successfully"
   end
 
   private

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -32,7 +32,7 @@ module SearchLinksHelper
     link_to_unless(
       target.deleted? || target.draft?,
       highlighted_for(:resource_organisation_name, service, highlights),
-      service.organisation_search_link(target.name),
+      service.organisation_search_link(target),
       preview_options
     )
   end
@@ -55,7 +55,7 @@ module SearchLinksHelper
         else
           link_to_unless target.deleted? || target.draft?,
                          target.name,
-                         service.provider_search_link(target.name),
+                         service.provider_search_link(target),
                          preview_options
         end
       end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -293,12 +293,12 @@ class Service < ApplicationRecord
     service_user_relationships.where(user: user).count.positive?
   end
 
-  def organisation_search_link(target_name, default_path = nil)
-    _provider_search_link(target_name, "resource_organisation", default_path)
+  def organisation_search_link(target, default_path = nil)
+    _provider_search_link(target, "resource_organisation", default_path)
   end
 
-  def provider_search_link(target_name, default_path = nil)
-    _provider_search_link(target_name, "providers", default_path)
+  def provider_search_link(target, default_path = nil)
+    _provider_search_link(target, "providers", default_path)
   end
 
   def geographical_availabilities_link(gcap)
@@ -307,13 +307,14 @@ class Service < ApplicationRecord
 
   private
 
-  def _provider_search_link(target_name, filter_query, default_path = nil)
+  def _provider_search_link(target, filter_query, default_path = nil)
+    target_name = target.respond_to?(:name) ? target.name : target
     search_base_url = Mp::Application.config.search_service_base_url
     enable_external_search = Mp::Application.config.enable_external_search
     if enable_external_search
       search_base_url + "/search/service?q=*&fq=#{filter_query}:(%22#{target_name}%22)"
     else
-      default_path || provider_path(self)
+      default_path || provider_path(target)
     end
   end
 

--- a/app/policies/ordering_configuration/bundle_policy.rb
+++ b/app/policies/ordering_configuration/bundle_policy.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class OrderingConfiguration::BundlePolicy < Backoffice::BundlePolicy
+end

--- a/app/views/layouts/common_parts/services/_bundle_box.html.haml
+++ b/app/views/layouts/common_parts/services/_bundle_box.html.haml
@@ -8,6 +8,11 @@
        helpdesk_url: bundle.helpdesk_url || ""
     .card-button.text-center.backoffice-button
       %label
-        = link_to edit_backoffice_service_bundle_path(bundle.service, bundle) do
-          %span.btn.btn-primary.font-webtn-linkight-bold
-            = _("Edit")
+        - if controller_name == "ordering_configurations"
+          = link_to edit_service_ordering_configuration_bundle_path(bundle.service, bundle) do
+            %span.btn.btn-primary.font-webtn-linkight-bold
+              = _("Edit")
+        - else
+          = link_to edit_backoffice_service_bundle_path(bundle.service, bundle) do
+            %span.btn.btn-primary.font-webtn-linkight-bold
+              = _("Edit")

--- a/app/views/layouts/common_parts/services/_offers.html.haml
+++ b/app/views/layouts/common_parts/services/_offers.html.haml
@@ -34,4 +34,5 @@
   -# haml-lint:enable MultilinePipe
 .row
   = render partial: "layouts/common_parts/services/bundle_box", collection: bundles, as: :bundle
-  = render "layouts/common_parts/services/new_bundle", service: service
+  - unless controller_name == "ordering_configurations"
+    = render "layouts/common_parts/services/new_bundle", service: service

--- a/app/views/services/ordering_configuration/bundles/edit.html.haml
+++ b/app/views/services/ordering_configuration/bundles/edit.html.haml
@@ -1,0 +1,12 @@
+- content_for :title, _("Edit Bundle")
+- breadcrumb :backoffice_bundle_edit, @bundle
+.container
+  .mb-4.pb-4.border-header
+    %h1= _("Edit Bundle")
+
+    = render "backoffice/services/bundles/form",
+      service: @service,
+      bundle: @bundle,
+      show_delete_button: false,
+      bundle_form_source_module: [@service, :ordering_configuration, @bundle],
+      back_link: service_ordering_configuration_path(@service)

--- a/app/views/services/ordering_configuration/bundles/new.html.haml
+++ b/app/views/services/ordering_configuration/bundles/new.html.haml
@@ -1,0 +1,12 @@
+- content_for :title, _("Create new bundle")
+- breadcrumb :backoffice_bundle_new, @bundle
+.container
+  .mb-4.pb-4.border-header
+    %h1= _("Create new bundle")
+
+  = render "backoffice/services/bundles/form",
+    service: @service,
+    bundle: @bundle,
+    show_delete_button: false,
+    bundle_form_source_module: [@service, :ordering_configuration, @bundle],
+    back_link: service_ordering_configuration_path(@service)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       resource :ordering_configuration, only: :show do
         scope module: :ordering_configuration do
           resources :offers, only: [:new, :edit, :create, :update, :destroy]
+          resources :bundles, only: [:edit, :update]
         end
       end
     end


### PR DESCRIPTION
Remove link to add new bundle
in the ordering_configuration path
Closes #2979