### PR TITLE
fix: Fix JMS import

### DIFF
--- a/app/services/jms/manage_message.rb
+++ b/app/services/jms/manage_message.rb
@@ -40,7 +40,7 @@ class Jms::ManageMessage < ApplicationService
       end
       if action != "delete" && resource["serviceBundle"]["service"]
         Service::PcCreateOrUpdateJob.perform_later(
-          resource["serviceBundle"]["service"].merge(resource_extras(resource["serviceBundle"])),
+          resource["serviceBundle"]["service"],
           @eosc_registry_base_url,
           resource["serviceBundle"]["active"] && !resource["serviceBundle"]["suspended"],
           modified_at,


### PR DESCRIPTION
This PR fixes an error caused by a change in the JMS message schema.
Removed `resourceExtras` from the `serviceBundle` entity.