### PR TITLE
fix:[#3057] Removing offer from bundle by draft/delete

### DIFF
--- a/app/controllers/backoffice/services/offers/drafts_controller.rb
+++ b/app/controllers/backoffice/services/offers/drafts_controller.rb
@@ -8,7 +8,7 @@ class Backoffice::Services::Offers::DraftsController < Backoffice::ApplicationCo
       flash[:notice] = "Offer changed to draft successfully"
       redirect_to backoffice_service_path(@service)
     else
-      flash[:alert] = "Offer cannot be changed to draft"
+      flash[:alert] = "Offer cannot be changed to draft. Reason: #{@offer.errors.full_messages.join(", ")}"
       redirect_to edit_backoffice_service_offer_path(@service, @offer)
     end
   end

--- a/app/services/offer/application_service.rb
+++ b/app/services/offer/application_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Offer::ApplicationService < ApplicationService
+  def initialize(offer)
+    super()
+    @offer = offer
+    @service = @offer.service
+    @bundles = @offer.bundles.to_a
+  end
+
+  private
+
+  def unbundle!
+    @bundles.each do |bundle|
+      Bundle::Update.call(
+        bundle,
+        { offer_ids: bundle.offer_ids.to_a.reject { |o| o == @offer.id } }.stringify_keys,
+        external_update: true
+      )
+    end
+  end
+end

--- a/app/services/offer/create.rb
+++ b/app/services/offer/create.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-class Offer::Create < ApplicationService
-  def initialize(offer)
-    super()
-    @offer = offer
-  end
-
+class Offer::Create < Offer::ApplicationService
   def call
     @offer.save
-    @offer.service.reindex
+    @service.reindex
     @offer.reindex
     @offer
   end

--- a/app/services/offer/destroy.rb
+++ b/app/services/offer/destroy.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
-class Offer::Destroy < ApplicationService
-  def initialize(offer)
-    super()
-    @offer = offer
-  end
-
+class Offer::Destroy < Offer::ApplicationService
   def call
-    @service = @offer.service
-    @bundles = @offer.bundles.to_a
     unbundle!
     result = @offer&.project_items.present? ? @offer.update(status: :deleted) : @offer.destroy
 
@@ -17,17 +10,5 @@ class Offer::Destroy < ApplicationService
     end
     @service.reindex
     result
-  end
-
-  private
-
-  def unbundle!
-    @bundles.each do |bundle|
-      Bundle::Update.call(
-        bundle,
-        { offer_ids: bundle.offers.to_a.reject { |o| o == @offer }.map(&:id) },
-        external_update: true
-      )
-    end
   end
 end

--- a/app/services/offer/draft.rb
+++ b/app/services/offer/draft.rb
@@ -1,27 +1,9 @@
 # frozen_string_literal: true
 
-class Offer::Draft < ApplicationService
-  def initialize(offer)
-    super()
-    @offer = offer
-  end
-
+class Offer::Draft < Offer::ApplicationService
   def call
     result = @offer.update(status: :draft)
     unbundle!
     result
-  end
-
-  private
-
-  def unbundle!
-    @offer.bundles.each do |bundle|
-      Bundle::Update.call(
-        bundle,
-        { offers: bundle.offers.to_a.reject { |o| o.id == @offer.id } }.stringify_keys,
-        external_update: true
-      )
-    end
-    @offer.main_bundles.each { |bundle| Bundle::Draft.call(bundle) }
   end
 end

--- a/app/services/offer/publish.rb
+++ b/app/services/offer/publish.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-class Offer::Publish < ApplicationService
-  def initialize(offer)
-    super()
-    @offer = offer
-  end
-
+class Offer::Publish < Offer::ApplicationService
   def call
     # Don't send Offer::Mailer::Bundled notification here, since this mini-service is only used in the context,
     # where such notifications will be sent by the caller, i.e. Service::Publish.

--- a/app/services/offer/update.rb
+++ b/app/services/offer/update.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-class Offer::Update < ApplicationService
+class Offer::Update < Offer::ApplicationService
   def initialize(offer, params)
-    super()
-    @offer = offer
+    super(offer)
     @params = params
   end
 
@@ -18,11 +17,5 @@ class Offer::Update < ApplicationService
     unbundle! if !@offer.published? && public_before
     @offer.service.reindex
     @offer.valid?
-  end
-
-  def unbundle!
-    @offer.bundles.each do |b|
-      Bundle::Update.call(b, { offers: b.offers.reject { |o| o == @offer } }, external_update: true)
-    end
   end
 end

--- a/spec/services/offer/draft_spec.rb
+++ b/spec/services/offer/draft_spec.rb
@@ -28,14 +28,15 @@ RSpec.describe Offer::Draft, backend: true do
         expect(bundle.status).to eq("draft")
       end
 
-      it "sends notification if main bundle drafted" do
-        expect { described_class.call(bundle_offer) }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      it "doesn't allow to change to draft for main offer" do
+        expect { described_class.call(bundle_offer) }.to_not change { ActionMailer::Base.deliveries.count }
 
         bundle_offer.reload
         bundle.reload
 
-        expect(bundle.valid?).to be_truthy
-        expect(bundle.status).to eq("draft")
+        expect(bundle_offer.valid?).to be_truthy
+        expect(bundle_offer.status).to eq("published")
+        expect(bundle.status).to eq("published")
       end
     end
   end


### PR DESCRIPTION
Unify behavior of drafting and deleting offers
Now it removes just the current offer regardless
of the action changing the offer's status
Closes #3057