### PR TITLE
fix:[#3142] Change `all_catalogs` to `all_resources`

### DIFF
--- a/app/helpers/landing_page_helper.rb
+++ b/app/helpers/landing_page_helper.rb
@@ -2,7 +2,7 @@
 
 module LandingPageHelper
   SEARCH_ITEMS = {
-    all: "All catalogs",
+    all_collection: "All resources",
     software: "Software",
     service: "Services",
     publication: "Publications",


### PR DESCRIPTION
Change link label from `All catalogs`
to `All resources`

Closes #3142