### PR TITLE
[#3091] Fix datasources question link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ### Changed
 - Bundle linking available for all types of offers (@goreck888)
+- Improvements for the UI in the Marketplace's projects (@jarekzet, @goreck888)
 
 ### Fixed
 - Blocked connecting drafted offers to the bundle (@goreck888)
@@ -26,6 +27,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Linking one main offer with multiple bundles (@goreck888)
 - Random failing tests (@goreck888)
 - Offer status validation when bundle is published (@goreck888)
+- Question link in the datasource page (@goreck888)
 
 ## [3.50.0] 2023-08-30
 

--- a/app/components/presentable/header_component.rb
+++ b/app/components/presentable/header_component.rb
@@ -37,10 +37,10 @@ class Presentable::HeaderComponent < ApplicationComponent
   end
 
   def new_question_link
-    @object.instance_of?(Service) ? new_service_question_path(@object) : new_provider_question_path(@object)
+    @object.instance_of?(Provider) ? new_provider_question_path(@object) : new_service_question_path(@object)
   end
 
   def new_question_prompt
-    @object.instance_of?(Service) ? "Ask a question about this service?" : "Ask this provider a question"
+    @object.instance_of?(Provider) ? "Ask this provider a question" : "Ask a question about this service?"
   end
 end


### PR DESCRIPTION
This PR fixes "Ask a question about this resource" link in the datasource details page
Closes #3091