### PR TITLE
feat:[] Create task to create SOLR dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Bundles functionality (@goreck888)
 - Improvements for the UI of bundles (@jarekzet)
 - Interoperability guidelines import (@michal-szostak)
+- New task to create data dumps for SOLR (@goreck888)
+- Live update for SOLR collections (@goreck888)
 
 ### Changed
 - Datasources as services (@goreck888)

--- a/README.md
+++ b/README.md
@@ -330,6 +330,27 @@ You can customize it by using environment variables:
   * `MP_DATABASE_PASSWORD` - PostgreSQL database password
 
 
+## SOLR dumps
+You can use a rake task `ess:dump[#{collections}]` to get data in 
+`#{collection}.json` prepared for SOLR-Transformation API/script.
+Possible options:
+- all
+- providers
+- services
+- datasources
+- offers
+- bundles
+
+E.g. call `rake ess:dump[all]` to return all collections,
+`rake ess:dump[providers]` will generate file providers.json,
+and `rake ess:dump[services offers]` creates services.json and offers.json
+
+## SOLR Live connection
+
+Set ENV variable `ESS_UPDATE_ENABLED` to `true` 
+to enable live update objects to the SOLR transformation service.
+To get it working set also `ESS_UPDATE_URL`.
+
 ## OpenAPI docs
 Marketplace is using OpenAPI documentation standard([swagger](https://swagger.io/)). To do this we are using `rswag` gem.
 To check API documentation go to `/api-docs`.

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -75,6 +75,8 @@ class Offer < ApplicationRecord
                )
            }
 
+  after_commit :propagate_to_ess
+
   def current_oms
     primary_oms || OMS.find_by(default: true)
   end
@@ -201,5 +203,9 @@ class Offer < ApplicationRecord
 
   def sanitize_oms_params
     oms_params.select! { |_, v| v.present? } if oms_params.present?
+  end
+
+  def propagate_to_ess
+    status == "published" && !destroyed? ? Offer::Ess::Add.call(self) : Offer::Ess::Delete.call(id)
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -274,7 +274,7 @@ class Service < ApplicationRecord
   end
 
   def propagate_to_ess
-    public? && !destroyed? ? Service::Ess::Add.call(self) : Service::Ess::Delete.call(id)
+    public? && !destroyed? ? Service::Ess::Add.call(self) : Service::Ess::Delete.call(id, type)
   end
 
   def offers?

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -8,4 +8,13 @@ class ApplicationService
   def call
     raise "Should be implemented in descendent class"
   end
+
+  def hierarchical_to_s(hierarchical)
+    result = []
+    result.push(hierarchical.ancestors.to_a.append(hierarchical).map(&:name).join(">"))
+    hierarchical.ancestors.to_a.map do |ancestor|
+      result.push(ancestor.ancestors.to_a.append(ancestor).map(&:name).join(">"))
+    end
+    result
+  end
 end

--- a/app/services/bundle/ess/add.rb
+++ b/app/services/bundle/ess/add.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Bundle::Ess::Add < ApplicationService
+  def initialize(bundle, async: true, dry_run: false)
+    super()
+    @bundle = bundle
+    @type = "bundle"
+    @async = async
+    @dry_run = dry_run
+  end
+
+  def call
+    if @dry_run
+      ess_data
+    else
+      @async ? Ess::UpdateJob.perform_later(payload) : Ess::Update.call(payload)
+    end
+  end
+
+  private
+
+  def payload
+    { action: "update", data_type: @type, data: ess_data }.as_json
+  end
+
+  def ess_data
+    {
+      id: @bundle.id,
+      name: @bundle.name,
+      bundle_goals: @bundle.bundle_goals.map(&:name),
+      capabilities_of_goals: @bundle.capabilities_of_goals.map(&:name),
+      main_offer_id: @bundle.main_offer.id,
+      description: @bundle.description,
+      target_users: @bundle.target_users.map(&:name),
+      scientific_domains: @bundle.scientific_domains&.map { |sd| hierarchical_to_s(sd) },
+      research_steps: @bundle.research_steps.map(&:name),
+      offer_ids: @bundle.offers.map(&:id),
+      related_training: @bundle.related_training,
+      contact_email: @bundle.contact_email,
+      helpdesk_url: @bundle.helpdesk_url,
+      service_id: @bundle.service.id,
+      resource_organisation: @bundle.resource_organisation.name,
+      providers:
+        (
+          [@bundle.main_offer.service.providers.map(&:name)] +
+            @bundle.offers.map { |o| o.service.providers.map(&:name) }
+        ).flatten.uniq
+    }
+  end
+end

--- a/app/services/bundle/ess/delete.rb
+++ b/app/services/bundle/ess/delete.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Bundle::Ess::Delete < ApplicationService
+  def initialize(bundle_id)
+    super()
+    @bundle_id = bundle_id
+    @type = "bundle"
+  end
+
+  def call
+    # TODO: add endpoint to job
+    Ess::UpdateJob.perform_later(payload)
+  end
+
+  private
+
+  def payload
+    # TODO: Must be adequate endpoint
+    { action: "delete", data_type: @type, data: { id: @bundle_id } }.as_json
+  end
+end

--- a/app/services/offer/ess/add.rb
+++ b/app/services/offer/ess/add.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Offer::Ess::Add < ApplicationService
+  def initialize(offer, async: true, dry_run: false)
+    super()
+    @offer = offer
+    @type = "offer"
+    @async = async
+    @dry_run = dry_run
+  end
+
+  def call
+    if @dry_run
+      ess_data
+    else
+      @async ? Ess::UpdateJob.perform_later(payload) : Ess::Update.call(payload)
+    end
+  end
+
+  private
+
+  def payload
+    { action: "update", data_type: @type, data: ess_data }.as_json
+  end
+
+  def ess_data
+    {
+      id: @offer.id,
+      name: @offer.name,
+      description: @offer.description,
+      service_id: @offer.service_id,
+      status: @offer.status,
+      order_type: @offer.order_type,
+      internal: @offer.internal,
+      voucherable: @offer.voucherable,
+      parameters: @offer.parameters.map(&:as_json)
+    }
+  end
+end

--- a/app/services/offer/ess/delete.rb
+++ b/app/services/offer/ess/delete.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Offer::Ess::Delete < ApplicationService
+  def initialize(offer_id)
+    super()
+    @offer_id = offer_id
+    @type = "offer"
+  end
+
+  def call
+    # TODO: add endpoint to job
+    Ess::UpdateJob.perform_later(payload)
+  end
+
+  private
+
+  def payload
+    # TODO: Must be adequate endpoint
+    { action: "delete", data_type: @type, data: { id: @offer_id } }.as_json
+  end
+end

--- a/app/services/provider/ess/add.rb
+++ b/app/services/provider/ess/add.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Provider::Ess::Add < ApplicationService
+  def initialize(provider, async: true, dry_run: false)
+    super()
+    @provider = provider # TODO: Change payload to the new format here
+    @type = "provider"
+    @async = async
+    @dry_run = dry_run
+  end
+
+  def call
+    if @dry_run
+      ess_data
+    else
+      @async ? Ess::UpdateJob.perform_later(payload) : Ess::Update.call(payload)
+    end
+  end
+
+  private
+
+  def payload
+    { action: "update", data_type: @type, data: ess_data }.as_json
+  end
+
+  def ess_data # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    {
+      id: @provider.id,
+      pid: @provider.pid,
+      catalogue: @provider.catalogue&.name,
+      slug: @provider.pid,
+      name: @provider.name,
+      abbreviation: @provider.abbreviation,
+      webpage_url: @provider.website,
+      legal_entity: @provider.legal_entity,
+      legal_status: @provider.legal_statuses.first&.name,
+      hosting_legal_entity: @provider.hosting_legal_entities&.first&.name,
+      description: @provider.description,
+      multimedia_urls: @provider.link_multimedia_urls&.map { |m| { name: m.name, url: m.url } },
+      scientific_domains: @provider.scientific_domains&.map { |sd| hierarchical_to_s(sd) },
+      tag_list: @provider.tag_list,
+      structure_types: @provider.structure_types&.map(&:name),
+      street_name_and_number: @provider.street_name_and_number,
+      postal_code: @provider.postal_code,
+      city: @provider.city,
+      region: @provider.region,
+      country: @provider.country.iso_short_name,
+      public_contacts: @provider.public_contacts&.map(&:as_json),
+      provider_life_cycle_status: @provider.provider_life_cycle_statuses&.first&.name,
+      certifications: @provider.certifications,
+      participating_countries: @provider.participating_countries&.map(&:iso_short_name),
+      affiliations: @provider.affiliations,
+      networks: @provider.networks&.map(&:name),
+      esfri_domains: @provider.esfri_domains&.map(&:name),
+      esfri_type: @provider.esfri_types&.first&.name,
+      meril_scientific_domains: @provider.meril_scientific_domains&.map(&:name),
+      areas_of_activity: @provider.areas_of_activity&.map(&:name),
+      societal_grand_challenges: @provider.societal_grand_challenges&.map(&:name),
+      national_roadmaps: @provider.national_roadmaps
+    }
+  end
+end

--- a/app/services/provider/ess/delete.rb
+++ b/app/services/provider/ess/delete.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Provider::Ess::Delete < ApplicationService
+  def initialize(provider_id)
+    super()
+    @provider_id = provider_id
+    @type = "provider"
+  end
+
+  def call
+    # TODO: add endpoint to job
+    Ess::UpdateJob.perform_later(payload)
+  end
+
+  private
+
+  def payload
+    # TODO: Must be adequate endpoint
+    { action: "delete", data_type: @type, data: { id: @provider_id } }.as_json
+  end
+end

--- a/app/services/service/ess/add.rb
+++ b/app/services/service/ess/add.rb
@@ -1,51 +1,106 @@
 # frozen_string_literal: true
 
 class Service::Ess::Add < ApplicationService
-  def initialize(service, async: true)
+  def initialize(service, async: true, dry_run: false)
     super()
     @service = service
+    @type = service.type == "Datasource" ? "data source" : "service"
     @async = async
+    @dry_run = dry_run
   end
 
   def call
-    @async ? Ess::UpdateJob.perform_later(payload) : Ess::Update.call(payload)
+    if @dry_run
+      ess_data
+    else
+      @service.offers.each(&:save) unless @service.offers.published.size.zero?
+      @async ? Ess::UpdateJob.perform_later(payload) : Ess::Update.call(payload)
+    end
   end
 
   private
 
   def payload
-    { add: { doc: ess_data }, commit: {} }.to_json
+    { action: "update", data_type: @type, data: ess_data }.as_json
   end
 
-  def ess_data
+  def ess_data # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    different =
+      if @service.type == "Datasource"
+        {
+          resource_level_url: @service.resource_level_url,
+          persistent_identity_systems:
+            @service.persistent_identity_systems&.map do |p|
+              { entity_type: p.entity_type.name, entity_type_schemes: p.entity_type_schemes&.map(&:name) }
+            end
+        }
+      else
+        { sla_url: @service.resource_level_url, slug: @service.slug }
+      end
     {
       id: @service.id,
-      pid_s: @service.pid,
-      slug_s: @service.slug,
-      # card
-      name_t: @service.name,
-      description_t: @service.description,
-      rating_f: @service.rating,
-      tagline_t: @service.tagline,
-      resource_organisation_s: @service.resource_organisation.name,
-      # filtering
-      categories_ss: @service.categories.map { |category| hierarchical_to_s(category) },
-      scientific_domains_ss: @service.scientific_domains.map { |domain| hierarchical_to_s(domain) },
-      providers_ss: @service.providers.map(&:name),
-      target_users_ss: @service.target_users.map { |target_user| hierarchical_to_s(target_user) },
-      platforms_ss: @service.platforms.map(&:name),
-      tags_ss: @service.tag_list,
-      order_type_s: @service.order_type,
-      geographical_availabilities_ss: @service.geographical_availabilities.map(&:alpha2)
-    }
-  end
-
-  def hierarchical_to_s(hierarchical)
-    result = []
-    result.push(hierarchical.ancestors.to_a.append(hierarchical).map(&:name).join(">"))
-    hierarchical.ancestors.to_a.map do |ancestor|
-      result.push(ancestor.ancestors.to_a.append(ancestor).map(&:name).join(">"))
-    end
-    result
+      pid: @service.pid,
+      catalogue: @service.catalogue&.name,
+      abbreviation: @service.abbreviation,
+      name: @service.name,
+      tagline: @service.tagline,
+      description: @service.description,
+      order_type: @service.order_type,
+      categories: @service.categories&.map { |category| hierarchical_to_s(category) },
+      scientific_domains: @service.scientific_domains&.map { |sd| hierarchical_to_s(sd) },
+      resource_organisation: @service.resource_organisation.name,
+      providers: @service.providers&.map(&:name),
+      multimedia_urls: @service.link_multimedia_urls&.map { |m| { name: m.name, url: m.url } },
+      use_cases_urls: @service.link_use_cases_urls&.map { |m| { name: m.name, url: m.url } },
+      access_types: @service.access_types&.map(&:name),
+      access_modes: @service.access_modes&.map(&:name),
+      platforms: @service.platforms&.map(&:name),
+      related_platforms: @service.related_platforms,
+      funding_bodies: @service.funding_bodies&.map(&:name),
+      funding_programs: @service.funding_programs&.map(&:name),
+      dedicated_for: @service.target_users.map(&:name),
+      resource_geographic_locations: @service.resource_geographic_locations&.map(&:iso_short_name),
+      geographical_availabilities: @service.geographical_availabilities&.map(&:iso_short_name),
+      language_availability: @service.languages,
+      public_contacts: @service.public_contacts&.map(&:as_json),
+      trl: @service.trl.first&.name,
+      life_cycle_status: @service.life_cycle_status.first&.name,
+      status: @service.status,
+      phase: @service.phase,
+      version: @service.version,
+      terms_of_use_url: @service.terms_of_use_url,
+      training_information_url: @service.training_information_url,
+      access_policies_url: @service.access_policies_url,
+      maintenance_url: @service.maintenance_url,
+      webpage_url: @service.webpage_url,
+      manual_url: @service.manual_url,
+      helpdesk_url: @service.helpdesk_url,
+      helpdesk_email: @service.helpdesk_email,
+      pricing_url: @service.pricing_url,
+      privacy_policy_url: @service.privacy_policy_url,
+      activate_message: @service.activate_message,
+      restrictions: @service.restrictions,
+      security_contact_email: @service.security_contact_email,
+      certifications: @service.certifications,
+      status_monitoring_url: @service.status_monitoring_url,
+      standards: @service.standards,
+      open_source_technologies: @service.open_source_technologies,
+      grant_project_names: @service.grant_project_names,
+      order_url: @service.order_url,
+      payment_model_url: @service.payment_model_url,
+      changelog: @service.changelog,
+      tag_list: @service.tag_list,
+      last_update: @service.last_update,
+      upstream_id: @service.upstream_id,
+      created_at: @service.created_at,
+      updated_at: @service.updated_at,
+      synchronized_at: @service.synchronized_at,
+      rating: @service.rating,
+      offers_count: @service.offers_count,
+      project_items_count: @service.project_items_count,
+      service_opinion_count: @service.service_opinion_count,
+      horizontal: @service.horizontal || false,
+      unified_categories: @service.research_steps&.map(&:name) || []
+    }.merge(different)
   end
 end

--- a/app/services/service/ess/delete.rb
+++ b/app/services/service/ess/delete.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 class Service::Ess::Delete < ApplicationService
-  def initialize(service_id)
+  def initialize(service_id, type)
     super()
     @service_id = service_id
+    @type = type == "Datasource" ? "data source" : "service"
   end
 
   def call
+    Offer.where(service_id: @service_id).each { |offer| Offer::Ess::Delete.call(offer.id) }
     Ess::UpdateJob.perform_later(payload)
   end
 
   private
 
   def payload
-    { delete: { id: "#{@service_id}" }, commit: {} }.to_json
+    { action: "delete", data_type: @type, data: { id: @service_id } }.as_json
   end
 end

--- a/config/ess_update.yml
+++ b/config/ess_update.yml
@@ -1,6 +1,6 @@
 default: &default
   enabled: <%= ENV["ESS_UPDATE_ENABLED"] || "false" %>
-  url: <%= ENV["ESS_UPDATE_URL"] || "http://localhost:8983/solr/marketplace/update" %>
+  url: <%= ENV["ESS_UPDATE_URL"] || "http://localhost:8080/batch" %>
   timeout: <%= ENV["ESS_UPDATE_TIMEOUT"] || "1" %>
 
 test:

--- a/docs/upgrade/3.47.0.md
+++ b/docs/upgrade/3.47.0.md
@@ -1,4 +1,4 @@
-# Upgrade to 3.46.0
+# Upgrade to 3.47.0
 
 # Standard procedure
 

--- a/docs/upgrade/3.48.0.md
+++ b/docs/upgrade/3.48.0.md
@@ -1,0 +1,20 @@
+# Upgrade to 3.48.0
+
+# Standard procedure
+
+All steps run in production scope.
+
+- make database dump and all application files.
+- `bundle install --deployment --without development test`
+- `bundle exec rake assets:clean assets:precompile`
+- `rails db:migrate`
+
+# Special steps
+
+- Set `ESS_UPDATE_ENABLED` and `ESS_UPDATE_URL` to enable jobs to the SOLR data transformation service
+- You can make json dumps for SOLR running `rake:import[all]` - you can replace all with options:
+  - providers
+  - services
+  - datasources
+  - offers
+  - bundles

--- a/lib/tasks/ess.rake
+++ b/lib/tasks/ess.rake
@@ -1,12 +1,54 @@
 # frozen_string_literal: true
 
 desc "EOSC Search Service tasks"
+COLLECTIONS = {
+  services: "Service",
+  datasources: "Datasource",
+  providers: "Provider",
+  offers: "Offer",
+  bundles: "Bundle"
+}.freeze
 namespace :ess do
   namespace :reindex do
     task all: :environment do
       Ess::Update.call({ delete: { query: "*:*" }, commit: {} }.to_json)
 
       Service.all.filter(&:public?).each { |service| Service::Ess::Add.call(service, async: false) }
+    end
+  end
+
+  task :dump, [:collections] => [:environment] do |_t, options|
+    keys = options[:collections]
+    if keys == "all"
+      dump(COLLECTIONS)
+    else
+      keys = options[:collections].split.map(&:to_sym)
+
+      dump(COLLECTIONS.select { |k, _v| keys.include?(k) })
+    end
+  end
+
+  def load_dataset(value)
+    case value.to_s
+    when "Service", "Datasource"
+      value.where(type: value.to_s).filter(&:public?)
+    when "Offer", "Bundle"
+      value.where(status: :published)
+    when "Provider"
+      value.active
+    end
+  end
+
+  def dump(collections)
+    collections.each do |key, value|
+      puts "Dump #{key} to \"#{key}.json\""
+
+      value = value.constantize
+      dataset = load_dataset(value)
+      output =
+        dataset.each.map { |object| "#{object.class}::Ess::Add".constantize.call(object, async: false, dry_run: true) }
+      File.write("#{key}.json", JSON.pretty_generate(output))
+      puts "#{key.to_s.camelize} dump complete"
     end
   end
 end

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Services in backoffice" do
 
       expect { click_on "Create Service" }.to change { user.owned_services.count }.by(1).and change { Offer.count }.by(
                                                    1
-                                                 ).and have_enqueued_job(Ess::UpdateJob)
+                                                 ).and have_enqueued_job(Ess::UpdateJob).exactly(2).times
 
       expect(page).to have_content("service name")
       expect(page).to have_content("service description")
@@ -250,6 +250,8 @@ RSpec.feature "Services in backoffice" do
       select resource_organisation.name, from: "Service organisation"
       select "open_access", from: "Order type"
 
+      enqueued_jobs.each(&:clear)
+
       click_on "Preview"
 
       expect(page).to have_content("service name")
@@ -257,6 +259,8 @@ RSpec.feature "Services in backoffice" do
 
       click_on "Go back to edit"
       expect { click_on "Create Service" }.to change { Service.count }.by(1).and have_enqueued_job(Ess::UpdateJob)
+                                       .exactly(2)
+                                       .times
       expect(page).to have_content("service name")
     end
 
@@ -339,7 +343,7 @@ RSpec.feature "Services in backoffice" do
       click_on "Edit"
 
       fill_in "service_name", with: "updated name"
-      expect { click_on "Update Service" }.to have_enqueued_job(Ess::UpdateJob)
+      expect { click_on "Update Service" }.to have_enqueued_job(Ess::UpdateJob).exactly(2).times
 
       expect(page).to have_content("updated name")
     end


### PR DESCRIPTION
Add task rake ess:dump["#{collection}"] to get collections in json dump. Possible options:
- all
- providers
- services
- offers
- bundles and arrays like `ess:dump["services datasources"]

@wziajka description of connecting to the transformation API described in docs. The variables should be set on the worker container.