### PR TITLE
fix:[#2996]Change provided by to resource organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.48.1]
+
+### Fixed
+- Resource organisation instead of service name in "Provided by" fields (@goreck888)
+
 ## [3.48.0] 2023-05-23
 
 ### Added

--- a/app/views/services/_bundled_offer.html.haml
+++ b/app/views/services/_bundled_offer.html.haml
@@ -11,7 +11,7 @@
         %h4.card-title
           = offer.name
         .provided-by
-          = _("Provided by #{offer.service.name}")
+          = _("Provided by #{offer.service.resource_organisation.name}")
       .bundle-offer-parameters.p-2
         .card-text{ "data-controller" => "paragraph" }
           = render "services/offers/bundle_parameters",

--- a/app/views/services/configurations/_bundled_offers.html.haml
+++ b/app/views/services/configurations/_bundled_offers.html.haml
@@ -8,7 +8,7 @@
         %h3.bundle-configuration-title
           = offer.name
         %span.text-muted
-          = _("Provided by #{ offer.service.name}")
+          = _("Provided by #{ offer.service.resource_organisation.name}")
       .col-12.offer-description
         .card-body.p-0.pt-5
           .col-12.col-lg-12.pl-0.additional-information.technical

--- a/app/views/services/configurations/show.html.haml
+++ b/app/views/services/configurations/show.html.haml
@@ -17,7 +17,7 @@
             %h3.bundle-configuration-title
               = @step.offer.name
             %span.text-muted
-              = _("Provided by #{ @step.offer.service.name}")
+              = _("Provided by #{ @step.offer.service.resource_organisation.name}")
           = render "services/configurations/voucher", step: @step, f: f
           = render "services/configurations/attributes", step: @step, service: @service, form: f
       - else

--- a/app/views/services/summaries/_bundle_technical.html.haml
+++ b/app/views/services/summaries/_bundle_technical.html.haml
@@ -3,7 +3,7 @@
     .card-body.p-4
       %h4.card-title.mb-1= offer.name
       .text-muted.mb-3
-        = _("Provided by #{ offer.service.name}")
+        = _("Provided by #{ offer.service.resource_organisation.name}")
       .card-text= markdown(offer.description)
 
       - if bundle_params[offer.id].present?


### PR DESCRIPTION
Change "Provided by" fields from service name
to resource organisation name
Closes #2996