### PR TITLE
fix: [#3415] removal of FAQ link on LP

### DIFF
--- a/app/views/pages/landing_page.html.haml
+++ b/app/views/pages/landing_page.html.haml
@@ -195,7 +195,6 @@
           issues while using the website or<br>
           have any other suggestions that<br>
           we should know about.
-        %a.blue-link{ href: "https://eosc-portal.eu/about/faqs" } Frequently Asked Questions >
       .col-md-2.col-sm-12
       .col-md-5.col-sm-12.contact-form
         %button{ id: "zammad-feedback-form" }


### PR DESCRIPTION
closes: #3415 

![image](https://github.com/user-attachments/assets/8597b306-15b1-41a2-8dee-5310ffc53b6b)
