### PR TITLE
fix:[#3141] Remove interoperability patterns from tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.53.2] 2023-12-06
+
+### Removed
+- Interoperability patterns from the tag list (@goreck888)
+
 ## [3.53.1] 2023-11-30
 
 ### Fixed

--- a/app/views/taggable/_details_section.html.haml
+++ b/app/views/taggable/_details_section.html.haml
@@ -1,6 +1,6 @@
 - if taggable.tag_list.present?
   .container
     = _("Tags") + ":"
-    - taggable.tag_list.sort.each do |tag|
+    - taggable.tag_list.reject { |tag| tag.downcase.start_with?("eosc::") }.sort.each do |tag|
       = link_to tag, services_tag_link(tag), class: "badge badge-light", "data-e2e": "tag-btn",
       "data-preview-target": local_assigns[:preview] ? "link" : ""


### PR DESCRIPTION
Remove interoperability patterns in the
tag_list in the bottom of the service view

Closes #3141