### PR TITLE
fix:[#3038] Provider filter links in Search Service

### DIFF
--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -37,7 +37,7 @@ module SearchLinksHelper
     link_to_unless(
       target.deleted? || target.draft?,
       highlighted_for(:resource_organisation_name, service, highlights),
-      service.organisation_search_link(target),
+      service.organisation_search_link(target.name, services_path(providers: target.id)),
       preview_options
     )
   end
@@ -55,12 +55,12 @@ module SearchLinksHelper
         if highlighted.present? && highlighted.strip == target.name.strip
           link_to_unless target.deleted? || target.draft?,
                          highlights[:provider_names].html_safe,
-                         service.provider_search_link(target),
+                         service.provider_search_link(target.name, services_path(providers: target.id)),
                          preview_options
         else
           link_to_unless target.deleted? || target.draft?,
                          target.name,
-                         service.provider_search_link(target),
+                         service.provider_search_link(target.name, services_path(providers: target.id)),
                          preview_options
         end
       end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -313,14 +313,13 @@ class Service < ApplicationRecord
 
   private
 
-  def _provider_search_link(target, filter_query, default_path = nil)
-    target_name = target.respond_to?(:name) ? target.name : target
+  def _provider_search_link(target_name, filter_query, default_path = nil)
     search_base_url = Mp::Application.config.search_service_base_url
     enable_external_search = Mp::Application.config.enable_external_search
     if enable_external_search
       search_base_url + "/search/service?q=*&fq=#{filter_query}:(%22#{target_name}%22)"
     else
-      default_path || provider_path(target)
+      default_path
     end
   end
 


### PR DESCRIPTION
This PR fixes provider filter links
from the marketplace to the Search Service

Closes #3038