### PR TITLE
fix:[#3072] Bundle configuration's step regression

### DIFF
--- a/app/controllers/services/summaries_controller.rb
+++ b/app/controllers/services/summaries_controller.rb
@@ -53,7 +53,7 @@ class Services::SummariesController < Services::ApplicationController
   end
 
   def summary_params
-    session[session_key].merge(params.require(:customizable_project_item).permit(:project_id))
+    session[session_key].merge(params.require(:customizable_project_item).permit(:project_id, :additional_comment))
   end
 
   def setup_show_variables!

--- a/app/models/project_item.rb
+++ b/app/models/project_item.rb
@@ -26,6 +26,8 @@ class ProjectItem < ApplicationRecord
   enum status_type: STATUS_TYPES
   enum issue_status: ISSUE_STATUSES
 
+  attr_accessor :additional_comment
+
   belongs_to :offer
   belongs_to :bundle, optional: true
   belongs_to :service, inverse_of: :project_items

--- a/app/models/project_item/wizard.rb
+++ b/app/models/project_item/wizard.rb
@@ -36,7 +36,7 @@ class ProjectItem::Wizard
 
     delegate(*::ProjectItem.attribute_names.map { |a| [a, "#{a}="] }.flatten, to: :project_item)
 
-    delegate :offer, :bundle, :project, :parent, to: :project_item
+    delegate :offer, :bundle, :project, :parent, :voucher_id, :request_voucher, to: :project_item
 
     def initialize(service, project_item_attributes)
       @service = service
@@ -85,8 +85,11 @@ class ProjectItem::Wizard
 
   class SummaryStep < ConfigurationStep
     include ProjectItem::ProjectValidation
+    include ProjectItem::VoucherValidation
 
-    attr_accessor :additional_comment, :verified_recaptcha
+    delegate :additional_comment, to: :project_item
+
+    attr_accessor :verified_recaptcha
 
     def error
       "Please correct errors presented below"

--- a/app/services/project_item/create.rb
+++ b/app/services/project_item/create.rb
@@ -33,6 +33,8 @@ class ProjectItem::Create
               parent_id: @project_item.id,
               project_id: @project.id,
               offer_id: offer.id,
+              voucher_id: @project_item.voucher_id,
+              request_voucher: @project_item.request_voucher,
               bundle_id: @project_item.bundle.id,
               properties: bundled_parameters
             )

--- a/app/views/services/configurations/_bundled_offers.html.haml
+++ b/app/views/services/configurations/_bundled_offers.html.haml
@@ -1,6 +1,7 @@
 - if step.bundle.present?
   - step.bundled_property_values.each do |offer, property_values|
-
+    - if offer.voucherable? && (step.bundle.nil? || step&.bundle&.all_offers&.select(&:voucherable?)&.size == 1)
+      = render "services/configurations/voucher", step: step, f: f
     .row.bundle-info
       .col-12.col-md-2
         = presentable_logo(offer.service, "align-self-center img-fluid", "180x120")

--- a/app/views/services/configurations/_voucher.html.haml
+++ b/app/views/services/configurations/_voucher.html.haml
@@ -1,20 +1,24 @@
 - if step&.offer&.voucherable || step&.bundle&.main_offer&.voucherable || step&.bundle&.offers&.any?(&:voucherable)
-  %h2.mb-3.font-weight-normal
-    = _("Voucher")
-  .btn-group.voucher-radio.btn-group-toggle.mb-4.col-12.col-lg-8.p-0
-    %label#have.btn.btn-secondary.p-2.pl-5.pr-5{ "data-project-item-target" => "iHaveVoucher",
-                                            class: ("active" unless step.request_voucher) }
-      %input{ type: "radio", name: "customizable_project_item[request_voucher]",
-                   value: "false", "data-action" => "change->project-item#voucherChanged" }
-        %i.fas.fa-check
-        = _("I have a voucher, I want to use it")
-    %label#ask.btn.btn-secondary.p-2.pl-5.pr-5{ "data-project-item-target" => "iDontHaveVoucher",
-                                            class: ("active" if step.request_voucher) }
-      %input{ type: "radio", name: "customizable_project_item[request_voucher]",
-                  value: "true", "data-action" => "change->project-item#voucherChanged" }
-        %i.fas.fa-check
-        = _("I want to ask for vouchers")
+  .row.bundle-info
+    .col-12.col-md-2
+    .col-12.col-md-10
+    %h2.mb-3.font-weight-normal
+      = _("Voucher")
+    .col-12.col-md-10
+    .btn-group.voucher-radio.btn-group-toggle.mb-4.col-12.col-lg-8.p-0
+      %label#have.btn.btn-secondary.p-2.pl-5.pr-5{ "data-project-item-target" => "iHaveVoucher",
+                                              class: ("active" unless step.request_voucher) }
+        %input{ type: "radio", name: "customizable_project_item[request_voucher]",
+                     value: "false", "data-action" => "change->project-item#voucherChanged" }
+          %i.fas.fa-check
+          = _("I have a voucher, I want to use it")
+      %label#ask.btn.btn-secondary.p-2.pl-5.pr-5{ "data-project-item-target" => "iDontHaveVoucher",
+                                              class: ("active" if step.request_voucher) }
+        %input{ type: "radio", name: "customizable_project_item[request_voucher]",
+                    value: "true", "data-action" => "change->project-item#voucherChanged" }
+          %i.fas.fa-check
+          = _("I want to ask for vouchers")
 
-  .form-group.voucher_id.col-12.col-lg-7.pl-0.mb-5{ "data-project-item-target" => "hasVoucher",
-                                                    class: ("hidden-fields" if step.request_voucher) }
-    = f.input :voucher_id, label: _("Voucher ID"), input_html: { autocomplete: "new-password" }
+    .form-group.voucher_id.col-12.col-lg-7.pl-0.mb-5{ "data-project-item-target" => "hasVoucher",
+                                                      class: ("hidden-fields" if step.request_voucher) }
+      = f.input :voucher_id, label: _("Voucher ID"), input_html: { autocomplete: "new-password" }

--- a/app/views/services/configurations/show.html.haml
+++ b/app/views/services/configurations/show.html.haml
@@ -7,24 +7,21 @@
       - if @step.bundle.present?
         %h2.mb-2.mt-3.font-bold Bundle configuration
         %p.mb-4 Your service will be configured to work with following services:
-      - else
-        %p.mb-4= _("Please specify parameters. It is necessary to handle your request.")
-      - if @step.bundle.present?
-        .row.bundle-info
-          .col-12.col-md-2
-          .col-12.col-md-10
+        - if @step.bundle.all_offers.select(&:voucherable?).size > 1
           = render "services/configurations/voucher", step: @step, f: f
         .row.bundle-info
           .col-12.col-md-2
             = presentable_logo(@step.bundle.service, "align-self-center img-fluid", "180x120")
           .col-12.col-md-10
             %h3.bundle-configuration-title
-              = @step.bundle.name
+              = @step.bundle.main_offer.name
             %span.text-muted
               = _("Provided by #{ @step.bundle.service.resource_organisation.name}")
           = render "services/configurations/attributes", step: @step, service: @service, form: f
-      - else
-        = render "services/configurations/voucher", step: @step, f: f
-        = render "services/configurations/attributes", step: @step, service: @service, form: f
-      - if @step.bundle.present?
         = render "services/configurations/bundled_offers", step: @step, service: @service, f: f
+      - else
+        %p.mb-4= _("Please specify parameters. It is necessary to handle your request.")
+        = render "services/configurations/voucher", step: @step, f: f
+        .row.bundle-info
+          = render "services/configurations/attributes", step: @step, service: @service, form: f
+

--- a/app/views/services/summaries/show.html.haml
+++ b/app/views/services/summaries/show.html.haml
@@ -18,7 +18,7 @@
   .additional-information.mb-4
     .card.offer-description.mb-4
       .card-body.pb-2.pt-4.pl-4.pr-4
-        - if @offer.voucherable
+        - if @offer.voucherable || @step.bundle&.all_offers&.select(&:voucherable)&.size&.positive?
           %h4
             = _("Voucher")
           %dl.mb-4


### PR DESCRIPTION
Fix displaying unnecessary box
and change showing main_offer.name
instead of bundle.name

Closes #3072, #3078