### PR TITLE
feat:[] Add tags to offers and bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Added
 - Optional hiding offers dedicated for bundle (@goreck888)
+- Possibility to tag offers and bundles (@goreck888)
 
 ### Changed
 - Bundle linking available for all types of offers (@goreck888)

--- a/app/controllers/concerns/service/recommendable.rb
+++ b/app/controllers/concerns/service/recommendable.rb
@@ -53,7 +53,7 @@ module Service::Recommendable
       end
     body = JSON.parse(response.body)
 
-    return if response.status != 200
+    raise StandardError if response.status != 200
 
     ids = body.is_a?(Array) ? body.each.map { |e| e["service_id"].to_i } : []
     Service.where(id: ids, status: %i[published unverified])

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -5,6 +5,8 @@ class Bundle < ApplicationRecord
 
   # include Offer::Parameters
 
+  acts_as_taggable
+
   searchkick word_middle: %i[offer_name description], highlight: %i[offer_name description]
 
   STATUSES = { published: "published", draft: "draft", deleted: "deleted" }.freeze

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -5,6 +5,8 @@ class Offer < ApplicationRecord
   include Offerable
   include Offer::Parameters
 
+  acts_as_taggable
+
   searchkick word_middle: %i[offer_name description], highlight: %i[offer_name description]
 
   STATUSES = { published: "published", draft: "draft", deleted: "deleted" }.freeze

--- a/app/policies/backoffice/bundle_policy.rb
+++ b/app/policies/backoffice/bundle_policy.rb
@@ -61,6 +61,7 @@ class Backoffice::BundlePolicy < ApplicationPolicy
       [target_user_ids: []],
       [research_step_ids: []],
       :main_offer_id,
+      :tag_list,
       :from,
       [offer_ids: []],
       :related_training,

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -54,6 +54,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
       :internal,
       :from,
       :primary_oms_id,
+      :tag_list,
       oms_params: {},
       parameters_attributes: %i[
         type

--- a/app/serializers/ess/bundle_serializer.rb
+++ b/app/serializers/ess/bundle_serializer.rb
@@ -7,6 +7,7 @@ class Ess::BundleSerializer < ApplicationSerializer
              :capabilities_of_goals,
              :main_offer_id,
              :description,
+             :tag_list,
              :target_users,
              :scientific_domains,
              :research_steps,

--- a/app/serializers/ess/offer_serializer.rb
+++ b/app/serializers/ess/offer_serializer.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
 class Ess::OfferSerializer < ApplicationSerializer
-  attributes :id, :name, :description, :service_id, :status, :order_type, :internal, :voucherable, :parameters
+  attributes :id,
+             :name,
+             :description,
+             :service_id,
+             :tag_list,
+             :status,
+             :order_type,
+             :internal,
+             :voucherable,
+             :parameters
 end

--- a/app/views/backoffice/services/bundles/_form.html.haml
+++ b/app/views/backoffice/services/bundles/_form.html.haml
@@ -11,6 +11,7 @@
     = f.association :main_offer, collection: service.offers.published, label_method: :name, value_method: :id,
             input_html: { multiple: false, data: { choice: true } }
     = f.input :description, input_html: { rows: 10 }
+    = f.input :tag_list, input_html: { value: bundle.tag_list.to_s, data: { choice: true } }
 
     = f.association :target_users, multiple: true, input_html: {data: { choice: true } }
     - sds = ScientificDomain.child_names.filter_map { |name, sd| [name, sd.id] if sd.parent.present? }

--- a/app/views/backoffice/services/form/_classification.html.haml
+++ b/app/views/backoffice/services/form/_classification.html.haml
@@ -36,4 +36,5 @@
                             disabled: cant_edit([access_type_ids: []])
       = f.association :access_modes, input_html: { data: { choice: true } },
                             disabled: cant_edit([access_mode_ids: []])
-      = f.input :tag_list, input_html: { value: service.tag_list.to_s }, disabled: cant_edit(:tag_list)
+      = f.input :tag_list, input_html: { value: service.tag_list.to_s, data: { choice: true } },
+      disabled: cant_edit(:tag_list)

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -7,6 +7,7 @@
     = f.hidden_field :id
     = f.input :name, input_html: { class: "form-control-lg" }
     = f.input :description, input_html: { rows: 10 }
+    = f.input :tag_list, input_html: { value: offer&.tag_list&.to_s, data: { choice: true } }
     = f.input :bundle_exclusive
     = f.input :order_type, collection: Offer.order_types.keys.map(&:to_sym),
       selected: (offer.order_type || service.order_type),

--- a/swagger/v1/ess/bundle/bundle_read.json
+++ b/swagger/v1/ess/bundle/bundle_read.json
@@ -25,6 +25,13 @@
     "description": {
       "type": "string"
     },
+    "tag_list": {
+      "type": "array",
+      "nullable": true,
+      "items": {
+        "type": "string"
+      }
+    },
     "target_users": {
       "type": "array",
       "nullable": true,

--- a/swagger/v1/ess/offer/offer_read.json
+++ b/swagger/v1/ess/offer/offer_read.json
@@ -10,6 +10,13 @@
     "description": {
       "type": "string"
     },
+    "tag_list": {
+      "type": "array",
+      "nullable": true,
+      "items": {
+        "type": "string"
+      }
+    },
     "service_id": {
       "type": "integer"
     },


### PR DESCRIPTION
Add tags (keywords) to the backoffice forms for offers and bundles. It allows sending tags to the SOLR directly from an offer/bundle.
This PR Is created upon @roksanaer's request.

We can also change a schema for SOLR in this PR, but it should be discussed with @Michal-Kolomanski 