### PR TITLE
fix:[#3391] Change default link to the explore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Please view this file on the master branch, on stable branches it's out of date.
 
+## [3.58.1] 2025-03-04
+
+### Changed
+- Default link to the Explore service (@goreck888)
+
+
 ## [3.58.0] 2025-01-22
 
 ### Added

--- a/config/eosc_explore_banner.yml
+++ b/config/eosc_explore_banner.yml
@@ -1,6 +1,6 @@
 default: &default
   tags: <%= ENV["EOSC_EXPLORE_TAGS"]&.split(",") || ["EOSC::Jupyter Notebook", "EOSC::Galaxy Workflow", "EOSC::Twitter Data"] %>
-  base_url: <%= ENV["EOSC_EXPLORE_BASE_URL"] || "https://beta.search.marketplace.eosc-portal.eu/" %>
+  base_url: <%= ENV["EOSC_EXPLORE_BASE_URL"] || "https://explore.sandbox.eosc-beyond.eu/" %>
   search_url: <%= ENV["EOSC_EXPLORE_SEARCH_URL"] || "\"search/all_collection?q=*&fq=eosc_if:\"" %>
   datasource_search_url: <%= ENV["EOSC_EXPLORE_DATASOURCE_SEARCH_URL"] || "\"search/all_collection?q=*&fq=datasource_pids:\"" %>
 


### PR DESCRIPTION
Change default link to
`https://explore.sandbox.eosc-beyond.eu/`

Closes #3391