### PR TITLE
feat: add logo redirect endpoint

### DIFF
--- a/app/controllers/providers/logos_controller.rb
+++ b/app/controllers/providers/logos_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Providers::LogosController < ApplicationController
+  def show
+    @provider = Provider.with_attached_logo.friendly.find(params[:provider_id])
+    authorize(@provider)
+    redirect_to @provider.logo.variant(resize: "84x84"), allow_other_host: false
+  end
+end

--- a/app/controllers/services/logos_controller.rb
+++ b/app/controllers/services/logos_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Services::LogosController < ApplicationController
+  def show
+    @service = Service.friendly.find(params[:service_id])
+    authorize(ServiceContext.new(@service, false))
+    redirect_to @service.logo.variant(resize: "84x84"), allow_other_host: false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
       resource :information, only: [:show, :update]
       resource :summary, only: [:show, :create]
       resource :cancel, only: :destroy
+      resource :logo, only: :show
       resource :question, only: [:new, :create], constraints: lambda { |req| req.format == :js }
       resources :opinions, only: :index
       resources :details, only: :index
@@ -74,6 +75,7 @@ Rails.application.routes.draw do
     scope module: :providers do
       resource :question, only: [:new, :create], constraints: lambda { |req| req.format == :js }
       resources :details, only: :index
+      resource :logo, only: :show
     end
   end
 


### PR DESCRIPTION
* Add logo redirect endpoint to services and providers

How to test - `/logo` endpoint has been added to services and providers - so on the details page of the service / provider add `/logo` to the link. You should be redirected to the image.

Eg. `https://marketplace-11.docker-fid.grid.cyf-kr.edu.pl/services/eosc.egi-fed.cloud_compute/logo`
(Provider) eg. `https://marketplace-11.docker-fid.grid.cyf-kr.edu.pl/providers/eosc.upv-es/logo`