### PR TITLE
feat: Resource cache ttl can be defined via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ We are currently using the following ENV variables:
   * `ESS_UPDATE_ENABLED` (Optional) - turn on updating ESS if set to `true` (default `false`)
   * `ESS_UPDATE_URL` (Optional) - URL to which service updates will be sent (default `http://localhost:8983/solr/marketplace/update`)
   * `ESS_UPDATE_TIMEOUT` (Optional) - ESS update HTTP client timeout in seconds (default `1`)
+  * `ESS_RESOURCE_CACHE_TTL` (Optional) - TTL for caching resources for `ess/` API endpoints (default `60` (seconds))
   * **Provider importer**
     * `IMPORTER_AAI_BASE_URL` (Optional) - Base URL used to generate access token from a refresh token (default `ENV["CHECKIN_HOST"]` or "aai.eosc-portal.eu")
     * `IMPORTER_AAI_REFRESH_TOKEN` - The refresh token generated for specific instance of AAI

--- a/app/controllers/api/v1/ess/application_controller.rb
+++ b/app/controllers/api/v1/ess/application_controller.rb
@@ -64,7 +64,7 @@ class Api::V1::Ess::ApplicationController < ActionController::API
       serializer = "Ess::#{controller_class(collection)}Serializer".constantize
       Rails
         .cache
-        .fetch("ess_#{collection}", expires_in: 2.hours) do
+        .fetch("ess_#{collection}", expires_in: Mp::Application.config.resource_cache_ttl) do
           instance_variable_get("@#{collection}")&.map { |o| serializer.new(o).as_json }
         end
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,8 @@ module Mp
     config.user_dashboard_url = ENV.fetch("USER_DASHBOARD_URL",
                                           "https://eosc-user-dashboard.docker-fid.grid.cyf-kr.edu.pl")
 
+    config.resource_cache_ttl = ENV.fetch("ESS_RESOURCE_CACHE_TTL", "60").to_i.seconds
+
     config.mp_stomp_publisher_enabled =
       if ENV["MP_STOMP_PUBLISHER_ENABLED"].present?
         ENV["MP_STOMP_PUBLISHER_ENABLED"]


### PR DESCRIPTION
Change cache ttl to be configurable via env variable, changed default to `60 seconds`.

Testing changes should be done in `60 seconds` intervals, are within that time data is being cached.