### PR TITLE
feat:[#3115] show suspended objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 ## [3.55.0-milestone]
 
+### Added
+- View of the suspended services and datasources (@goreck888)
+
 ### Changed
 - Service page design (@jarekzet, @goreck888)
 - Requesting similar services recommendations through RS Facade (@goreck888)

--- a/app/components/presentable/description_component.html.haml
+++ b/app/components/presentable/description_component.html.haml
@@ -12,10 +12,11 @@
           .col-12
             = render "services/related", related_services: @similar_services, title: similar_services_title,
             preview: @preview
-        .row
-          .col-12
-            = render "services/related", related_services: @related_services, title: related_services_title,
-            preview: @preview
+        - unless @object.suspended?
+          .row
+            .col-12
+              = render "services/related", related_services: @related_services, title: related_services_title,
+              preview: @preview
 
     %sidebar.col-12.col-xl-3{ "data-shepherd-tour-target": "service-classification" }
       = render "components/presentable/explore_links", object: @object

--- a/app/components/presentable/details_component.html.haml
+++ b/app/components/presentable/details_component.html.haml
@@ -20,6 +20,7 @@
                                   type: group[:type] || "single",
                                   clazz: group[:clazz] || "",
                                   nested: group[:nested] || "",
+                                  inactive: @object.suspended? && !group[:active_when_suspended],
                                   with_desc: group[:with_desc] || false,
                                   preview: @preview
       .related-container

--- a/app/components/presentable/header_component.html.haml
+++ b/app/components/presentable/header_component.html.haml
@@ -14,7 +14,7 @@
 
       - unless @object.instance_of?(Provider)
         = render "components/presentable/header_component/categorization",
-              service: @object, highlights: nil, preview: @preview
+              service: @object, highlights: nil, preview: @preview || @object.suspended?
       %p.mb-3.subtitle-row= @subtitle
 
       - if @object.instance_of?(Service)

--- a/app/components/presentable/links_component.html.haml
+++ b/app/components/presentable/links_component.html.haml
@@ -3,4 +3,5 @@
            object: @object,
            fields: group[:fields],
            nested: group[:nested],
+           active_when_suspended: group[:active_when_suspended],
            preview: @preview

--- a/app/components/presentable/sidebar_component.html.haml
+++ b/app/components/presentable/sidebar_component.html.haml
@@ -13,5 +13,6 @@
                     type: group[:type] || "",
                     clazz: group[:clazz] || "",
                     with_desc: group[:with_desc] || false,
+                    inactive: @object.suspended? && !group[:active_when_suspended],
                     filter_query: group[:filter_query] || [],
                     nested: group[:nested] || []

--- a/app/controllers/backoffice/services/bundles/drafts_controller.rb
+++ b/app/controllers/backoffice/services/bundles/drafts_controller.rb
@@ -4,13 +4,14 @@ class Backoffice::Services::Bundles::DraftsController < Backoffice::ApplicationC
   before_action :find_and_authorize
 
   def create
-    if Bundle::Draft.call(@bundle)
+    if Bundle::Unpublish.call(@bundle)
+      flash[:notice] = "Bundle unpublished successfully"
       redirect_to backoffice_service_path(@service)
     else
       flash[:alert] =
-        "Bundle not drafted, errors: " +
+        "Bundle cannot be unpublished. Please ensure your form is properly completed. " +
           "#{@bundle.errors.messages.each.map { |k, v| "The field #{k} #{v.join(", ")}" }.join(", ")}"
-      redirect_to edit_backoffice_service_offer_path(@service, @bundle)
+      redirect_to edit_backoffice_service_bundle_path(@service, @bundle)
     end
   end
 

--- a/app/controllers/backoffice/services/bundles/publishes_controller.rb
+++ b/app/controllers/backoffice/services/bundles/publishes_controller.rb
@@ -5,10 +5,11 @@ class Backoffice::Services::Bundles::PublishesController < Backoffice::Applicati
 
   def create
     if Bundle::Publish.call(@bundle)
+      flash[:notice] = "Bundle published successfully"
       redirect_to backoffice_service_path(@service)
     else
       flash[:alert] =
-        "Bundle not published, errors: " +
+        "Bundle cannot be published. Please ensure your form is properly completed. " +
           "#{@bundle.errors.messages.each.map { |k, v| "The field #{k} #{v.join(", ")}" }.join(", ")}"
       redirect_to edit_backoffice_service_bundle_path(@service, @bundle)
     end

--- a/app/controllers/backoffice/services/drafts_controller.rb
+++ b/app/controllers/backoffice/services/drafts_controller.rb
@@ -4,8 +4,16 @@ class Backoffice::Services::DraftsController < Backoffice::ApplicationController
   before_action :find_and_authorize
 
   def create
-    Service::Draft.call(@service)
-    redirect_to backoffice_service_path(@service)
+    result = params[:suspend] ? Service::Suspend.call(@service) : Service::Unpublish.call(@service)
+    if result
+      flash[:notice] = "Service #{params[:suspend] ? "suspended" : "unpublished"} successfully"
+      redirect_to backoffice_service_path(@service)
+    else
+      flash[:alert] =
+        "Service not #{params[:suspend] ? "suspended" : "unpublished"}. " +
+          "Reason: #{@service.errors.full_messages.join(", ")}"
+      redirect_to edit_backoffice_service_path(@service)
+    end
   end
 
   private

--- a/app/controllers/backoffice/services/offers/drafts_controller.rb
+++ b/app/controllers/backoffice/services/offers/drafts_controller.rb
@@ -4,11 +4,13 @@ class Backoffice::Services::Offers::DraftsController < Backoffice::ApplicationCo
   before_action :find_and_authorize
 
   def create
-    if Offer::Draft.call(@offer)
-      flash[:notice] = "Offer changed to draft successfully"
+    if Offer::Unpublish.call(@offer)
+      flash[:notice] = "Offer unpublished successfully"
       redirect_to backoffice_service_path(@service)
     else
-      flash[:alert] = "Offer cannot be changed to draft. Reason: #{@offer.errors.full_messages.join(", ")}"
+      flash[:alert] =
+        "Offer cannot be unpublished. Please ensure your form is properly completed. " +
+          "#{@offer.errors.messages.each.map { |k, v| "The field #{k} #{v.join(", ")}" }.join(", ")}"
       redirect_to edit_backoffice_service_offer_path(@service, @offer)
     end
   end

--- a/app/controllers/backoffice/services/offers/publishes_controller.rb
+++ b/app/controllers/backoffice/services/offers/publishes_controller.rb
@@ -5,9 +5,12 @@ class Backoffice::Services::Offers::PublishesController < Backoffice::Applicatio
 
   def create
     if Offer::Publish.call(@offer)
+      flash[:notice] = "Offer published successfully"
       redirect_to backoffice_service_path(@service)
     else
-      flash[:alert] = "Offer not published, errors: #{@offer.errors.messages}"
+      flash[:alert] =
+        "Offer cannot be published. Please ensure your form is properly completed. " +
+          "#{@offer.errors.messages.each.map { |k, v| "The field #{k} #{v.join(", ")}" }.join(", ")}"
       redirect_to edit_backoffice_service_offer_path(@service, @offer)
     end
   end

--- a/app/controllers/services/logos_controller.rb
+++ b/app/controllers/services/logos_controller.rb
@@ -3,7 +3,7 @@
 class Services::LogosController < ApplicationController
   def show
     @service = Service.friendly.find(params[:service_id])
-    authorize(ServiceContext.new(@service, false))
+    authorize(ServiceContext.new(@service, params.key?(:from) && params[:from] == "backoffice_service"))
 
     if @service.logo.attached? && @service.logo.variable?
       redirect_to @service.logo.variant(resize: "84x84"), allow_other_host: false

--- a/app/controllers/services/ordering_configuration/bundles/drafts_controller.rb
+++ b/app/controllers/services/ordering_configuration/bundles/drafts_controller.rb
@@ -5,11 +5,11 @@ module Services::OrderingConfiguration::Bundles
     before_action :find_and_authorize
 
     def create
-      if Bundle::Draft.call(@bundle)
+      if Bundle::Unpublish.call(@bundle)
         redirect_to service_ordering_configuration_path(@service)
       else
         flash[:alert] =
-          "Bundle not drafted, errors: " +
+          "Bundle cannot be set to draft. Please ensure your form is properly completed. " +
             "#{@bundle.errors.messages.each.map { |k, v| "The field #{k} #{v.join(", ")}" }.join(", ")}"
         redirect_to edit_service_ordering_configuration_bundle_path(@service, @bundle)
       end

--- a/app/controllers/services/ordering_configuration/bundles/publishes_controller.rb
+++ b/app/controllers/services/ordering_configuration/bundles/publishes_controller.rb
@@ -9,7 +9,7 @@ module Services::OrderingConfiguration::Bundles
         redirect_to service_ordering_configuration_path(@service)
       else
         flash[:alert] =
-          "Bundle not published, errors: " +
+          "Bundle cannot be published. Please ensure your form is properly completed. " +
             "#{@bundle.errors.messages.each.map { |k, v| "The field #{k} #{v.join(", ")}" }.join(", ")}"
         redirect_to edit_service_ordering_configuration_bundle_path(@service, @bundle)
       end

--- a/app/controllers/services/ordering_configuration/offers/drafts_controller.rb
+++ b/app/controllers/services/ordering_configuration/offers/drafts_controller.rb
@@ -4,7 +4,7 @@ class Services::OrderingConfiguration::Offers::DraftsController < Services::Orde
   before_action :find_and_authorize
 
   def create
-    Offer::Draft.call(@offer)
+    Offer::Unpublish.call(@offer)
     redirect_to backoffice_service_path(@service)
   end
 

--- a/app/helpers/backoffice/services_helper.rb
+++ b/app/helpers/backoffice/services_helper.rb
@@ -11,17 +11,8 @@ module Backoffice::ServicesHelper
     "deleted" => "badge-error"
   }.freeze
 
-  #TODO: Remove this in PR adding suspended status and change name of status
-  STATUSES = {
-    "published" => "published",
-    "unverified" => "unverified",
-    "draft" => "unpublished",
-    "errored" => "errored",
-    "deleted" => "deleted"
-  }.freeze
-
   def service_status(service, additional_classes = nil)
-    content_tag(:span, STATUSES[service.status], class: "badge #{BADGES[service.status]} #{additional_classes}")
+    content_tag(:span, service.status, class: "badge #{BADGES[service.status]} #{additional_classes}")
   end
 
   def offers_status(service)

--- a/app/helpers/presentable/details_helper.rb
+++ b/app/helpers/presentable/details_helper.rb
@@ -55,7 +55,8 @@ module Presentable::DetailsHelper
       clazz: "public_contacts",
       nested: {
         email: "email"
-      }
+      },
+      active_when_suspended: true
     }
   end
 
@@ -76,16 +77,29 @@ module Presentable::DetailsHelper
         target_users: "name",
         access_types: "name",
         access_modes: "name"
-      }
+      },
+      active_when_suspended: false
     }
   end
 
   def availability
-    { name: "availability", template: "array", fields: %w[geographical_availabilities languages], with_desc: true }
+    {
+      name: "availability",
+      template: "array",
+      fields: %w[geographical_availabilities languages],
+      with_desc: true,
+      active_when_suspended: false
+    }
   end
 
   def marketing
-    { name: "marketing", template: "links", fields: %w[link_multimedia_urls link_use_cases_urls], type: "array" }
+    {
+      name: "marketing",
+      template: "links",
+      fields: %w[link_multimedia_urls link_use_cases_urls],
+      type: "array",
+      active_when_suspended: false
+    }
   end
 
   def dependencies
@@ -99,7 +113,8 @@ module Presentable::DetailsHelper
         related_services: "service",
         catalogue: "name",
         platforms: "name"
-      }
+      },
+      active_when_suspended: true
     }
   end
 
@@ -117,7 +132,8 @@ module Presentable::DetailsHelper
       nested: {
         funding_bodies: "name",
         funding_programs: "name"
-      }
+      },
+      active_when_suspended: false
     }
   end
 
@@ -130,7 +146,8 @@ module Presentable::DetailsHelper
         order_type: "label",
         order_url: "link"
       },
-      with_desc: true
+      with_desc: true,
+      active_when_suspended: true
     }
   end
 
@@ -143,7 +160,8 @@ module Presentable::DetailsHelper
       nested: {
         trls: "name",
         life_cycle_statuses: "name"
-      }
+      },
+      active_when_suspended: false
     }
   end
 
@@ -161,7 +179,8 @@ module Presentable::DetailsHelper
         status_monitoring_url
         maintenance_url
       ],
-      with_desc: true
+      with_desc: true,
+      active_when_suspended: false
     }
   end
 
@@ -212,7 +231,8 @@ module Presentable::DetailsHelper
       fields: %w[research_product_access_policies],
       nested: {
         research_product_access_policies: "name"
-      }
+      },
+      active_when_suspended: true
     }
   end
 
@@ -221,7 +241,8 @@ module Presentable::DetailsHelper
       name: "research_product_metadata_licensing",
       template: "links",
       fields: %w[link_research_product_metadata_license_urls],
-      type: "array"
+      type: "array",
+      active_when_suspended: true
     }
   end
   def research_product_metadata_access_policies
@@ -231,7 +252,8 @@ module Presentable::DetailsHelper
       fields: %w[research_product_metadata_access_policies],
       nested: {
         research_product_metadata_access_policies: "name"
-      }
+      },
+      active_when_suspended: false
     }
   end
 
@@ -352,9 +374,13 @@ module Presentable::DetailsHelper
     { name: "national_roadmaps", template: "list", fields: %w[national_roadmaps] }
   end
 
-  def monitoring_link(object)
-    link_to _("Show more details"),
-            "#{Mp::Application.config.monitoring_data_ui_url}/#{Mp::Application.config.monitoring_data_path}" +
-              "#{object.pid.to_s.partition(".").last}/details"
+  def monitoring_link(object, inactive)
+    if inactive
+      link_to _("Show more details")
+    else
+      link_to _("Show more details"),
+              "#{Mp::Application.config.monitoring_data_ui_url}/#{Mp::Application.config.monitoring_data_path}" +
+                "#{object.pid.to_s.partition(".").last}/details"
+    end
   end
 end

--- a/app/helpers/presentable/links_helper.rb
+++ b/app/helpers/presentable/links_helper.rb
@@ -38,6 +38,17 @@ module Presentable::LinksHelper
         terms_of_use_url
         access_policies_url
         maintenance_url
+      ],
+      active_when_suspended: %w[
+        webpage_url
+        helpdesk_url
+        helpdesk_email
+        manual_url
+        training_information_url
+        privacy_policy_url
+        terms_of_use_url
+        access_policies_url
+        maintenance_url
       ]
     }
   end

--- a/app/helpers/presentable/sidebar_helper.rb
+++ b/app/helpers/presentable/sidebar_helper.rb
@@ -36,11 +36,16 @@ module Presentable::SidebarHelper
   end
 
   def monitoring_data
-    { name: "uptime_monitoring", fields: %w[availability_cache reliability_cache], template: "monitoring" }
+    {
+      name: "uptime_monitoring",
+      fields: %w[availability_cache reliability_cache],
+      template: "monitoring",
+      active_when_suspended: false
+    }
   end
 
   def analytics
-    { name: "Statistics", fields: %w[analytics], template: "analytics" }
+    { name: "Statistics", fields: %w[analytics], template: "analytics", active_when_suspended: false }
   end
 
   def availability
@@ -48,7 +53,8 @@ module Presentable::SidebarHelper
       name: "availability_and_language",
       template: "map",
       fields: %w[geographical_availabilities languages],
-      with_desc: true
+      with_desc: true,
+      active_when_suspended: false
     }
   end
 

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -43,7 +43,7 @@ module SearchLinksHelper
     target = service.resource_organisation
     preview_options = preview ? { "data-preview-target": "link" } : {}
     link_to_unless(
-      target.deleted? || target.draft?,
+      target.deleted? || target.draft? || service.suspended?,
       highlighted_for(:resource_organisation_name, service, highlights),
       service.organisation_search_link(target.name, services_path(providers: target.id)),
       preview_options
@@ -61,12 +61,12 @@ module SearchLinksHelper
       .uniq
       .map do |target|
         if highlighted.present? && highlighted.strip == target.name.strip
-          link_to_unless target.deleted? || target.draft?,
+          link_to_unless target.deleted? || target.draft? || target.suspended?,
                          highlights[:provider_names].html_safe,
                          service.provider_search_link(target.name, services_path(providers: target.id)),
                          preview_options
         else
-          link_to_unless target.deleted? || target.draft?,
+          link_to_unless target.deleted? || target.draft? || target.suspended?,
                          target.name,
                          service.provider_search_link(target.name, services_path(providers: target.id)),
                          preview_options

--- a/app/javascript/stylesheets/_bootstrap-customizations.scss
+++ b/app/javascript/stylesheets/_bootstrap-customizations.scss
@@ -1,5 +1,10 @@
 @import 'variables';
 
+.suspended {
+  filter: grayscale(1);
+}
+
+
 body {
   font-size: $font-size-sm;
   margin-bottom: 0 !important;

--- a/app/jobs/catalogue/pc_create_or_update_job.rb
+++ b/app/jobs/catalogue/pc_create_or_update_job.rb
@@ -5,7 +5,7 @@ class Catalogue::PcCreateOrUpdateJob < ApplicationJob
 
   rescue_from(Errno::ECONNREFUSED) { |exception| raise exception }
 
-  def perform(catalogue, is_active, modified_at)
-    Catalogue::PcCreateOrUpdate.new(catalogue, is_active, modified_at).call
+  def perform(catalogue, status, modified_at)
+    Catalogue::PcCreateOrUpdate.new(catalogue, status, modified_at).call
   end
 end

--- a/app/jobs/provider/pc_create_or_update_job.rb
+++ b/app/jobs/provider/pc_create_or_update_job.rb
@@ -3,7 +3,7 @@
 class Provider::PcCreateOrUpdateJob < ApplicationJob
   queue_as :pc_subscriber
 
-  def perform(provider, is_active, modified_at)
-    Provider::PcCreateOrUpdate.call(provider, is_active, modified_at)
+  def perform(provider, status, modified_at)
+    Provider::PcCreateOrUpdate.call(provider, status, modified_at)
   end
 end

--- a/app/jobs/service/pc_create_or_update_job.rb
+++ b/app/jobs/service/pc_create_or_update_job.rb
@@ -5,7 +5,7 @@ class Service::PcCreateOrUpdateJob < ApplicationJob
 
   rescue_from(Errno::ECONNREFUSED) { |exception| raise exception }
 
-  def perform(infra_service, eosc_registry_base_url, is_active, modified_at, token = nil)
-    Service::PcCreateOrUpdate.new(infra_service, eosc_registry_base_url, is_active, modified_at, token).call
+  def perform(infra_service, eosc_registry_base_url, status, modified_at, token = nil)
+    Service::PcCreateOrUpdate.new(infra_service, eosc_registry_base_url, status, modified_at, token).call
   end
 end

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -3,14 +3,13 @@
 class Bundle < ApplicationRecord
   include Offerable
   include Viewable
+  include Statusable
 
   # include Offer::Parameters
 
   acts_as_taggable
 
   searchkick word_middle: %i[offer_name description], highlight: %i[offer_name description]
-
-  STATUSES = { published: "published", draft: "draft", deleted: "deleted" }.freeze
 
   counter_culture :service,
                   column_name: proc { |model| model.published? ? "bundles_count" : nil },
@@ -19,8 +18,6 @@ class Bundle < ApplicationRecord
                   }
 
   before_save :clear_training
-
-  enum status: STATUSES
 
   belongs_to :service, optional: false
   belongs_to :main_offer, class_name: "Offer", optional: false

--- a/app/models/concerns/importable.rb
+++ b/app/models/concerns/importable.rb
@@ -2,7 +2,8 @@
 
 module Importable
   def object_status(active, suspended)
-    active && !suspended ? :published : :draft
+    current = active ? :published : :unpublished
+    suspended && active ? :suspended : current
   end
 
   def map_alternative_identifier(identifier)

--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Statusable
+  extend ActiveSupport::Concern
+
+  included do
+    enum status: STATUSES
+
+    validates :status, presence: true, inclusion: { in: STATUSES.values }
+  end
+
+  STATUSES = {
+    published: "published",
+    unverified: "unverified",
+    suspended: "suspended",
+    unpublished: "unpublished",
+    draft: "draft",
+    errored: "errored",
+    deleted: "deleted"
+  }.freeze
+
+  PUBLIC_STATUSES = %w[published unverified errored].freeze
+  VISIBLE_STATUSES = %w[published unverified suspended errored].freeze
+end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -17,6 +17,8 @@ class Country
 
   ISO3166::Data.register(alpha2: "N/E", iso_short_name: "Non-European", translations: { "en" => "Non-European" })
 
+  ISO3166::Data.register(alpha2: "OT", iso_short_name: "Other", translations: { "en" => "Other" })
+
   ISO3166::Data.unregister("GB")
   ISO3166::Data.unregister("GR")
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -7,6 +7,7 @@ class Service < ApplicationRecord
   include Publishable
   include Presentable
   include Viewable
+  include Statusable
 
   extend FriendlyId
   friendly_id :name, use: :slugged
@@ -18,11 +19,10 @@ class Service < ApplicationRecord
 
   attr_accessor :catalogue_id, :monitoring_status, :bundle_id
 
-  PUBLIC_STATUSES = %w[published unverified errored].freeze
   SERVICE_TYPES = %w[Service Datasource].freeze
 
   scope :horizontal, -> { where(horizontal: true) }
-  scope :visible, -> { where(status: %i[published unverified]) }
+  scope :visible, -> { where(status: %i[published unverified suspended]) }
   scope :datasources, -> { where(type: "Datasource") }
 
   has_one_attached :logo
@@ -42,16 +42,6 @@ class Service < ApplicationRecord
          production: "production",
          retired: "retired"
        }
-
-  STATUSES = {
-    published: "published",
-    unverified: "unverified",
-    draft: "draft",
-    errored: "errored",
-    deleted: "deleted"
-  }.freeze
-
-  enum status: STATUSES
 
   has_many :service_alternative_identifiers
   has_many :alternative_identifiers, through: :service_alternative_identifiers
@@ -259,7 +249,6 @@ class Service < ApplicationRecord
               minimum: 1,
               message: "are required. Please add at least one"
             }
-  validates :status, presence: true
   validates :trls, length: { maximum: 1 }
   validates :life_cycle_statuses, length: { maximum: 1 }
   validates :geographical_availabilities,

--- a/app/policies/backoffice/bundle_policy.rb
+++ b/app/policies/backoffice/bundle_policy.rb
@@ -44,7 +44,7 @@ class Backoffice::BundlePolicy < ApplicationPolicy
   end
 
   def publish?
-    managed? && record.status == "draft"
+    managed? && (record.unpublished? || record.draft?)
   end
 
   def permitted_attributes

--- a/app/policies/backoffice/offer_policy.rb
+++ b/app/policies/backoffice/offer_policy.rb
@@ -36,7 +36,7 @@ class Backoffice::OfferPolicy < ApplicationPolicy
   end
 
   def publish?
-    managed? && record.persisted? && record.draft?
+    managed? && record.persisted? && (record.unpublished? || record.draft?)
   end
 
   def draft?

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -46,15 +46,23 @@ class Backoffice::ServicePolicy < ApplicationPolicy
   end
 
   def publish?
-    service_portfolio_manager? && (record.draft? || record.unverified?) && !record.deleted?
+    service_portfolio_manager? && !record.published? && !record.deleted?
   end
 
   def publish_unverified?
-    service_portfolio_manager? && (record.draft? || record.published?) && !record.deleted?
+    service_portfolio_manager? && !record.unverified? && !record.deleted?
+  end
+
+  def suspend?
+    service_portfolio_manager? && !record.suspended? && !record.deleted?
+  end
+
+  def unpublish?
+    service_portfolio_manager? && !record.unpublished? && !record.deleted?
   end
 
   def draft?
-    service_portfolio_manager? && (record.published? || record.unverified?) && !record.deleted?
+    service_portfolio_manager? && !record.draft? && !record.deleted?
   end
 
   def preview?

--- a/app/policies/bundle_policy.rb
+++ b/app/policies/bundle_policy.rb
@@ -5,7 +5,7 @@ class BundlePolicy < ApplicationPolicy
     def resolve
       scope
         .joins(:service)
-        .where("bundles.status = ? AND services.status IN (?)", "published", %w[published unverified])
+        .where("bundles.status = ? AND services.status IN (?)", "published", Statusable::VISIBLE_STATUSES)
     end
   end
 

--- a/app/policies/offer_policy.rb
+++ b/app/policies/offer_policy.rb
@@ -3,7 +3,9 @@
 class OfferPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.joins(:service).where("offers.status = ? AND services.status IN (?)", "published", %w[published unverified])
+      scope
+        .joins(:service)
+        .where("offers.status = ? AND services.status IN (?)", "published", Statusable::VISIBLE_STATUSES)
     end
   end
 

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -3,7 +3,7 @@
 class ServicePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.where(status: %i[published unverified errored])
+      scope.where(status: Statusable::VISIBLE_STATUSES)
     end
   end
 

--- a/app/services/bundle/application_service.rb
+++ b/app/services/bundle/application_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Bundle::ApplicationService < ApplicationService
+  def initialize(bundle)
+    super()
+    @bundle = bundle
+  end
+
+  private
+
+  def notify_bundled!
+    @bundle.offers&.each { |bundle_offer| Offer::Mailer::Bundled.call(bundle_offer, @bundle.main_offer) }
+  end
+
+  def notify_unbundled!
+    @bundle.offers&.each { |bundle_offer| Offer::Mailer::Unbundled.call(bundle_offer, @bundle.main_offer) }
+  end
+end

--- a/app/services/bundle/create.rb
+++ b/app/services/bundle/create.rb
@@ -1,23 +1,12 @@
 # frozen_string_literal: true
 
-class Bundle::Create < ApplicationService
-  def initialize(bundle)
-    super()
-    @bundle = bundle
-  end
-
+class Bundle::Create < Bundle::ApplicationService
   def call
     @bundle.order_type = @bundle.main_offer.order_type if @bundle.main_offer.present?
     if @bundle.save
-      notify_added_bundled_offers!
+      notify_bundled!
       @bundle.service.reindex
     end
     @bundle
-  end
-
-  private
-
-  def notify_added_bundled_offers!
-    @bundle&.offers&.each { |added_bundled_offer| Offer::Mailer::Bundled.call(added_bundled_offer, @bundle.main_offer) }
   end
 end

--- a/app/services/bundle/destroy.rb
+++ b/app/services/bundle/destroy.rb
@@ -1,24 +1,10 @@
 # frozen_string_literal: true
 
-class Bundle::Destroy < ApplicationService
-  def initialize(bundle)
-    super()
-    @bundle = bundle
-    @service = @bundle.service
-    @bundle_offers = @bundle.offers.to_a
-    @main_offer = @bundle.main_offer
-  end
-
+class Bundle::Destroy < Bundle::ApplicationService
   def call
     result = @bundle&.project_items.present? ? @bundle.update(status: :deleted) : @bundle.destroy
     notify_unbundled! if result
-    @service.reindex
+    @bundle.service.reindex
     result
-  end
-
-  private
-
-  def notify_unbundled!
-    @bundle_offers.each { |bundle_offer| Offer::Mailer::Unbundled.call(bundle_offer, @main_offer) }
   end
 end

--- a/app/services/bundle/draft.rb
+++ b/app/services/bundle/draft.rb
@@ -1,27 +1,19 @@
 # frozen_string_literal: true
 
-class Bundle::Draft < ApplicationService
+class Bundle::Draft < Bundle::ApplicationService
   def initialize(bundle, empty_offers: false)
-    super()
-    @bundle = bundle
+    super(bundle)
     @empty_offers = empty_offers
   end
 
   def call
     if @empty_offers
-      @bundle.status = "draft"
       @bundle.offers = []
-      @bundle.save!(validate: false)
     else
-      @bundle.update(status: :draft)
       notify_unbundled!
     end
+    @bundle.status = "draft"
+    @bundle.save!(validate: false)
     @bundle
-  end
-
-  private
-
-  def notify_unbundled!
-    @bundle.offers&.each { |bundle_offer| Offer::Mailer::Unbundled.call(bundle_offer, @bundle.main_offer) }
   end
 end

--- a/app/services/bundle/unpublish.rb
+++ b/app/services/bundle/unpublish.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class Bundle::Publish < Bundle::ApplicationService
+class Bundle::Unpublish < Bundle::ApplicationService
   def call
-    if @bundle.update(status: :published)
-      notify_bundled!
+    if @bundle.update(status: :unpublished)
+      notify_unbundled!
       @bundle.service.reindex
       @bundle.offers.reindex
     else

--- a/app/services/bundle/update.rb
+++ b/app/services/bundle/update.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-class Bundle::Update < ApplicationService
+class Bundle::Update < Bundle::ApplicationService
   def initialize(bundle, params, external_update: false)
-    super()
-    @bundle = bundle
+    super(bundle)
     @params = params
     @external_update = external_update
     @current_offer_ids = @params["offer_ids"] || @params["offers"]&.map(&:id) || []
@@ -15,7 +14,8 @@ class Bundle::Update < ApplicationService
     result = @bundle.update(@params)
     if @external_update
       notify_own_offer!
-      @bundle = Bundle::Draft.call(@bundle, empty_offers: @current_offer_ids.empty?)
+      @bundle =
+        @current_offer_ids.empty? ? Bundle::Draft.call(@bundle, empty_offers: true) : Bundle::Unpublish.call(@bundle)
     else
       public_before = @bundle.published?
       notify_bundled_offers! if result && public_before

--- a/app/services/catalogue/pc_create_or_update.rb
+++ b/app/services/catalogue/pc_create_or_update.rb
@@ -7,18 +7,19 @@ class Catalogue::PcCreateOrUpdate
   class NotUpdatedError < StandardError
   end
 
-  def initialize(eosc_registry_catalogue, is_active, modified_at)
+  def initialize(eosc_registry_catalogue, status, modified_at)
     @error_message = "Catalogue haven't been updated. Message #{eosc_registry_catalogue}"
-    @is_active = is_active
+    @status = status
     @source_type = "eosc_registry"
     @mp_catalogue = Catalogue.find_by(pid: eosc_registry_catalogue["id"])
     @catalogue_hash = Importers::Catalogue.new(eosc_registry_catalogue, modified_at).call
+    @catalogue_hash[:status] = @status
     @new_update_available = Catalogue::PcCreateOrUpdate.new_update_available(@mp_catalogue, modified_at)
     @logo = eosc_registry_catalogue["logo"]
   end
 
   def call
-    create_new = @mp_catalogue.nil? && @is_active
+    create_new = @mp_catalogue.nil? && @status == :published
     return Catalogue::PcCreateOrUpdate.create_catalogue(@catalogue_hash, @logo) if create_new
     return @mp_catalogue unless @new_update_available
 

--- a/app/services/offer/application_service.rb
+++ b/app/services/offer/application_service.rb
@@ -6,11 +6,13 @@ class Offer::ApplicationService < ApplicationService
     @offer = offer
     @service = @offer.service
     @bundles = @offer.bundles.to_a
+    @main_bundles = @offer.main_bundles.to_a
   end
 
   private
 
   def unbundle!
+    @main_bundles.each { |bundle| Bundle::Unpublish.call(bundle) }
     @bundles.each do |bundle|
       Bundle::Update.call(
         bundle,

--- a/app/services/offer/unpublish.rb
+++ b/app/services/offer/unpublish.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Offer::Unpublish < Offer::ApplicationService
+  def call
+    result = @offer.update(status: :unpublished)
+    unbundle!
+    result
+  end
+end

--- a/app/services/provider/pc_create_or_update.rb
+++ b/app/services/provider/pc_create_or_update.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Provider::PcCreateOrUpdate < ApplicationService
-  def initialize(eosc_registry_provider, is_active, modified_at)
+  def initialize(eosc_registry_provider, status, modified_at)
     super()
     @eosc_registry_provider = eosc_registry_provider
     @eid = eosc_registry_provider["id"]
-    @is_active = is_active
+    @status = status
     @modified_at = modified_at
   end
 
@@ -16,7 +16,7 @@ class Provider::PcCreateOrUpdate < ApplicationService
     if mapped_provider.nil?
       mapped_provider = Provider.new(provider_hash)
       mapped_provider.set_default_logo
-      mapped_provider.status = @is_active ? "published" : "draft"
+      mapped_provider.status = @status
       if mapped_provider.save!
         provider_source =
           ProviderSource.create!(provider_id: mapped_provider.id, source_type: "eosc_registry", eid: @eid)
@@ -24,7 +24,7 @@ class Provider::PcCreateOrUpdate < ApplicationService
     else
       mapped_provider.update(provider_hash)
       provider_source = mapped_provider.sources.find_by(source_type: "eosc_registry")
-      mapped_provider.status = @is_active ? "published" : "draft"
+      mapped_provider.status = @status
     end
     mapped_provider.update(upstream_id: provider_source.id) if provider_source.present?
 

--- a/app/services/service/application_service.rb
+++ b/app/services/service/application_service.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Service::ApplicationService < ApplicationService
+  def initialize(service)
+    super()
+    @service = service
+  end
+end

--- a/app/services/service/create.rb
+++ b/app/services/service/create.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-class Service::Create < ApplicationService
+class Service::Create < Service::ApplicationService
   def initialize(service, logo = nil)
-    super()
-    @service = service
+    super(service)
     @logo = logo
   end
 

--- a/app/services/service/delete.rb
+++ b/app/services/service/delete.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-class Service::Delete
+class Service::Delete < ApplicationService
   def initialize(service_eid, source: "eosc_registry")
+    super()
     @service =
       Service.joins(:sources).find_by("service_sources.source_type": source, "service_sources.eid": service_eid)
   end

--- a/app/services/service/destroy.rb
+++ b/app/services/service/destroy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-class Service::Destroy
-  def initialize(service)
-    @service = service
-  end
-
+class Service::Destroy < Service::ApplicationService
   def call
     @service.destroy
   end

--- a/app/services/service/pc_create_or_update.rb
+++ b/app/services/service/pc_create_or_update.rb
@@ -9,16 +9,17 @@ class Service::PcCreateOrUpdate
   class NotUpdatedError < StandardError
   end
 
-  def initialize(eosc_registry_service, eosc_registry_base_url, is_active, modified_at, token)
+  def initialize(eosc_registry_service, eosc_registry_base_url, status, modified_at, token)
     @error_message = "Service haven't been updated. Message #{eosc_registry_service}"
     @logo = eosc_registry_service["logo"]
-    @is_active = is_active
+    @status = status
+    @is_active = status == :published
     @source_type = "eosc_registry"
     @mp_service =
       Service
         .joins(:sources)
         .find_by("service_sources.source_type": @source_type, "service_sources.eid": [eosc_registry_service["id"]])
-    eosc_registry_service["status"] = @is_active ? "published" : "draft"
+    eosc_registry_service["status"] = @status
     @service_hash = Importers::Service.new(eosc_registry_service, modified_at, eosc_registry_base_url, token).call
     @new_update_available = Service::PcCreateOrUpdate.new_update_available(@mp_service, modified_at)
   end

--- a/app/services/service/publish.rb
+++ b/app/services/service/publish.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-class Service::Publish < ApplicationService
+class Service::Publish < Service::ApplicationService
   def initialize(service, verified: true)
-    super()
-    @service = service
-    @status = verified ? :published : :unverified
+    super(service)
+    @status = verified ? "published" : "unverified"
   end
 
   def call

--- a/app/services/service/suspend.rb
+++ b/app/services/service/suspend.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Service::Suspend < Service::ApplicationService
+  def call
+    public_before = @service.public?
+    result = @service.update!(status: :suspended)
+    unbundle_and_notify! if result && public_before
+    result
+  end
+
+  private
+
+  def unbundle_and_notify!
+    @service
+      .offers
+      .map { |o| [o, o.bundles] }
+      .each do |offer, bundles|
+        bundles.each do |bundle|
+          Bundle::Update.call(bundle, { offers: bundle.offers.to_a.reject { |o| o == offer } }, external_update: true)
+        end
+      end
+  end
+end

--- a/app/services/service/unpublish.rb
+++ b/app/services/service/unpublish.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-class Service::Draft < ApplicationService
-  def initialize(service)
-    super()
-    @service = service
-  end
-
+class Service::Unpublish < Service::ApplicationService
   def call
     public_before = @service.public?
-    result = @service.update!(status: :draft)
+    result = @service.update!(status: :unpublished)
     unbundle_and_notify! if result && public_before
     result
   end

--- a/app/services/service/update.rb
+++ b/app/services/service/update.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-class Service::Update < ApplicationService
+class Service::Update < Service::ApplicationService
   def initialize(service, params, logo = nil)
-    super()
-    @service = service
+    super(service)
     @params = params
     @logo = logo
   end

--- a/app/views/backoffice/providers/index.html.haml
+++ b/app/views/backoffice/providers/index.html.haml
@@ -31,5 +31,5 @@
                     edit_backoffice_provider_path(provider),
                     class: "btn-sm btn-warning float-right mr-4"
             %span.status{ class: provider.status }
-              = Backoffice::ServicesHelper::STATUSES[provider.status]
+              = provider.status
   = (pagy_bootstrap_nav @pagy).html_safe

--- a/app/views/backoffice/providers/show.html.haml
+++ b/app/views/backoffice/providers/show.html.haml
@@ -5,7 +5,7 @@
 .status-row
   %span Status:
   %span.font-weight-bold
-    = Backoffice::ServicesHelper::STATUSES[@provider.status]
+    = @provider.status
 
 .service-box.p-4.mt-3.backoffice-form
   .logo-wrapper

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -18,7 +18,7 @@
       .col-12.col-lg-4
         %span
           = _("Status") + ":"
-        %span.font-weight-bold= Backoffice::ServicesHelper::STATUSES[@service.status]
+        %span.font-weight-bold= @service.status
       .col-12.col-lg-8.service-buttons
         .btn-group.float-right
           - if policy([:backoffice, @service]).publish?
@@ -33,7 +33,13 @@
                       method: :post,
                       data: { confirm: _("Are you sure you want to publish this service as unverified service?") },
                       class: "btn btn-warning btn-sm"
-          - if policy([:backoffice, @service]).draft?
+          - if policy([:backoffice, @service]).suspend?
+            = link_to _("Suspend #{@service.type.downcase}"),
+                      backoffice_service_draft_path(@service, suspend: true),
+                      method: :post,
+                      data: { confirm: _("Are you sure you want to publish this service as unverified service?") },
+                      class: "btn btn-info btn-sm"
+          - if policy([:backoffice, @service]).unpublish?
             = link_to _("Stop showing in the MP"),
                       backoffice_service_draft_path(@service),
                       method: :post,

--- a/app/views/components/presentable/_explore_links.html.haml
+++ b/app/views/components/presentable/_explore_links.html.haml
@@ -1,7 +1,9 @@
+- href_explore = object.suspended? ? { class: "suspended" } : { href: eosc_explore_url(object.tag_list) }
 - if show_banner?(object.tag_list)
-  %a.right-panel-button.explore{ href: eosc_explore_url(object.tag_list) }
+  %a.right-panel-button.explore{ href_explore }
     Explore Compatible<br>
     Research Products
 - if object.respond_to?(:guidelines) && object.guidelines.present?
-  %a.right-panel-button.interoperability{ href: services_array_filter_link(object.guidelines, :title) }
+  - href_guidelines = object.suspended? ? href_explore : { href: services_array_filter_link(object.guidelines, :title) }
+  %a.right-panel-button.interoperability{ href_guidelines }
     Interoperability guidelines

--- a/app/views/components/presentable/header_component/_categorization.html.haml
+++ b/app/views/components/presentable/header_component/_categorization.html.haml
@@ -3,7 +3,8 @@
     %span
       = _("Organisation") + ":"
   %dd
-    .categorization-content= resource_organisation(service, highlights, preview: local_assigns[:preview])
+    .categorization-content= resource_organisation(service, highlights,
+      preview: local_assigns[:preview])
 - active_providers = providers(service, highlights, preview: local_assigns[:preview])
 - if active_providers.present?
   %dl.mb-0.d-flex

--- a/app/views/components/presentable/header_component/_order_buttons.html.haml
+++ b/app/views/components/presentable/header_component/_order_buttons.html.haml
@@ -1,4 +1,5 @@
-- if policy(service).order? || local_assigns[:preview]
+- if local_assigns[:preview] || policy(ServiceContext.new(service,
+  params.key?(:from) && params[:from] == "backoffice_service")).order?
   = link_to _("Access the service"),
                   service_offers_path(service),
                   class: "btn btn-primary d-block mb-3 py-3",

--- a/app/views/components/presentable/links_component/_links.html.haml
+++ b/app/views/components/presentable/links_component/_links.html.haml
@@ -6,6 +6,7 @@
           = mail_to(object.send(field), t("components.presentable.sidebar_component.fields.#{field}"), "data-probe": "",
             "data-preview-target": preview ? "link" : "")
         - else
-          = link_to(t("components.presentable.sidebar_component.fields.#{field}"), object.send(field), "data-probe": "",
+          = link_to(t("components.presentable.sidebar_component.fields.#{field}"),
+            object.suspended? && !field.in?(active_when_suspended) ? nil : object.send(field), "data-probe": "",
             "data-preview-target": preview ? "link" : "")
           -# TODO: refactor dynamic translation (above)

--- a/app/views/components/presentable/sidebar_component/_analytics.html.haml
+++ b/app/views/components/presentable/sidebar_component/_analytics.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   %li.list-group-item
     %span.text-sm-left
       = _("Catalog views") + ":"

--- a/app/views/components/presentable/sidebar_component/_array.html.haml
+++ b/app/views/components/presentable/sidebar_component/_array.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   - fields.each do |field|
     - if type == "tree"
       - field_tree(object, field).each do |parent, children|

--- a/app/views/components/presentable/sidebar_component/_classification.html.haml
+++ b/app/views/components/presentable/sidebar_component/_classification.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group.domains.mt-3.mb-4
+%ul.list-group.domains.mt-3.mb-4{ class: "#{"suspended" if inactive}" }
   - fields.map do |field|
     - if object.send(field).present?
       - field_tree(object, field).each do |parent, children|

--- a/app/views/components/presentable/sidebar_component/_date.html.haml
+++ b/app/views/components/presentable/sidebar_component/_date.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   - fields.each do |field|
     - if object.send(field).present?
       %li.list-group-item

--- a/app/views/components/presentable/sidebar_component/_filter.html.haml
+++ b/app/views/components/presentable/sidebar_component/_filter.html.haml
@@ -1,4 +1,4 @@
-.taglist-holder
+.taglist-holder{ class: "#{"suspended" if inactive}" }
   - fields.each do |field|
     - object.send(field).each do |element|
       .tag-item

--- a/app/views/components/presentable/sidebar_component/_links.html.haml
+++ b/app/views/components/presentable/sidebar_component/_links.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   - fields.each do |field|
     - if object.send(field).present?
       - object.send(field).each_with_index do |link, idx|

--- a/app/views/components/presentable/sidebar_component/_map.html.haml
+++ b/app/views/components/presentable/sidebar_component/_map.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   - fields.map do |field|
     - if object.send(field).present?
       %li{ class: ("links" if nested.present? && nested[field.to_sym] == "link") }
@@ -18,12 +18,12 @@
             %ul
               - get_only_regions(object.send(field)).each do |c|
                 %li
-                  = link_to c, services_geographical_availabilities_link(object, c),
+                  = link_to c, inactive ? "#" : services_geographical_availabilities_link(object, c),
                   "data-preview-target": local_assigns[:preview] ? "link" : ""
               - if get_only_countries(object.send(field)).present?
                 - get_only_countries(object.send(field)).each do |c|
                   %li.geographical
-                    = link_to c, services_geographical_availabilities_link(object, c),
+                    = link_to c, inactive ? "#" : services_geographical_availabilities_link(object, c),
                     "data-preview-target": local_assigns[:preview] ? "link" : ""
         - else
           %div{ id: t(".#{field}"), class: object.send(field).size > 1 ? "collapse" : nil }
@@ -32,7 +32,7 @@
                 - if nested.present? && nested[field.to_sym].present?
                   - if nested[field.to_sym] == "link"
                     %li.links
-                      = link_to field.humanize, element, "data-probe": "",
+                      = link_to field.humanize, inactive ? "#" : element, "data-probe": "",
                       "data-preview-target": local_assigns[:preview] ? "link" : ""
                       %i.fas.fa-arrow-right
                   - else

--- a/app/views/components/presentable/sidebar_component/_monitoring.html.haml
+++ b/app/views/components/presentable/sidebar_component/_monitoring.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group.uptime-list
+%ul.list-group.uptime-list{ class: "#{"suspended" if inactive}" }
   %li.list-group-item{ title: "The percentage of time that the service was working
   (with or without warnings) over a month (#{1.month.before.strftime("%B %Y")})" }
     %span
@@ -17,4 +17,4 @@
     %strong.status-info{ class: "#{monitoring_status_class(object&.monitoring_status)}" }
       .big-dot &#8226;
       = t("components.presentable.sidebar_component.fields.monitoring_data.#{object.monitoring_status}")
-  = monitoring_link(object)
+  = monitoring_link(object, inactive)

--- a/app/views/components/presentable/sidebar_component/_object.html.haml
+++ b/app/views/components/presentable/sidebar_component/_object.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   - Array(object.send(clazz)).map do |record|
     %li.list-group-item
       - fields.map do |field|

--- a/app/views/components/presentable/sidebar_component/_plain_text.html.haml
+++ b/app/views/components/presentable/sidebar_component/_plain_text.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   - fields.each do |field|
     - if object.send(field).present?
       %li.list-group-item

--- a/app/views/components/presentable/sidebar_component/_text.html.haml
+++ b/app/views/components/presentable/sidebar_component/_text.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   - fields.each do |field|
     - if object.send(field).present?
       %li.list-group-item

--- a/app/views/components/presentable/sidebar_component/_urls.html.haml
+++ b/app/views/components/presentable/sidebar_component/_urls.html.haml
@@ -1,4 +1,4 @@
-%ul.list-group
+%ul.list-group{ class: "#{"suspended" if inactive}" }
   - fields.each do |field|
     - if object.send(field).present?
       %li.list-group-item

--- a/app/views/services/_bundle.html.haml
+++ b/app/views/services/_bundle.html.haml
@@ -1,4 +1,4 @@
-.bundle-box
+.bundle-box{ class: "#{"suspended" if parent.service.suspended?}" }
   = render partial: "services/bundled_offer",
      collection: bundled_offers, as: :offer, parent: parent
 

--- a/app/views/services/_bundle_box.html.haml
+++ b/app/views/services/_bundle_box.html.haml
@@ -6,10 +6,11 @@
        contact_email: bundle.contact_email || "",
        related_training: bundle.related_training_url || "",
        helpdesk_url: bundle.helpdesk_url || ""
-    .card-button.text-center
-      %label
-        = link_to service_offers_path(bundle.service,
-              customizable_project_item: { offer_id: bundle.main_offer.iid, bundle_id: bundle.iid }),
-              "data-probe": "", "data-service-id": bundle.service.id, method: :put do
-          %span.btn.btn-primary
-            = _("Select bundle")
+    - if policy(ServiceContext.new(bundle.service, params.key?(:from) && params[:from] == "backoffice_service")).order?
+      .card-button.text-center
+        %label
+          = link_to service_offers_path(bundle.service,
+                customizable_project_item: { offer_id: bundle.main_offer.iid, bundle_id: bundle.iid }),
+                "data-probe": "", "data-service-id": bundle.service.id, method: :put do
+            %span.btn.btn-primary
+              = _("Select bundle")

--- a/app/views/services/_errors.html.haml
+++ b/app/views/services/_errors.html.haml
@@ -3,3 +3,7 @@
   .container
     .alert.alert-danger.mb-0.text-center
       = _("This datasource is not up to date because of invalid import data. Reason: #{error_reason}")
+- if service.suspended?
+  .container
+    .alert.alert-info.mb-0.text-left
+      = _("Service currently unavailable; some links may not be operational.")

--- a/app/views/services/_offer.html.haml
+++ b/app/views/services/_offer.html.haml
@@ -2,11 +2,12 @@
   .card.m-0.mb-5.w-100.d-block
     = render "services/offers/description", offer: offer
     = render "services/offers/parameters", id: offer.id,
-      technical_parameters: offer.attributes.map(&:to_json)
-    .card-button.text-center
-      %label.d-block
-        = link_to service_offers_path(offer.service, customizable_project_item: { offer_id: offer.iid }),
-        "data-probe": "", "data-service-id": offer.service.id, "data-e2e": "select-offer-btn",
-        "data-preview-target": local_assigns[:preview] ? "link" : "", method: :put do
-          %span.btn.btn-secondary.font-weight-bolder
-            = _("Select an offer")
+      technical_parameters: offer.attributes.map(&:to_json), service: offer.service
+    - if policy(ServiceContext.new(offer.service, params.key?(:from) && params[:from] == "backoffice_service")).order?
+      .card-button.text-center
+        %label.d-block
+          = link_to service_offers_path(offer.service, customizable_project_item: { offer_id: offer.iid }),
+          "data-probe": "", "data-service-id": offer.service.id, "data-e2e": "select-offer-btn",
+          "data-preview-target": local_assigns[:preview] ? "link" : "", method: :put do
+            %span.btn.btn-secondary.font-weight-bolder
+              = _("Select an offer")

--- a/app/views/services/_tabs.haml
+++ b/app/views/services/_tabs.haml
@@ -31,7 +31,9 @@
             data: { probe: "", "service-id": service.id, e2e: "service-details-btn",
             "shepherd-tour-target": "service-more-about" }
         %li.nav-item
-          = link_to _("Reviews (%{ssoc})") % { ssoc: service.service_opinion_count },
+          = link_to_unless service.suspended?, _("Reviews (%{ssoc})") % { ssoc: service.service_opinion_count },
             service_opinions_path(service, go_to_search_query_params(params)),
-            class: "nav-link #{"active" if controller.controller_name == "opinions"}", role: "tab",
-            data: { probe: "", "service-id": service.id, e2e: "service-reviews-btn" }
+            class: "nav-link #{"active" if controller.controller_name == "opinions"}",
+            role: "tab", data: { probe: "", "service-id": service.id, e2e: "service-reviews-btn" } do
+            %a.nav-link{ class: "#{"suspended" if service.suspended?}" }
+              = _("Reviews (%{ssoc})") % { ssoc: service.service_opinion_count }

--- a/app/views/services/bundles/_description.html.haml
+++ b/app/views/services/bundles/_description.html.haml
@@ -1,4 +1,4 @@
-.card-body
+.card-body{ class: "#{"suspended" if bundle.service.suspended?}" }
   %span.text-sm-right.fa-pull-right.badge-right
     %i{ class: "ordertype #{order_type(bundle)}" }
     = t("offers.type.#{order_type(bundle)}")

--- a/app/views/services/bundles/_offer.html.haml
+++ b/app/views/services/bundles/_offer.html.haml
@@ -20,10 +20,9 @@
           %article.mt-3
             %p
               = truncate(service.tagline, length: 1000, escape: false)
-          -# jeśli chcesz zmienić style w środku, to patrz jak się to zachowa w backoffice i na stronie serwisu
           .bundle-parameters-list
             = render "services/offers/parameters",
-              technical_parameters: offer.attributes.map(&:to_json)
+              technical_parameters: offer.attributes.map(&:to_json), service: offer.service
 
       .row.service-links
         .col-12.col-lg-12.row

--- a/app/views/services/details/index.html.haml
+++ b/app/views/services/details/index.html.haml
@@ -1,6 +1,7 @@
 - content_for :title, @service.name
 - breadcrumb :resource_details, @service
-.container{ "data-controller": "comparison" }
+= render "services/errors", service: @service
+.container{ class: "#{"suspended" if @service.suspended?}", "data-controller": "comparison" }
   - dynamic_class = params[:from] == "backoffice_service" ? "backoffice" : nil
   .pt-4.service-box-redesign.service-detail{ class: dynamic_class }
     = render Presentable::HeaderComponent.new(object: @service,
@@ -8,7 +9,7 @@
                         subtitle: @service.tagline,
                         abbreviation: @service.abbreviation,
                         comparison_enabled: @comparison_enabled,
-                        preview: local_assigns[:preview],
+                        preview: local_assigns[:preview] || @service.suspended?,
                         show_checkboxes: params[:from].blank?,
                         favourite_services: @favourite_services) do |c|
       - c.buttons do

--- a/app/views/services/offers/_offer.html.haml
+++ b/app/views/services/offers/_offer.html.haml
@@ -2,7 +2,7 @@
   .card.m-0.mb-5
     = render "services/offers/description", offer: offer
     = render "services/offers/parameters", id: offer.id,
-      technical_parameters: offer.attributes.map(&:to_json)
+      technical_parameters: offer.attributes.map(&:to_json), service: offer.service
 
     .card-button.text-center
       %label

--- a/app/views/services/offers/_parameters.html.haml
+++ b/app/views/services/offers/_parameters.html.haml
@@ -1,6 +1,6 @@
 - if technical_parameters.present?
   .card-body.pt-0.collapse-group.parameters-wrapper{ "data-controller": "parameter" }
-    %h5.text-uppercase.parameters-title.mb-3
+    %h5.text-uppercase.parameters-title.mb-3{ class: "#{"suspended" if service.suspended?}" }
       %i.fas.fa-tachometer-alt
       = _("Technical Parameters")
     %table.offer-params.table.table-hover

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -4,28 +4,31 @@
   _paq.push(['trackEvent', 'Service', 'Visit', '#{id}']);
 - breadcrumb :service, @service
 = render "services/errors", service: @service
-.container{ "data-controller": "comparison", "data-shepherd-tour-target": "overview_10" }
-  .pt-4.service-box-redesign.service-detail{ "data-shepherd-tour-target": "service-box" }
-    = render Presentable::HeaderComponent.new(object: @service,
-                          title: @service.name,
-                          abbreviation: @service.abbreviation,
-                          subtitle: @service.tagline,
-                          comparison_enabled: @comparison_enabled,
-                          preview: local_assigns[:preview],
-                          favourite_services: @favourite_services) do |c|
-      - c.buttons do
-        = render "components/presentable/header_component/order_buttons", service: @service
-    = render "services/tabs", service: @service
-  - dynamic_class = (session[:comparison]&.size || 0).positive? ? "d-block" : "d-none"
-  #comparison-bar.comparison-bar.fixed-bottom{ class: dynamic_class,
-    "data-comparison-target": "bar", "data-e2e": "comparison-bar" }
-    = render "comparisons/bar", services: @compare_services, category: @category
-.tab-content
-  = render Presentable::DescriptionComponent.new(object: @service,
-    similar_services: @similar_services, related_services: @related_services, question: @question) do |c|
-    - c.description_panels do
-      - if policy(@service).order? && (policy(@service).offers_show? || policy(@service).bundles_show?)
-        = render "services/offers", offers: @offers, service: @service,
-                                    bundles: @bundles, bundled: @bundled, preview: local_assigns[:preview]
+%div
+  .container{ class: "#{"suspended" if @service.suspended?}", "data-controller": "comparison",
+    "data-shepherd-tour-target": "overview_10" }
+    .pt-4.service-box-redesign.service-detail{ "data-shepherd-tour-target": "service-box" }
+      = render Presentable::HeaderComponent.new(object: @service,
+                            title: @service.name,
+                            abbreviation: @service.abbreviation,
+                            subtitle: @service.tagline,
+                            comparison_enabled: @comparison_enabled,
+                            preview: local_assigns[:preview] || @service.suspended?,
+                            favourite_services: @favourite_services) do |c|
+        - c.buttons do
+          = render "components/presentable/header_component/order_buttons", service: @service
+      = render "services/tabs", service: @service
+    - dynamic_class = (session[:comparison]&.size || 0).positive? ? "d-block" : "d-none"
+    #comparison-bar.comparison-bar.fixed-bottom{ class: dynamic_class,
+      "data-comparison-target": "bar", "data-e2e": "comparison-bar" }
+      = render "comparisons/bar", services: @compare_services, category: @category
+  .tab-content
+    = render Presentable::DescriptionComponent.new(object: @service,
+      similar_services: @similar_services, related_services: @related_services, question: @question) do |c|
+      - c.description_panels do
+        - if policy(@service).offers_show? || policy(@service).bundles_show?
+          = render "services/offers", offers: @offers, service: @service,
+                                      bundles: @bundles, bundled: @bundled,
+                                      preview: local_assigns[:preview] || @service.suspended?
 
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -184,6 +184,25 @@
       "note": ""
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "715ee6d743a8af33c7b930d728708ce19c765fb40e2ad9d2b974db04d92dc7d1",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 3.0.3 ends on 2024-03-31",
+      "file": ".ruby-version",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "76ddb05b9974791f865b25b27bda950d14f7a0770a8df1933835c854412f668e",
@@ -500,6 +519,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-01-21 13:43:48 +0100",
-  "brakeman_version": "6.1.1"
+  "updated": "2024-02-02 13:24:56 +0100",
+  "brakeman_version": "6.1.2"
 }

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -161,9 +161,11 @@ en:
           production: "Production (min. TRL 8)"
           retired: "Retired (n/a)"
         status:
-          draft: "Unpublished"
+          draft: "Unpublish"
+          unpublished: "Unpublished"
           published: "Published"
           unverified: "Published as unverified"
+          suspended: "Suspended"
           errored: "Errored"
           deleted: "Deleted"
     project_item:

--- a/lib/import/resources.rb
+++ b/lib/import/resources.rb
@@ -54,7 +54,7 @@ class Import::Resources
         synchronized_at = service_data["metadata"]["modifiedAt"].to_i
         image_url = service["logo"]
         service = Importers::Service.new(service, synchronized_at, @eosc_registry_base_url, @token, "rest").call
-        service["status"] = object_status(service_data["active"], service_data["suspended"])
+        service[:status] = object_status(service_data["service"]["active"], service_data["service"]["suspended"])
         if (service_source = ServiceSource.find_by(eid: service[:pid], source_type: "eosc_registry")).nil?
           created += 1
           log "Adding [NEW] service: #{service[:name]}, eid: #{service[:pid]}"

--- a/spec/factories/eosc_registry_services_response.rb
+++ b/spec/factories/eosc_registry_services_response.rb
@@ -17,6 +17,8 @@ FactoryBot.define do
         "results" => [
           {
             "service" => {
+              "active" => true,
+              "suspended" => false,
               "id" => "phenomenal.phenomenal",
               "webpage" => "https://portal.phenomenal-h2020.eu/home",
               "name" => "PhenoMeNal",

--- a/spec/factories/jms_catalogue_response.rb
+++ b/spec/factories/jms_catalogue_response.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
         "name" => name,
         "pid" => eid,
         "active" => true,
+        "suspended" => false,
         "logo" => "https://www.cyfronet.pl/zalacznik/8437",
         "users" => {
           "user" => {

--- a/spec/factories/jms_service.rb
+++ b/spec/factories/jms_service.rb
@@ -12,6 +12,8 @@ FactoryBot.define do
 
     initialize_with do
       next {
+        "active" => true,
+        "suspended" => false,
         "category" => "aggregator",
         "changeLog" => {
           "changeLog" => ["fixed bug"]

--- a/spec/factories/jms_xml_catalogue.rb
+++ b/spec/factories/jms_xml_catalogue.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
           "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" \
             "<tns:catalogueBundle xmlns:tns=\"http://einfracentral.eu\">" \
             "<tns:active>true</tns:active>" \
+            "<tns:suspended>false</tns:suspended>" \
             "<tns:metadata>" \
             "<tns:modifiedAt>1613193818577</tns:modifiedAt>" \
             "<tns:modifiedBy>Gaweł Porczyca</tns:modifiedBy>" \

--- a/spec/factories/jms_xml_provider.rb
+++ b/spec/factories/jms_xml_provider.rb
@@ -230,6 +230,7 @@ FactoryBot.define do
           "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" \
             "<tns:providerBundle xmlns:tns=\"http://einfracentral.eu\">" \
             "<tns:active>false</tns:active>" \
+            "<tns:suspended>false</tns:suspended>" \
             "<tns:latestOnboardingInfo>" \
             "<tns:actionType>rejected</tns:actionType>" \
             "</tns:latestOnboardingInfo>" \

--- a/spec/fixtures/files/eosc_registry_import_output.json
+++ b/spec/fixtures/files/eosc_registry_import_output.json
@@ -1,6 +1,8 @@
 [
   {
     "service": {
+      "active": true,
+      "suspended": false,
       "id": "phenomenal.phenomenal",
       "webpage": "https://portal.phenomenal-h2020.eu/home",
       "name": "PhenoMeNal",

--- a/spec/requests/backoffice/services_spec.rb
+++ b/spec/requests/backoffice/services_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe "Backoffice service", backend: true do
       expect(service).to be_published
     end
 
-    it "I can change service status to draft" do
+    it "I can change service status to unpublished" do
       service = create(:service, owners: [user])
 
       post backoffice_service_draft_path(service)
       service.reload
 
-      expect(service).to be_draft
+      expect(service).to be_unpublished
     end
 
     it "I can't publish a service with deleted status" do

--- a/spec/services/catalogue/pc_create_or_update_spec.rb
+++ b/spec/services/catalogue/pc_create_or_update_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Catalogue::PcCreateOrUpdate, backend: true do
   it "should create catalogue" do
     original_stdout = $stdout
     $stdout = StringIO.new
-    expect { described_class.new(published_catalogue_response, true, Time.now).call }.to change { Catalogue.count }.by(
-      1
-    )
+    expect { described_class.new(published_catalogue_response, :published, Time.now).call }.to change {
+      Catalogue.count
+    }.by(1)
 
     catalogue = Catalogue.last
 
@@ -30,7 +30,7 @@ RSpec.describe Catalogue::PcCreateOrUpdate, backend: true do
     expect do
       described_class.new(
         create(:jms_catalogue_response, eid: "tp", name: "Test Update Catalogue"),
-        true,
+        :published,
         Time.now.to_i
       ).call
     end.to change { Catalogue.count }.by(0)
@@ -48,7 +48,7 @@ RSpec.describe Catalogue::PcCreateOrUpdate, backend: true do
 
     original_stdout = $stdout
     $stdout = StringIO.new
-    expect { described_class.new(logoless_response, true, Time.now).call }.to change { Catalogue.count }.by(1)
+    expect { described_class.new(logoless_response, :published, Time.now).call }.to change { Catalogue.count }.by(1)
 
     catalogue = Catalogue.last
 

--- a/spec/services/jms/manage_message_spec.rb
+++ b/spec/services/jms/manage_message_spec.rb
@@ -43,7 +43,7 @@ describe Jms::ManageMessage, backend: true do
     expect(Service::PcCreateOrUpdateJob).to receive(:perform_later).with(
       resource["serviceBundle"]["service"],
       eosc_registry_base,
-      true,
+      :published,
       Time.at(resource["serviceBundle"]["metadata"]["modifiedAt"].to_i&./ 1000),
       nil
     )
@@ -59,7 +59,7 @@ describe Jms::ManageMessage, backend: true do
 
     expect(Provider::PcCreateOrUpdateJob).to receive(:perform_later).with(
       resource["providerBundle"]["provider"],
-      resource["providerBundle"]["active"],
+      :published,
       Time.at(resource["providerBundle"]["metadata"]["modifiedAt"].to_i&./ 1000)
     )
 
@@ -73,7 +73,7 @@ describe Jms::ManageMessage, backend: true do
     resource = parser.parse(provider_resource["resource"])
     expect(Provider::PcCreateOrUpdateJob).to receive(:perform_later).with(
       resource["providerBundle"]["provider"],
-      resource["providerBundle"]["active"],
+      :published,
       Time.at(resource["providerBundle"]["metadata"]["modifiedAt"].to_i&./ 1000)
     )
 
@@ -82,7 +82,7 @@ describe Jms::ManageMessage, backend: true do
     resource = parser.parse(draft_provider_resource["resource"])
     expect(Provider::PcCreateOrUpdateJob).to receive(:perform_later).with(
       resource["providerBundle"]["provider"],
-      resource["providerBundle"]["active"],
+      :unpublished,
       Time.at(resource["providerBundle"]["metadata"]["modifiedAt"].to_i&./ 1000)
     )
 
@@ -96,7 +96,7 @@ describe Jms::ManageMessage, backend: true do
     resource = parser.parse(rejected_provider_resource["resource"])
     expect(Provider::PcCreateOrUpdateJob).to receive(:perform_later).with(
       resource["providerBundle"]["provider"],
-      resource["providerBundle"]["active"],
+      :unpublished,
       Time.at(resource["providerBundle"]["metadata"]["modifiedAt"].to_i&./ 1000)
     )
 
@@ -146,7 +146,7 @@ describe Jms::ManageMessage, backend: true do
     resource = parser.parse(catalogue_resource["resource"])
     expect(Catalogue::PcCreateOrUpdateJob).to receive(:perform_later).with(
       resource["catalogueBundle"]["catalogue"],
-      resource["catalogueBundle"]["active"],
+      :published,
       Time.at(resource["catalogueBundle"]["metadata"]["modifiedAt"].to_i&./ 1000)
     )
 
@@ -160,7 +160,7 @@ describe Jms::ManageMessage, backend: true do
     resource = parser.parse(catalogue_resource["resource"])
     expect(Catalogue::PcCreateOrUpdateJob).to receive(:perform_later).with(
       resource["catalogueBundle"]["catalogue"],
-      resource["catalogueBundle"]["active"],
+      :published,
       Time.at(resource["catalogueBundle"]["metadata"]["modifiedAt"].to_i&./ 1000)
     )
 

--- a/spec/services/offer/unpublished_spec.rb
+++ b/spec/services/offer/unpublished_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Offer::Draft, backend: true do
+RSpec.describe Offer::Unpublish, backend: true do
   context "#bundled_offers" do
     it "doesn't send notification if no bundle offers" do
       drafted_offer = create(:offer)
@@ -28,15 +28,15 @@ RSpec.describe Offer::Draft, backend: true do
         expect(bundle.status).to eq("draft")
       end
 
-      it "doesn't allow to change to draft for main offer" do
-        expect { described_class.call(bundle_offer) }.to_not change { ActionMailer::Base.deliveries.count }
+      it "change to draft for main offer" do
+        expect { described_class.call(bundle_offer) }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
         bundle_offer.reload
         bundle.reload
 
         expect(bundle_offer.valid?).to be_truthy
-        expect(bundle_offer.status).to eq("published")
-        expect(bundle.status).to eq("published")
+        expect(bundle_offer.status).to eq("unpublished")
+        expect(bundle.status).to eq("unpublished")
       end
     end
   end

--- a/spec/services/provider/pc_create_or_update_spec.rb
+++ b/spec/services/provider/pc_create_or_update_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Provider::PcCreateOrUpdate, backend: true do
   it "should create provider with source and upstream is true" do
     original_stdout = $stdout
     $stdout = StringIO.new
-    expect { described_class.new(published_provider_response, true, Time.now).call }.to change { Provider.count }.by(1)
+    expect { described_class.new(published_provider_response, :published, Time.now).call }.to change { Provider.count }
+      .by(1)
 
     provider = Provider.last
 
@@ -24,7 +25,7 @@ RSpec.describe Provider::PcCreateOrUpdate, backend: true do
     $stdout = original_stdout
   end
 
-  it "should update provider when is_active is true" do
+  it "should update provider when it is active" do
     original_stdout = $stdout
     $stdout = StringIO.new
     provider =
@@ -37,7 +38,7 @@ RSpec.describe Provider::PcCreateOrUpdate, backend: true do
     expect do
       described_class.new(
         create(:jms_published_provider_response, eid: "new.provider", name: "Supper new name for updated  provider"),
-        true,
+        :published,
         Time.now.to_i
       ).call
     end.to change { Provider.count }.by(0)
@@ -52,7 +53,7 @@ RSpec.describe Provider::PcCreateOrUpdate, backend: true do
     $stdout = original_stdout
   end
 
-  it "should update provider when is_active is false" do
+  it "should update provider when it isn't active" do
     original_stdout = $stdout
     $stdout = StringIO.new
     provider =
@@ -65,7 +66,7 @@ RSpec.describe Provider::PcCreateOrUpdate, backend: true do
     expect do
       described_class.new(
         create(:jms_draft_provider_response, eid: "new.provider", name: "Supper new name for updated  provider"),
-        false,
+        :unpublished,
         Time.now.to_i
       ).call
     end.to change { Provider.count }.by(0)
@@ -76,14 +77,15 @@ RSpec.describe Provider::PcCreateOrUpdate, backend: true do
     expect(updated_provider.sources.length).to eq(1)
     expect(updated_provider.sources[0].eid).to eq("new.provider")
     expect(updated_provider.upstream_id).to eq(updated_provider.sources[0].id)
-    expect(updated_provider.draft?).to be_truthy
+    expect(updated_provider.unpublished?).to be_truthy
     $stdout = original_stdout
   end
 
-  it "should create provider with source and upstream and is_active is false" do
+  it "should create provider with source and upstream and it isn't active" do
     original_stdout = $stdout
     $stdout = StringIO.new
-    expect { described_class.new(draft_provider_response, false, Time.now).call }.to change { Provider.count }.by(1)
+    expect { described_class.new(draft_provider_response, :unpublished, Time.now).call }.to change { Provider.count }
+      .by(1)
 
     provider = Provider.last
 
@@ -91,7 +93,7 @@ RSpec.describe Provider::PcCreateOrUpdate, backend: true do
     expect(provider.sources.length).to eq(1)
     expect(provider.sources[0].eid).to eq("tp")
     expect(provider.upstream_id).to eq(provider.sources[0].id)
-    expect(provider.draft?).to be_truthy
+    expect(provider.unpublished?).to be_truthy
     $stdout = original_stdout
   end
 end

--- a/spec/services/service/pc_create_or_update_spec.rb
+++ b/spec/services/service/pc_create_or_update_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe Service::PcCreateOrUpdate, backend: true do
 
   private
 
-  def stub_described_class(jms_service, is_active: true, modified_at: Time.now)
-    described_service = Service::PcCreateOrUpdate.new(jms_service, test_url, is_active, modified_at, nil)
+  def stub_described_class(jms_service, status: :published, modified_at: Time.now)
+    described_service = Service::PcCreateOrUpdate.new(jms_service, test_url, status, modified_at, nil)
 
     stub_http_file(
       described_service,

--- a/spec/services/service/unpublish_spec.rb
+++ b/spec/services/service/unpublish_spec.rb
@@ -2,15 +2,15 @@
 
 require "rails_helper"
 
-RSpec.describe Service::Draft, backend: true do
+RSpec.describe Service::Unpublish, backend: true do
   it "draft service" do
     service = create(:service)
     offer = create(:offer, service: service)
     service.reload
     described_class.call(service)
 
-    expect(service.reload).to be_draft
-    expect(offer.reload).to_not be_draft
+    expect(service.reload).to be_unpublished
+    expect(offer.reload).to_not be_unpublished
   end
 
   context "#bundled_offers" do

--- a/test/system/cypress/e2e/regression_tests/backoffice/providers/providers.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/providers/providers.spec.ts
@@ -282,7 +282,7 @@ describe("Providers", () => {
     cy.get("[data-e2e='filter-tag']")
       .should("be.visible");
     cy.get("[data-e2e='service-id'] span")
-      .should("have.text", "unpublished")
+      .should("have.text", "draft")
     cy.get("[data-e2e='searchbar-input']")
       .type(providerStatusDraft);
     cy.get("[data-e2e='autocomplete-results'] li")

--- a/test/system/cypress/e2e/regression_tests/backoffice/resources/owned_resources.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/resources/owned_resources.spec.ts
@@ -52,7 +52,7 @@ describe("Owned services", () => {
       .should("be.visible") 
     cy.contains("a","Set parameters and offers")
       .should("be.visible")  
-    cy.contains("span", "unpublished")
+    cy.contains("span", "draft")
       .should("be.visible") 
     cy.get("[data-e2e='publish-btn']")
       .click();


### PR DESCRIPTION
Add entities's application services
Remove code duplication
Add `suspended` and `draft` statuses
Unify `statusable` logic

Closes https://github.com/cyfronet-fid/marketplace/issues/3115