### PR TITLE
feat:[#3201, #3212] Handle `suspended` status in importable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
-## [3.55.2-milestone]
+## [3.55.2] 2024-02-19
+
+### Added
+- Suspended view for providers and catalogues (@goreck888)
 
 ### Fixed
 - Minor style and design fixes (@jarekzet, @goreck888)

--- a/app/views/catalogues/show.html.haml
+++ b/app/views/catalogues/show.html.haml
@@ -1,7 +1,7 @@
 -# haml-lint:disable InlineStyles
 - breadcrumb :catalogue, @catalogue
 
-.container
+.container{ class: "#{"suspended" if @catalogue.suspended?}" }
   .pt-4.service-box-redesign.service-detail
     .row.space-between
       .col-12.col-lg-9.row
@@ -159,6 +159,4 @@
       %sidebar.col-12.col-xl-3
         - if @catalogue.website
           = link_to "Website", @catalogue.website, target: "_blank", class: "right-panel-button website"
-
-
 -# haml-lint:enable InlineStyles

--- a/app/views/components/presentable/header_component/_provider_buttons.html.haml
+++ b/app/views/components/presentable/header_component/_provider_buttons.html.haml
@@ -1,11 +1,12 @@
-- if external_search_enabled
-  = link_to _("Show all resources"),
-            ess_providers_resources_link(provider),
-            class: "btn btn-primary d-block mb-3"
-- else
-  = link_to _("Browse services"),
-            services_path(providers: provider.id),
-            class: "btn btn-primary d-block mb-3 py-3", "data-e2e": "btn-browse-service"
+- unless provider.suspended?
+  - if external_search_enabled
+    = link_to _("Show all resources"),
+              ess_providers_resources_link(provider),
+              class: "btn btn-primary d-block mb-3"
+  - else
+    = link_to _("Browse services"),
+              services_path(providers: provider.id),
+              class: "btn btn-primary d-block mb-3 py-3", "data-e2e": "btn-browse-service"
 
-- if user_signed_in? && show_manage_button?(provider)
-  = render "components/presentable/header_component/provider_drop_down_menu", provider: provider
+  - if user_signed_in? && show_manage_button?(provider)
+    = render "components/presentable/header_component/provider_drop_down_menu", provider: provider

--- a/app/views/providers/details/index.html.haml
+++ b/app/views/providers/details/index.html.haml
@@ -1,15 +1,17 @@
 - content_for :title, @provider.name
 - breadcrumb :provider, @provider
-.container
+.container{ class: "#{"suspended" if @provider.suspended?}" }
   .pt-4.service-box-redesign.service-detail
     = render Presentable::HeaderComponent.new(object: @provider,
                           title: @provider.abbreviation,
                           subtitle: @provider.name,
                           comparison_enabled: @comparison_enabled,
-                          preview: local_assigns[:preview]) do |c|
+                          preview: @provider.suspended? || local_assigns[:preview]) do |c|
       - c.buttons do
         = render "components/presentable/header_component/provider_buttons", provider: @provider
     = render "providers/tabs", provider: @provider
 
-.tab-content.provider-view
-  = render Presentable::DetailsComponent.new(@provider, question: @question)
+.tab-content.provider-view{ class: "#{"suspended" if @provider.suspended?}" }
+  = render Presentable::DetailsComponent.new(@provider,
+           question: @question,
+           preview: @provider.suspended? || local_assigns[:preview])

--- a/app/views/providers/show.html.haml
+++ b/app/views/providers/show.html.haml
@@ -1,20 +1,21 @@
 - content_for :title, @provider.name
 - breadcrumb :provider, @provider
-.container
+.container{ class: "#{"suspended" if @provider.suspended?}" }
   .pt-4.service-box-redesign.service-detail
     = render Presentable::HeaderComponent.new(object: @provider,
                           title: @provider.abbreviation,
                           subtitle: @provider.name,
                           comparison_enabled: @comparison_enabled,
-                          preview: local_assigns[:preview]) do |c|
+                          preview: @provider.suspended? || local_assigns[:preview]) do |c|
       - c.buttons do
         = render "components/presentable/header_component/provider_buttons", provider: @provider
 
     = render "providers/tabs", provider: @provider
 
-.tab-content.provider-view
-  = render Presentable::DescriptionComponent.new(object: @provider, question: @question) do |c|
+.tab-content.provider-view{ class: "#{"suspended" if @provider.suspended?}" }
+  = render Presentable::DescriptionComponent.new(object: @provider,
+                        question: @question,
+                        preview: @provider.suspended? || local_assigns[:preview]) do |c|
     - c.description_panels do
       = render "providers/related", provider: @provider, related_services: @related_services
-  -# = render "providers/about", provider: @provider, related_services: @related_services
   = render "taggable/details_section", taggable: @provider

--- a/spec/features/ordering_configuration_spec.rb
+++ b/spec/features/ordering_configuration_spec.rb
@@ -180,7 +180,7 @@ RSpec.feature "Services in ordering_configuration panel", end_user_frontend: tru
       service.reload
 
       visit service_ordering_configuration_path(service, from: "backoffice_service")
-      page.save_page
+
       first(".btn.btn-outline-secondary.font-weight-bold").click
 
       check "Use EOSC Portal as the order management platform"


### PR DESCRIPTION
Add `suspended` grey view for `Provider`
and `Catalogue`

Closes
- #3201
- #3212
