### PR TITLE
fix:[] Fix typo in landing page

### DIFF
--- a/app/helpers/landing_page_helper.rb
+++ b/app/helpers/landing_page_helper.rb
@@ -8,7 +8,7 @@ module LandingPageHelper
     publication: "Publications",
     dataset: "Data",
     "data-source": "Data Sources",
-    bundle: "Service Bundle",
+    bundle: "Service Bundles",
     training: "Training Materials",
     guideline: "Interoperability Guidelines"
   }.freeze


### PR DESCRIPTION
Change `service bundle` to `service bundles`