### PR TITLE
feat:[]Add logos endpoint for catalogues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
+## [3.55.3] 2024-02-21
+
+### Added
+- Logos endpoint for catalogues (@goreck888)
+
 ## [3.55.2] 2024-02-19
-- Add Catalogues to Backoffice (@wujuu)
+
+### Added
+- Catalogues to the Backoffice (@wujuu)
 
 ## [3.55.2] 2024-02-19
 

--- a/app/controllers/catalogues/logos_controller.rb
+++ b/app/controllers/catalogues/logos_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Catalogues::LogosController < ApplicationController
+  def show
+    @catalogue = Catalogue.with_attached_logo.friendly.find(params[:catalogue_id])
+    authorize(@catalogue)
+    if @catalogue.logo.attached? && @catalogue.logo.variable?
+      redirect_to @catalogue.logo.variant(resize: "84x84"), allow_other_host: false
+    else
+      redirect_to ImageHelper::DEFAULT_LOGO_PATH
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,11 @@ Rails.application.routes.draw do
   get "services/c/:category_id" => "services#index", :as => :category_services
   resources :categories, only: :show
 
-  resources :catalogues, only: %i[index show]
+  resources :catalogues, only: %i[index show] do
+    scope module: :catalogues do
+      resource :logo, only: :show
+    end
+  end
 
   resource :reports, only: %i[new create], constraints: lambda { |req| req.format == :js }
 


### PR DESCRIPTION
Logo for catalogue is available under /catalogues/:id/logo