### PR TITLE
feat: Add polymorphic orderable association and infrastructure tracking

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -p $PORT
-jobs: bundle exec sidekiq -q active_storage_analysis -q active_storage_purge -q pc_subscriber -q orders -q mailers -q reports -q probes -q default -q pc_publisher -q ess_update
+jobs: bundle exec sidekiq -q active_storage_analysis -q active_storage_purge -q pc_subscriber -q orders -q mailers -q reports -q probes -q default -q pc_publisher -q ess_update -q deployments

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,4 +2,4 @@ web: bundle exec rails s
 js: yarn build --watch
 css: yarn build:css --watch
 
-jobs: bundle exec sidekiq -q active_storage_analysis -q active_storage_purge -q pc_subscriber -q orders -q mailers -q reports -q probes -q default -q pc_publisher -q ess_update
+jobs: bundle exec sidekiq -q active_storage_analysis -q active_storage_purge -q pc_subscriber -q orders -q mailers -q reports -q probes -q default -q pc_publisher -q ess_update -q deployments

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -100,8 +100,9 @@ class HomeController < ApplicationController
   def load_opinion
     @opinion =
       ServiceOpinion
-        .joins(project_item: { offer: :service })
-        .where(project_item: { offer: { services: { status: %i[published errored] } } })
+        .joins(project_item: :offer)
+        .joins(Offer::JOIN_SERVICE_SQL)
+        .where(services: { status: %i[published errored] })
         .sample
   end
 end

--- a/app/controllers/project_items_controller.rb
+++ b/app/controllers/project_items_controller.rb
@@ -4,7 +4,7 @@ class ProjectItemsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @project_item = ProjectItem.joins(offer: :service, project: :user).find(params[:id])
+    @project_item = ProjectItem.joins(:offer, project: :user).find(params[:id])
 
     authorize(@project_item)
 

--- a/app/controllers/projects/services/infrastructures_controller.rb
+++ b/app/controllers/projects/services/infrastructures_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Projects::Services::InfrastructuresController < ApplicationController
+  include Project::Authorize
+
+  def destroy
+    @project_item = @project.project_items.joins(project: :user).find_by!(iid: params[:service_id])
+
+    authorize(@project_item, :destroy_infrastructure?)
+
+    infrastructure = @project_item.infrastructure
+
+    if infrastructure&.can_destroy?
+      Infrastructure::DestroyJob.perform_later(infrastructure.id)
+      flash[:notice] = _("Infrastructure destruction has been initiated. This may take a few minutes.")
+    else
+      flash[:alert] = _("Infrastructure cannot be destroyed at this time.")
+    end
+
+    redirect_to project_service_path(@project, @project_item)
+  end
+end

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -33,11 +33,14 @@ class Projects::ServicesController < ApplicationController
 
   def sample_recommended_offers
     if @project_items.present?
-      domains = @project.scientific_domains.presence || @project_items.first.service.scientific_domains
+      domains = @project.scientific_domains.presence || @project_items.first.service&.scientific_domains
+
+      return Offer.all.sample(2) if domains.blank?
 
       Offer
-        .joins(service: :scientific_domains)
-        .where(scientific_domains: { id: domains.map(&:id) })
+        .join_service
+        .joins("INNER JOIN service_scientific_domains ON service_scientific_domains.service_id = services.id")
+        .where(service_scientific_domains: { scientific_domain_id: domains.map(&:id) })
         .distinct
         .sample(2)
         .presence || Offer.all.sample(2)

--- a/app/controllers/services/offers_controller.rb
+++ b/app/controllers/services/offers_controller.rb
@@ -23,7 +23,8 @@ class Services::OffersController < ApplicationController
     @similar_services = fetch_similar(@service.id, current_user&.id)
     @related_services = @service.related_services
 
-    @service_opinions = ServiceOpinion.joins(project_item: :offer).where(offers: { service_id: @service })
+    @service_opinions =
+      ServiceOpinion.joins(project_item: :offer).where(offers: { orderable_type: "Service", orderable_id: @service.id })
     @question = Service::Question.new(service: @service)
     @favourite_services =
       current_user&.favourite_services || Service.where(slug: Array(cookies[:favourites]&.split("&") || []))

--- a/app/controllers/services/opinions_controller.rb
+++ b/app/controllers/services/opinions_controller.rb
@@ -24,7 +24,7 @@ class Services::OpinionsController < ApplicationController
     @service_opinions =
       ServiceOpinion
         .includes(project_item: :offer)
-        .where(offers: { service_id: @service })
+        .where(offers: { orderable_type: "Service", orderable_id: @service.id })
         .includes(project_item: :project)
     @question = Service::Question.new(service: @service)
     @favourite_services =

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -64,7 +64,8 @@ class ServicesController < ApplicationController
     @similar_services = fetch_similar(@service.id, current_user&.id)
     @related_services = @service.related_services
 
-    @service_opinions = ServiceOpinion.joins(project_item: :offer).where(offers: { service_id: @service })
+    @service_opinions =
+      ServiceOpinion.joins(project_item: :offer).where(offers: { orderable_type: "Service", orderable_id: @service.id })
     @question = Service::Question.new(service: @service)
     @favourite_services =
       current_user&.favourite_services || Service.where(slug: Array(cookies[:favourites]&.split("&") || []))

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -42,10 +42,10 @@ module FormsHelper
   def other_offers(service)
     offer_ids = service.offers.map(&:id)
     Offer
-      .includes(:service)
       .accessible
+      .includes(:orderable)
       .reject { |item| item.id.in? offer_ids }
-      .map { |item| ["#{item.service.name} > #{item.name}", item.id] }
+      .map { |item| ["#{item.parent_service&.name} > #{item.name}", item.id] }
   end
 
   def render_data_administrator(form, object)

--- a/app/jobs/infrastructure/destroy_job.rb
+++ b/app/jobs/infrastructure/destroy_job.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Infrastructure::DestroyJob < ApplicationJob
+  queue_as :default
+
+  def perform(infrastructure_id)
+    infrastructure = Infrastructure.find_by(id: infrastructure_id)
+    return unless infrastructure&.can_destroy?
+
+    Rails.logger.info "Destroying Infrastructure #{infrastructure.id} (IM ID: #{infrastructure.im_infrastructure_id})"
+
+    im_client = InfrastructureManager::Client.new
+    result = im_client.destroy_infrastructure(infrastructure.im_infrastructure_id)
+
+    if result[:success]
+      infrastructure.mark_destroyed!
+      update_project_item_status(infrastructure, :destroyed)
+      Rails.logger.info "Infrastructure #{infrastructure.id} destroyed successfully"
+    else
+      error_message = result[:error] || "Unknown error"
+      Rails.logger.error "Failed to destroy Infrastructure #{infrastructure.id}: #{error_message}"
+      infrastructure.mark_failed!("Destroy failed: #{error_message}")
+      update_project_item_status(infrastructure, :failed, error_message)
+    end
+  rescue StandardError => e
+    Rails.logger.error "Destroy job failed for Infrastructure #{infrastructure_id}: #{e.class}: #{e.message}"
+    infrastructure&.mark_failed!(e.message)
+  end
+
+  private
+
+  def update_project_item_status(infrastructure, status, error_message = nil)
+    project_item = infrastructure.project_item
+
+    case status
+    when :destroyed
+      project_item.update!(status: "Infrastructure has been destroyed", status_type: :closed)
+    when :failed
+      project_item.update!(status: "Failed to destroy infrastructure: #{error_message}", status_type: :rejected)
+    end
+  end
+end

--- a/app/jobs/infrastructure/state_polling_job.rb
+++ b/app/jobs/infrastructure/state_polling_job.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Infrastructure::StatePollingJob < ApplicationJob
+  queue_as :default
+
+  # Poll all active infrastructures that need state updates
+  def perform(infrastructure_id = nil)
+    infrastructure_id ? poll_single(infrastructure_id) : poll_all_pending
+  end
+
+  private
+
+  def poll_single(infrastructure_id)
+    infrastructure = Infrastructure.find_by(id: infrastructure_id)
+    return unless infrastructure&.im_infrastructure_id.present?
+    return if infrastructure.destroyed? || infrastructure.failed?
+
+    update_infrastructure_state(infrastructure)
+  end
+
+  def poll_all_pending
+    Infrastructure.pending_state_check.find_each do |infrastructure|
+      next unless infrastructure.im_infrastructure_id.present?
+
+      update_infrastructure_state(infrastructure)
+    rescue StandardError => e
+      Rails.logger.error "Failed to poll Infrastructure #{infrastructure.id}: #{e.message}"
+      infrastructure.update_columns(last_state_check_at: Time.current)
+    end
+  end
+
+  def update_infrastructure_state(infrastructure)
+    im_client = InfrastructureManager::Client.new
+    result = im_client.get_state(infrastructure.im_infrastructure_id)
+
+    if result[:success]
+      im_state = result[:data]&.dig("state")
+      infrastructure.update_state_from_im!(im_state)
+
+      # If running, also fetch outputs
+      fetch_outputs(infrastructure, im_client) if infrastructure.running?
+    else
+      Rails.logger.warn "Could not get state for Infrastructure #{infrastructure.id}: #{result[:error]}"
+      infrastructure.update_columns(last_state_check_at: Time.current)
+    end
+  end
+
+  def fetch_outputs(infrastructure, im_client)
+    return if infrastructure.outputs.present? && infrastructure.outputs["jupyterhub_url"].present?
+
+    result = im_client.get_outputs(infrastructure.im_infrastructure_id)
+    return unless result[:success] && result[:data]
+
+    outputs = result[:data]["outputs"] || {}
+    infrastructure.update_columns(outputs: outputs) if outputs.present?
+
+    # Update project_item deployment_link if we got a better URL
+    update_project_item_link(infrastructure, outputs)
+  end
+
+  def update_project_item_link(infrastructure, outputs)
+    jupyterhub_url = outputs["jupyterhub_url"]
+    return unless jupyterhub_url.present?
+
+    project_item = infrastructure.project_item
+    return if project_item.deployment_link == jupyterhub_url
+
+    project_item.update!(deployment_link: jupyterhub_url, status: "Deployment ready at #{jupyterhub_url}")
+  end
+end

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -116,10 +116,13 @@ class Bundle < ApplicationRecord
   end
 
   def offers_correct
-    if offers.includes(:service).present?
+    if offers.present?
       errors.add(:offers, "cannot bundle main offer") if offers.include?(main_offer)
       errors.add(:offers, "must have only published offers selected") unless offers.all?(&:published?)
-      errors.add(:offers, "must have offers with public services selected") unless offers.map(&:service).all?(&:public?)
+      # Use parent_service to support both Service and DeployableService offers
+      unless offers.all? { |o| o.parent_service&.public? }
+        errors.add(:offers, "must have offers with public services selected")
+      end
     end
   end
 

--- a/app/models/concerns/orderable_resource.rb
+++ b/app/models/concerns/orderable_resource.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Shared interface for orderable resources (Service, DeployableService)
+# This concern defines the contract that both types must implement
+# for the ordering wizard, views, and offer associations to work correctly.
+module OrderableResource
+  extend ActiveSupport::Concern
+
+  REQUIRED_METHODS = %i[
+    name
+    description
+    tagline
+    slug
+    status
+    order_type
+    offers
+    bundles
+    bundles_count
+    offers_count
+    resource_organisation
+    owned_by?
+  ].freeze
+
+  included do
+    # Common scopes
+    scope :visible, -> { where(status: Statusable::VISIBLE_STATUSES) }
+    scope :active, -> { where(status: Statusable::PUBLIC_STATUSES) }
+  end
+
+  # Shared implementations
+  def offers?
+    offers_count.positive?
+  end
+
+  def bundles?
+    bundles_count.positive?
+  end
+
+  def suspended?
+    status == "suspended"
+  end
+
+  def deleted?
+    status == "deleted"
+  end
+
+  def draft?
+    status == "draft"
+  end
+
+  def published?
+    status == "published"
+  end
+
+  def organisation_search_link(target, default_path = nil)
+    _orderable_search_link(target, "resource_organisation", default_path)
+  end
+
+  def node_search_link(target, default_path = nil)
+    _orderable_search_link(target, "node", default_path)
+  end
+
+  def provider_search_link(target, default_path = nil)
+    _orderable_search_link(target, "providers", default_path)
+  end
+
+  private
+
+  def _orderable_search_link(target_name, filter_query, default_path = nil)
+    search_base_url = Mp::Application.config.search_service_base_url
+    enable_external_search = Mp::Application.config.enable_external_search
+
+    if enable_external_search
+      "#{search_base_url}/search/service?q=*&fq=#{filter_query}:(%22#{target_name}%22)"
+    else
+      default_path
+    end
+  end
+end

--- a/app/models/deployable_service.rb
+++ b/app/models/deployable_service.rb
@@ -3,6 +3,7 @@
 class DeployableService < ApplicationRecord
   include Rails.application.routes.url_helpers
   include LogoAttachable
+  include OrderableResource
   include Publishable
   include Statusable
   include Viewable
@@ -20,7 +21,7 @@ class DeployableService < ApplicationRecord
   has_many :sources, class_name: "DeployableServiceSource", dependent: :destroy
   has_many :deployable_service_scientific_domains, dependent: :destroy
   has_many :scientific_domains, through: :deployable_service_scientific_domains
-  has_many :offers, dependent: :destroy
+  has_many :offers, as: :orderable, dependent: :destroy
 
   belongs_to :upstream, foreign_key: "upstream_id", class_name: "DeployableServiceSource", optional: true
   belongs_to :resource_organisation, class_name: "Provider", optional: false
@@ -56,8 +57,11 @@ class DeployableService < ApplicationRecord
     url&.include?("jupyterhub_datamount.yml") || name&.downcase&.include?("jupyterhub")
   end
 
-  # AGGRESSIVE Duck-typing methods for full Service wizard compatibility
-  # Core counts and checks
+  # ============================================================================
+  # OrderableResource interface implementation
+  # ============================================================================
+
+  # Counts
   def bundles_count
     0
   end
@@ -66,36 +70,12 @@ class DeployableService < ApplicationRecord
     offers.count
   end
 
-  def project_items_count
-    offers.sum(&:project_items_count)
-  end
-
-  def service_opinion_count
-    0
-  end
-
-  def bundles?
-    false
-  end
-
-  def offers?
-    offers.any?
-  end
-
-  # Collections - return empty relations that respond to Service methods
+  # Collections
   def bundles
     Bundle.none
   end
 
-  def project_items
-    ProjectItem.joins(:offer).where(offers: { deployable_service_id: id })
-  end
-
-  def service_opinions
-    ServiceOpinion.joins(project_item: :offer).where(offers: { deployable_service_id: id })
-  end
-
-  # Ownership and access
+  # Ownership - checks resource_organisation and catalogue data administrators
   def owned_by?(user)
     return false if user.blank?
 
@@ -103,18 +83,14 @@ class DeployableService < ApplicationRecord
       (catalogue.present? && catalogue.data_administrators&.map(&:user_id)&.include?(user.id))
   end
 
-  # Service-specific attributes
+  # Order type - DeployableServices always require ordering
   def order_type
     "order_required"
   end
 
-  def type
-    "DeployableService"
-  end
-
-  def webpage_url
-    url # Use our URL field
-  end
+  # ============================================================================
+  # View compatibility methods
+  # ============================================================================
 
   def rating
     0.0
@@ -122,6 +98,55 @@ class DeployableService < ApplicationRecord
 
   def popularity_ratio
     0.0
+  end
+
+  def service_opinion_count
+    0
+  end
+
+  def horizontal
+    false
+  end
+
+  def main_contact
+    nil
+  end
+
+  def public_contacts
+    []
+  end
+
+  def categories
+    Category.none
+  end
+
+  def target_users
+    []
+  end
+
+  def geographical_availabilities
+    []
+  end
+
+  # Provider relationship (returns array to match Service interface)
+  def providers
+    [resource_organisation].compact
+  end
+
+  # ============================================================================
+  # Additional Service-compatible methods
+  # ============================================================================
+
+  def type
+    "DeployableService"
+  end
+
+  def webpage_url
+    url
+  end
+
+  def order_url
+    url
   end
 
   # Service relationships - empty collections
@@ -137,30 +162,12 @@ class DeployableService < ApplicationRecord
     Service.none
   end
 
-  # Categories and domains
-  def categories
-    Category.none
-  end
-
+  # Additional collections
   def platforms
     []
   end
 
   def service_categories
-    []
-  end
-
-  def target_users
-    []
-  end
-
-  # Provider relationship (alias to match Service)
-  def providers
-    [resource_organisation].compact
-  end
-
-  # Geographical and access info
-  def geographical_availabilities
     []
   end
 
@@ -176,43 +183,37 @@ class DeployableService < ApplicationRecord
     []
   end
 
-  # Service-specific flags
-  def horizontal
-    false
+  # Project items through offers (using polymorphic orderable)
+  def project_items
+    ProjectItem.joins(:offer).where(offers: { orderable_type: "DeployableService", orderable_id: id })
   end
 
+  def project_items_count
+    offers.sum(&:project_items_count)
+  end
+
+  def service_opinions
+    ServiceOpinion.joins(project_item: :offer).where(offers: { orderable_type: "DeployableService", orderable_id: id })
+  end
+
+  # Service-specific flags
   def thematic
     false
   end
 
-  # Analytics methods
-  def store_analytics
-    # No-op for DS
+  def datasource?
+    false
   end
 
-  def monitoring_status
-    nil
+  def service?
+    false
   end
 
-  def monitoring_status=(value)
-    # No-op for DS
+  def errored?
+    status == "errored"
   end
 
-  # Contact methods
-  def main_contact
-    nil
-  end
-
-  def public_contacts
-    []
-  end
-
-  # Search and discovery
-  def search_data
-    { name: name, description: description, tagline: tagline, status: status }
-  end
-
-  # URL helpers
+  # URL methods
   def terms_of_use_url
     nil
   end
@@ -221,41 +222,6 @@ class DeployableService < ApplicationRecord
     nil
   end
 
-  def order_url
-    url
-  end
-
-  # Service type methods
-  def datasource?
-    false
-  end
-
-  def service?
-    false # We're a DeployableService, not a Service
-  end
-
-  # Validation and status methods
-  def draft?
-    status == "draft"
-  end
-
-  def published?
-    status == "published"
-  end
-
-  def suspended?
-    status == "suspended"
-  end
-
-  def errored?
-    status == "errored"
-  end
-
-  def deleted?
-    status == "deleted"
-  end
-
-  # Additional URL methods
   def helpdesk_url
     nil
   end
@@ -276,7 +242,7 @@ class DeployableService < ApplicationRecord
     nil
   end
 
-  # Additional attributes that might be accessed
+  # Safe attribute accessors
   def abbreviation
     super || ""
   end
@@ -290,101 +256,33 @@ class DeployableService < ApplicationRecord
   end
 
   # Search and indexing
+  def search_data
+    { name: name, description: description, tagline: tagline, status: status }
+  end
+
   def should_index?
     published?
   end
 
-  # Counter culture compatibility
-  def increment_counter(counter_name, by = 1)
-    # No-op for DS
+  # Analytics (no-op for DeployableService)
+  def store_analytics
   end
 
-  def decrement_counter(counter_name, by = 1)
-    # No-op for DS
+  def monitoring_status
+    nil
   end
 
-  # Search link methods (duck-typing for Service)
-  def organisation_search_link(target, default_path = nil)
-    _search_link(target, "resource_organisation", default_path)
+  def monitoring_status=(_value)
   end
 
-  def node_search_link(target, default_path = nil)
-    _search_link(target, "node", default_path)
+  # Counter culture compatibility (no-op for DeployableService)
+  def increment_counter(_counter_name, _by = 1)
   end
 
-  def provider_search_link(target, default_path = nil)
-    _search_link(target, "providers", default_path)
-  end
-
-  def geographical_availabilities_link(gcap)
-    _search_link(gcap, "geographical_availabilities", deployable_services_path(geographical_availabilities: gcap))
-  end
-
-  # Method missing fallback for any Service methods we missed
-  def method_missing(method_name, *args, &)
-    # If it's a Service method that returns a count, return 0
-    return 0 if method_name.to_s.end_with?("_count")
-
-    # If it's a Service method that returns a boolean, return false
-    return false if method_name.to_s.end_with?("?")
-
-    # If it's a Service method that returns a collection, return empty array
-    return [] if method_name.to_s.pluralize == method_name.to_s && method_name.to_s != method_name.to_s.singularize
-
-    # Otherwise call super
-    super
-  end
-
-  def respond_to_missing?(method_name, include_private = false)
-    # Be more conservative - don't claim to respond to basic attribute methods
-    # that shoulda-matchers needs to introspect properly
-    method_string = method_name.to_s
-
-    # Skip basic attributes that shoulda-matchers checks
-    return super if %w[name description tagline].include?(method_string)
-
-    # Respond to Service-like methods
-    method_string.end_with?("_count") || method_string.end_with?("?") ||
-      (method_string.pluralize == method_string && method_string != method_string.singularize) || super
-  end
-
-  # Extend offers association to support Service-like scopes
-  def offers
-    super.extend(OfferScopeExtensions)
-  end
-
-  module OfferScopeExtensions
-    def inclusive
-      published.joins(:deployable_service).where(deployable_services: { status: Statusable::PUBLIC_STATUSES })
-    end
-
-    def accessible
-      published.joins(:deployable_service).where(deployable_services: { status: Statusable::PUBLIC_STATUSES })
-    end
-
-    def active
-      where(
-        "offers.status = ? AND bundle_exclusive = ? AND (limited_availability = ? " +
-          "OR availability_count > ?) AND deployable_service_id IS NOT NULL",
-        :published,
-        false,
-        false,
-        0
-      ).joins(:deployable_service).where(deployable_services: { status: Statusable::PUBLIC_STATUSES })
-    end
+  def decrement_counter(_counter_name, _by = 1)
   end
 
   private
-
-  def _search_link(target_name, filter_query, default_path = nil)
-    search_base_url = Mp::Application.config.search_service_base_url
-    enable_external_search = Mp::Application.config.enable_external_search
-    if enable_external_search
-      search_base_url + "/search/deployable_service?q=*&fq=#{filter_query}:(%22#{target_name}%22)"
-    else
-      default_path || deployable_services_path(filter_query => target_name)
-    end
-  end
 
   def create_default_offer
     return unless jupyterhub_datamount_template?

--- a/app/models/infrastructure.rb
+++ b/app/models/infrastructure.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class Infrastructure < ApplicationRecord
+  # States for infrastructure lifecycle
+  STATES = %w[pending creating configured running failed destroyed].freeze
+
+  belongs_to :project_item, autosave: false
+
+  validates :im_base_url, presence: true
+  validates :cloud_site, presence: true
+  validates :state, presence: true, inclusion: { in: STATES }
+  validates :im_infrastructure_id, uniqueness: true, allow_nil: true
+
+  scope :active, -> { where.not(state: %w[destroyed failed]) }
+  scope :pending_state_check,
+        lambda { active.where("last_state_check_at IS NULL OR last_state_check_at < ?", 1.minute.ago) }
+
+  # State predicates
+  STATES.each { |state_name| define_method("#{state_name}?") { state == state_name } }
+
+  def deployable_service
+    project_item.offer.parent_service
+  end
+
+  def mark_created!(infrastructure_id)
+    update_columns(im_infrastructure_id: infrastructure_id, state: "creating", last_state_check_at: Time.current)
+  end
+
+  def mark_configured!
+    update_columns(state: "configured", last_state_check_at: Time.current)
+  end
+
+  def mark_running!(outputs_data = {})
+    update_columns(state: "running", outputs: outputs_data, last_state_check_at: Time.current, last_error: nil)
+  end
+
+  def mark_failed!(error_message)
+    update_columns(
+      state: "failed",
+      last_error: error_message,
+      retry_count: retry_count + 1,
+      last_state_check_at: Time.current
+    )
+  end
+
+  def mark_destroyed!
+    update_columns(state: "destroyed", last_state_check_at: Time.current)
+  end
+
+  def update_state_from_im!(im_state)
+    case im_state&.downcase
+    when "pending"
+      update_columns(state: "creating", last_state_check_at: Time.current)
+    when "configured"
+      mark_configured!
+    when "running", "stopped", "off"
+      # "stopped"/"off" still considered running (infrastructure exists)
+      update_columns(state: "running", last_state_check_at: Time.current)
+    when "failed", "unconfigured"
+      mark_failed!("Infrastructure Manager reported state: #{im_state}")
+    else
+      Rails.logger.warn "Unknown IM state '#{im_state}' for Infrastructure #{id}"
+      update_columns(last_state_check_at: Time.current)
+    end
+  end
+
+  def can_destroy?
+    %w[creating configured running failed].include?(state) && im_infrastructure_id.present?
+  end
+
+  def deployment_url
+    # outputs defaults to {} but add nil safety for defensive coding
+    outputs&.dig("jupyterhub_url") || outputs&.dig("public_url") || outputs&.dig("endpoint")
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -9,6 +9,7 @@ class Service < ApplicationRecord
   include Viewable
   include Service::Search
   include Statusable
+  include OrderableResource
 
   extend FriendlyId
   friendly_id :name, use: :slugged
@@ -49,7 +50,7 @@ class Service < ApplicationRecord
   has_many :service_alternative_identifiers
   has_many :alternative_identifiers, through: :service_alternative_identifiers
 
-  has_many :offers, dependent: :restrict_with_error
+  has_many :offers, as: :orderable, dependent: :restrict_with_error
   has_many :bundles, dependent: :restrict_with_error
   has_many :project_items, through: :offers
   has_many :categorizations, dependent: :destroy

--- a/app/policies/api/v1/ess/offer_policy.rb
+++ b/app/policies/api/v1/ess/offer_policy.rb
@@ -3,7 +3,17 @@
 class Api::V1::Ess::OfferPolicy < Api::V1::EssPolicy
   class Scope < Scope
     def resolve
-      scope.joins(:service).where("offers.status = ? AND services.status = ?", "published", "published")
+      # Support both Service and DeployableService via polymorphic orderable
+      scope
+        .where(status: "published")
+        .joins(Offer::LEFT_JOIN_SERVICE_SQL)
+        .joins(Offer::LEFT_JOIN_DEPLOYABLE_SERVICE_SQL)
+        .where(
+          "(offers.orderable_type = 'Service' AND services.status = ?) " \
+            "OR (offers.orderable_type = 'DeployableService' AND deployable_services.status = ?)",
+          "published",
+          "published"
+        )
     end
   end
 end

--- a/app/policies/backoffice/orderable_policy.rb
+++ b/app/policies/backoffice/orderable_policy.rb
@@ -50,7 +50,8 @@ class Backoffice::OrderablePolicy < Backoffice::ApplicationPolicy
   end
 
   def managed?
-    coordinator? || record.service.owned_by?(user)
+    # Use parent_service to support both Service and DeployableService offers
+    coordinator? || record.parent_service&.owned_by?(user) || false
   end
 
   def orderless?
@@ -58,6 +59,7 @@ class Backoffice::OrderablePolicy < Backoffice::ApplicationPolicy
   end
 
   def service_deleted?
-    record.service.deleted?
+    # Use parent_service to support both Service and DeployableService offers
+    record.parent_service&.deleted? || false
   end
 end

--- a/app/policies/backoffice/service_policy.rb
+++ b/app/policies/backoffice/service_policy.rb
@@ -183,6 +183,6 @@ class Backoffice::ServicePolicy < Backoffice::ApplicationPolicy
   end
 
   def project_items
-    ProjectItem.joins(:offer).where(offers: { service_id: record })
+    ProjectItem.joins(:offer).where(offers: { orderable_type: "Service", orderable_id: record.id })
   end
 end

--- a/app/policies/ordering_configuration/offer_policy.rb
+++ b/app/policies/ordering_configuration/offer_policy.rb
@@ -67,6 +67,7 @@ class OrderingConfiguration::OfferPolicy < Backoffice::OfferPolicy
   private
 
   def offer_editor?
-    user&.coordinator? || record.service.owned_by?(user)
+    # Use parent_service to support both Service and DeployableService offers
+    user&.coordinator? || record.parent_service&.owned_by?(user) || false
   end
 end

--- a/app/policies/project_item_policy.rb
+++ b/app/policies/project_item_policy.rb
@@ -17,6 +17,13 @@ class ProjectItemPolicy < ApplicationPolicy
     user && record.project&.user == user
   end
 
+  def destroy_infrastructure?
+    return false unless user && record.project&.user == user
+    return false unless record.infrastructure&.can_destroy?
+
+    true
+  end
+
   def permitted_attributes
     attributes =
       record.offer.attributes.map do |a|

--- a/app/serializers/ess/offer_serializer.rb
+++ b/app/serializers/ess/offer_serializer.rb
@@ -5,7 +5,6 @@ class Ess::OfferSerializer < ApplicationSerializer
              :iid,
              :name,
              :description,
-             :service_id,
              :tag_list,
              :eosc_if,
              :status,
@@ -14,6 +13,11 @@ class Ess::OfferSerializer < ApplicationSerializer
              :voucherable,
              :parameters,
              :updated_at
+
+  # Resource ID (service or deployable_service) - uses polymorphic orderable
+  # Include orderable_type to allow ESS to differentiate between Service and DeployableService
+  attribute :orderable_id, key: :service_id
+  attribute :orderable_type
 
   attribute :created_at, key: :publication_date
 

--- a/app/serializers/recommender/user_serializer.rb
+++ b/app/serializers/recommender/user_serializer.rb
@@ -9,7 +9,8 @@ class Recommender::UserSerializer < ActiveModel::Serializer
 
   def accessed_services
     User
-      .joins(projects: [project_items: [offer: [:service]]])
+      .joins(projects: [project_items: :offer])
+      .joins(Offer::JOIN_SERVICE_SQL)
       .order("project_items.created_at")
       .where("users.email = ?", object.email)
       .pluck("services.id")

--- a/app/services/ess/delete.rb
+++ b/app/services/ess/delete.rb
@@ -10,7 +10,9 @@ class Ess::Delete < ApplicationService
 
   def call
     if @type == ("service" || "datasource")
-      Offer.where(service_id: @object_id).each { |offer| Ess::Delete.call(offer.id, offer.class.name) }
+      Offer
+        .where(orderable_type: "Service", orderable_id: @object_id)
+        .each { |offer| Ess::Delete.call(offer.id, offer.class.name) }
     end
     @async ? Ess::UpdateJob.perform_later(payload) : Ess::Update.call(payload)
   end

--- a/app/services/matomo/create_event.rb
+++ b/app/services/matomo/create_event.rb
@@ -13,7 +13,10 @@ class Matomo::CreateEvent
   end
 
   def call
-    sid = @project_item.service.sources&.first&.eid || @project_item.service.slug
+    # Use parent_service to support both Service and DeployableService
+    parent = @project_item.service
+    first_source = parent&.sources&.first
+    sid = first_source&.eid || parent&.slug
     url = Mp::Application.config.matomo_url
     site_id = Mp::Application.config.matomo_site_id
     request = "https:" + url + "matomo.php?e_c=#{@category}&e_a=#{@action}&e_n=#{sid}&idsite=#{site_id}&rec=1"

--- a/app/services/recommender/simple_recommender.rb
+++ b/app/services/recommender/simple_recommender.rb
@@ -20,16 +20,16 @@ class Recommender::SimpleRecommender
     "" \
       "
       select Services.id from Services
-      -- Join projects
-      join Offers on Offers.service_id=Services.id
+      -- Join projects (using polymorphic orderable)
+      join Offers on Offers.orderable_id=Services.id AND Offers.orderable_type='Service'
       join Project_items on Project_items.offer_id=Offers.id
       join Projects on Projects.id=Project_items.project_id
       -- Join categories
       join Categorizations on Categorizations.service_id=Services.id
       join Categories on Categories.id=Categorizations.category_id
       where Categories.id=(select Categories.id from Services
-                          -- Join projects
-                          join Offers on Offers.service_id=Services.id
+                          -- Join projects (using polymorphic orderable)
+                          join Offers on Offers.orderable_id=Services.id AND Offers.orderable_type='Service'
                           join Project_items on Project_items.offer_id=Offers.id
                           join Projects on Projects.id=Project_items.project_id
                           -- Join categories

--- a/app/views/projects/services/_details.html.haml
+++ b/app/views/projects/services/_details.html.haml
@@ -60,3 +60,13 @@
         %span.text-warning
           %i.fas.fa-clock
           = _("Deployment pending")
+  - if policy(project_item).destroy_infrastructure?
+    %dl
+      %dt
+        = _("Infrastructure Management") + ":"
+      %dd
+        = button_to _("Destroy Infrastructure"),
+          project_service_infrastructure_path(project, project_item),
+          method: :delete,
+          class: "btn btn-outline-danger btn-sm",
+          data: { "turbo-confirm": _("Are you sure you want to destroy this infrastructure? This action cannot be undone.") }

--- a/config/deployable_services.yml
+++ b/config/deployable_services.yml
@@ -1,0 +1,51 @@
+# Configuration for Deployable Services and Infrastructure Manager integration
+#
+# Environment variables (all optional with defaults):
+#   IM_BASE_URL              - Infrastructure Manager API base URL
+#   EGI_REFRESH_TOKEN_URL    - EGI AAI token refresh endpoint
+#   EGI_VO                   - Virtual Organization for EGI
+#   EGI_CLIENT_ID            - OAuth client ID for token refresh
+#   IM_DEFAULT_CLOUD         - Default cloud site for deployments
+#   IM_TIMEOUT               - Request timeout in seconds
+#   IM_OPEN_TIMEOUT          - Connection timeout in seconds
+#   IM_TOKEN_CACHE_EXPIRY    - Token cache expiry in minutes
+
+default: &default
+  infrastructure_manager:
+    base_url: <%= ENV.fetch('IM_BASE_URL', 'https://deploy.sandbox.eosc-beyond.eu') %>
+    timeout: <%= ENV.fetch('IM_TIMEOUT', 300).to_i %>
+    open_timeout: <%= ENV.fetch('IM_OPEN_TIMEOUT', 60).to_i %>
+
+  authentication:
+    type: service_account
+    refresh_token_url: <%= ENV.fetch('EGI_REFRESH_TOKEN_URL', 'https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/token') %>
+    vo: <%= ENV.fetch('EGI_VO', 'eosc-beyond.eu') %>
+    client_id: <%= ENV.fetch('EGI_CLIENT_ID', 'token-portal') %>
+    token_cache_key: egi_access_token
+    token_cache_expiry_minutes: <%= ENV.fetch('IM_TOKEN_CACHE_EXPIRY', 50).to_i %>
+
+  cloud_providers:
+    default: <%= ENV.fetch('IM_DEFAULT_CLOUD', 'IISAS-FedCloud') %>
+    # Available cloud providers can be extended here
+    # available:
+    #   - id: IISAS-FedCloud
+    #     name: "IISAS FedCloud (Slovakia)"
+    #   - id: CESNET-MCC
+    #     name: "CESNET MetaCentrum Cloud (Czech Republic)"
+
+  templates:
+    local_path: <%= Rails.root.join('config', 'templates') %>
+    fetch_timeout: 30
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+  infrastructure_manager:
+    base_url: "https://im.test.example.com"
+    timeout: 30
+    open_timeout: 10
+
+production:
+  <<: *default

--- a/config/initializers/deployable_services.rb
+++ b/config/initializers/deployable_services.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Load deployable services configuration
+# This includes Infrastructure Manager settings, EGI authentication, and cloud providers
+Rails.application.configure do
+  config.deployable_services = config_for(:deployable_services)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
           resource :opinion, only: %i[new create]
           resource :conversation, only: %i[show create]
           resource :timeline, only: :show
+          resource :infrastructure, only: :destroy
         end
       end
       resource :conversation, only: %i[show create]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -20,6 +20,7 @@ staging:
   - default
   - pc_publisher
   - ess_update
+  - deployments
 
 :limits:
   pc_subscriber: 1

--- a/db/migrate/20251213211539_make_offer_orderable_polymorphic.rb
+++ b/db/migrate/20251213211539_make_offer_orderable_polymorphic.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class MakeOfferOrderablePolymorphic < ActiveRecord::Migration[7.2]
+  def up
+    # Add polymorphic columns (nullable initially for safe data migration)
+    add_column :offers, :orderable_type, :string
+    add_column :offers, :orderable_id, :bigint
+
+    # Migrate existing data from service_id
+    execute <<-SQL.squish
+      UPDATE offers
+      SET orderable_type = 'Service', orderable_id = service_id
+      WHERE service_id IS NOT NULL
+    SQL
+
+    # Migrate existing data from deployable_service_id (if column exists)
+    execute <<-SQL.squish if column_exists?(:offers, :deployable_service_id)
+        UPDATE offers
+        SET orderable_type = 'DeployableService', orderable_id = deployable_service_id
+        WHERE deployable_service_id IS NOT NULL AND orderable_id IS NULL
+      SQL
+
+    # Log warning about orphan offers (no service_id or deployable_service_id)
+    # These are legacy data that will be excluded from queries via the polymorphic association
+    orphan_count = execute("SELECT COUNT(*) FROM offers WHERE orderable_id IS NULL").first["count"].to_i
+    if orphan_count.positive?
+      Rails.logger.warn "Found #{orphan_count} orphan offers with no service. These will have NULL orderable."
+    end
+
+    # Add index for polymorphic lookup (allows NULLs for orphan offers)
+    add_index :offers, %i[orderable_type orderable_id]
+
+    # NOTE: We intentionally keep service_id and deployable_service_id columns
+    # for rollback safety. They will be removed in a subsequent migration.
+  end
+
+  def down
+    remove_index :offers, %i[orderable_type orderable_id]
+    remove_column :offers, :orderable_type
+    remove_column :offers, :orderable_id
+  end
+end

--- a/db/migrate/20251214080854_create_infrastructures.rb
+++ b/db/migrate/20251214080854_create_infrastructures.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+class CreateInfrastructures < ActiveRecord::Migration[7.2]
+  def change
+    create_table :infrastructures do |t|
+      t.references :project_item, null: false, foreign_key: true
+
+      # Infrastructure Manager details
+      t.string :im_infrastructure_id
+      t.string :im_base_url, null: false
+      t.string :cloud_site, null: false
+
+      # State tracking
+      t.string :state, default: "pending", null: false
+      t.datetime :last_state_check_at
+
+      # Outputs from IM (e.g., jupyterhub_url, public_ip)
+      t.jsonb :outputs, default: {}
+
+      # Error tracking
+      t.text :last_error
+      t.integer :retry_count, default: 0
+
+      t.timestamps
+    end
+
+    add_index :infrastructures, :im_infrastructure_id, unique: true
+    add_index :infrastructures, :state
+  end
+end

--- a/db/migrate/20251214143117_remove_deprecated_offer_columns.rb
+++ b/db/migrate/20251214143117_remove_deprecated_offer_columns.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class RemoveDeprecatedOfferColumns < ActiveRecord::Migration[7.2]
+  def up
+    # Remove indexes first
+    remove_index :offers, name: "index_offers_on_deployable_service_id", if_exists: true
+    remove_index :offers, name: "index_offers_on_service_id_and_iid", if_exists: true
+    remove_index :offers, name: "index_offers_on_service_id", if_exists: true
+
+    # Remove the deprecated columns
+    # These were replaced by the polymorphic orderable_type/orderable_id columns
+    remove_column :offers, :service_id, :bigint
+    remove_column :offers, :deployable_service_id, :bigint
+  end
+
+  def down
+    # Restore columns
+    add_reference :offers, :service, foreign_key: true
+    add_reference :offers, :deployable_service, foreign_key: true
+
+    # Restore unique index on service_id and iid
+    add_index :offers, %i[service_id iid], unique: true
+
+    # Restore data from orderable columns
+    execute <<-SQL.squish
+      UPDATE offers
+      SET service_id = orderable_id
+      WHERE orderable_type = 'Service'
+    SQL
+
+    execute <<-SQL.squish
+      UPDATE offers
+      SET deployable_service_id = orderable_id
+      WHERE orderable_type = 'DeployableService'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_11_120720) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_14_143117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -361,6 +361,23 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_11_120720) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "infrastructures", force: :cascade do |t|
+    t.bigint "project_item_id", null: false
+    t.string "im_infrastructure_id"
+    t.string "im_base_url", null: false
+    t.string "cloud_site", null: false
+    t.string "state", default: "pending", null: false
+    t.datetime "last_state_check_at"
+    t.jsonb "outputs", default: {}
+    t.text "last_error"
+    t.integer "retry_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["im_infrastructure_id"], name: "index_infrastructures_on_im_infrastructure_id", unique: true
+    t.index ["project_item_id"], name: "index_infrastructures_on_project_item_id"
+    t.index ["state"], name: "index_infrastructures_on_state"
+  end
+
   create_table "lead_sections", force: :cascade do |t|
     t.string "slug", null: false
     t.string "title", null: false
@@ -446,7 +463,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_11_120720) do
     t.string "name"
     t.text "description"
     t.integer "iid", null: false
-    t.bigint "service_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.jsonb "parameters", default: [], null: false
@@ -468,12 +484,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_11_120720) do
     t.boolean "limited_availability", default: false
     t.bigint "availability_count", default: 0
     t.string "availability_unit", default: "piece"
-    t.bigint "deployable_service_id"
-    t.index ["deployable_service_id"], name: "index_offers_on_deployable_service_id"
+    t.string "orderable_type", null: false
+    t.bigint "orderable_id", null: false
     t.index ["iid"], name: "index_offers_on_iid"
+    t.index ["orderable_type", "orderable_id"], name: "index_offers_on_orderable_type_and_orderable_id"
     t.index ["primary_oms_id"], name: "index_offers_on_primary_oms_id"
-    t.index ["service_id", "iid"], name: "index_offers_on_service_id_and_iid", unique: true
-    t.index ["service_id"], name: "index_offers_on_service_id"
   end
 
   create_table "oms_administrations", force: :cascade do |t|
@@ -1091,13 +1106,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_11_120720) do
   add_foreign_key "deployable_service_sources", "deployable_services"
   add_foreign_key "deployable_services", "catalogues"
   add_foreign_key "deployable_services", "providers", column: "resource_organisation_id"
+  add_foreign_key "infrastructures", "project_items"
   add_foreign_key "observed_user_offers", "offers"
   add_foreign_key "observed_user_offers", "users"
   add_foreign_key "offer_links", "offers", column: "source_id"
   add_foreign_key "offer_links", "offers", column: "target_id"
   add_foreign_key "offer_vocabularies", "offers"
   add_foreign_key "offer_vocabularies", "vocabularies"
-  add_foreign_key "offers", "deployable_services"
   add_foreign_key "offers", "omses", column: "primary_oms_id"
   add_foreign_key "oms_administrations", "omses"
   add_foreign_key "oms_administrations", "users"

--- a/spec/factories/infrastructures.rb
+++ b/spec/factories/infrastructures.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :infrastructure do
+    association :project_item
+    im_base_url { "https://deploy.sandbox.eosc-beyond.eu" }
+    cloud_site { "IISAS-FedCloud" }
+    state { "pending" }
+    outputs { {} }
+    retry_count { 0 }
+
+    trait :creating do
+      state { "creating" }
+      im_infrastructure_id { SecureRandom.uuid }
+      last_state_check_at { Time.current }
+    end
+
+    trait :configured do
+      state { "configured" }
+      im_infrastructure_id { SecureRandom.uuid }
+      last_state_check_at { Time.current }
+    end
+
+    trait :running do
+      state { "running" }
+      im_infrastructure_id { SecureRandom.uuid }
+      last_state_check_at { Time.current }
+      outputs { { "jupyterhub_url" => "https://#{SecureRandom.uuid}.vm.fedcloud.eu/jupyterhub/" } }
+    end
+
+    trait :failed do
+      state { "failed" }
+      im_infrastructure_id { SecureRandom.uuid }
+      last_error { "Deployment failed: timeout" }
+      retry_count { 1 }
+      last_state_check_at { Time.current }
+    end
+
+    trait :destroyed do
+      state { "destroyed" }
+      im_infrastructure_id { SecureRandom.uuid }
+      last_state_check_at { Time.current }
+    end
+  end
+end

--- a/spec/jobs/deployable_service/deployment_job_spec.rb
+++ b/spec/jobs/deployable_service/deployment_job_spec.rb
@@ -11,23 +11,58 @@ RSpec.describe DeployableService::DeploymentJob, type: :job do
   let(:offer) { create(:offer, service: nil, deployable_service: deployable_service, offer_category: service_category) }
   let(:project_item) { create(:project_item, project: project, offer: offer, status: "created", status_type: :created) }
 
+  let(:filled_template) { "filled tosca template content" }
+  let(:mock_im_client) { instance_double(InfrastructureManager::Client) }
+  let(:infrastructure_id) { "inf-12345" }
+  let(:deployment_uri) { "https://deploy.sandbox.eosc-beyond.eu/infrastructures/#{infrastructure_id}" }
+
   subject { described_class.new }
 
+  before do
+    allow(DeployableService::ToscaTemplateFiller).to receive(:call).with(project_item).and_return(filled_template)
+    allow(InfrastructureManager::Client).to receive(:new).and_return(mock_im_client)
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
+  end
+
   describe "#perform" do
-    context "when deployment is successful" do
-      let(:filled_template) { "filled tosca template content" }
-      let(:mock_im_client) { instance_double(InfrastructureManager::Client) }
-      let(:successful_im_response) do
-        { success: true, data: { "uri" => "https://deploy.sandbox.eosc-beyond.eu/infrastructures/inf-12345" } }
+    context "when deployment is successful with outputs available" do
+      let(:successful_im_response) { { success: true, data: { "uri" => deployment_uri } } }
+      let(:outputs_response) do
+        { success: true, data: { "outputs" => { "jupyterhub_url" => "https://jupyter.example.com" } } }
       end
 
       before do
-        allow(DeployableService::ToscaTemplateFiller).to receive(:call).with(project_item).and_return(filled_template)
-        allow(InfrastructureManager::Client).to receive(:new).with(nil, "IISAS-FedCloud").and_return(mock_im_client)
         allow(mock_im_client).to receive(:create_infrastructure).with(filled_template).and_return(
           successful_im_response
         )
-        allow(Rails.logger).to receive(:info)
+        allow(mock_im_client).to receive(:get_outputs).with(infrastructure_id).and_return(outputs_response)
+      end
+
+      it "creates an Infrastructure record" do
+        expect { subject.perform(project_item) }.to change(Infrastructure, :count).by(1)
+      end
+
+      it "sets infrastructure to pending then running" do
+        subject.perform(project_item)
+
+        infrastructure = Infrastructure.last
+        expect(infrastructure.state).to eq("running")
+        expect(infrastructure.im_infrastructure_id).to eq(infrastructure_id)
+      end
+
+      it "stores outputs on infrastructure" do
+        subject.perform(project_item)
+
+        infrastructure = Infrastructure.last
+        expect(infrastructure.outputs["jupyterhub_url"]).to eq("https://jupyter.example.com")
+      end
+
+      it "associates infrastructure with project_item" do
+        subject.perform(project_item)
+
+        expect(project_item.reload.infrastructure).to be_present
+        expect(project_item.infrastructure.im_infrastructure_id).to eq(infrastructure_id)
       end
 
       it "calls ToscaTemplateFiller to get filled template" do
@@ -39,18 +74,22 @@ RSpec.describe DeployableService::DeploymentJob, type: :job do
       it "calls Infrastructure Manager API with filled template" do
         subject.perform(project_item)
 
-        expect(InfrastructureManager::Client).to have_received(:new).with(nil, "IISAS-FedCloud")
         expect(mock_im_client).to have_received(:create_infrastructure).with(filled_template)
       end
 
-      it "updates project item status to ready with deployment info" do
+      it "fetches outputs from Infrastructure Manager" do
+        subject.perform(project_item)
+
+        expect(mock_im_client).to have_received(:get_outputs).with(infrastructure_id)
+      end
+
+      it "updates project item status to ready with jupyterhub URL" do
         subject.perform(project_item)
 
         project_item.reload
         expect(project_item.status_type).to eq("ready")
         expect(project_item.status).to include("Deployment ready at")
-        expect(project_item.status).to include("inf-12345")
-        expect(project_item.deployment_link).to include("inf-12345")
+        expect(project_item.deployment_link).to eq("https://jupyter.example.com")
       end
 
       it "logs deployment information" do
@@ -63,19 +102,77 @@ RSpec.describe DeployableService::DeploymentJob, type: :job do
       end
     end
 
+    context "when deployment is successful but outputs are empty" do
+      let(:successful_im_response) { { success: true, data: { "uri" => deployment_uri } } }
+      let(:outputs_response) { { success: true, data: { "outputs" => {} } } }
+
+      before do
+        allow(mock_im_client).to receive(:create_infrastructure).with(filled_template).and_return(
+          successful_im_response
+        )
+        allow(mock_im_client).to receive(:get_outputs).with(infrastructure_id).and_return(outputs_response)
+      end
+
+      it "marks infrastructure as configured (not running, since no usable URL)" do
+        subject.perform(project_item)
+
+        infrastructure = Infrastructure.last
+        expect(infrastructure.state).to eq("configured")
+      end
+
+      it "uses deployment URI as fallback for deployment_link" do
+        subject.perform(project_item)
+
+        project_item.reload
+        expect(project_item.deployment_link).to eq(deployment_uri)
+      end
+    end
+
+    context "when get_outputs fails" do
+      let(:successful_im_response) { { success: true, data: { "uri" => deployment_uri } } }
+      let(:outputs_response) { { success: false, error: "Service unavailable" } }
+
+      before do
+        allow(mock_im_client).to receive(:create_infrastructure).with(filled_template).and_return(
+          successful_im_response
+        )
+        allow(mock_im_client).to receive(:get_outputs).with(infrastructure_id).and_return(outputs_response)
+      end
+
+      it "marks infrastructure as configured (polling will update later)" do
+        subject.perform(project_item)
+
+        infrastructure = Infrastructure.last
+        expect(infrastructure.state).to eq("configured")
+      end
+
+      it "uses deployment URI for deployment_link" do
+        subject.perform(project_item)
+
+        project_item.reload
+        expect(project_item.deployment_link).to eq(deployment_uri)
+      end
+    end
+
     context "when deployment fails due to IM API failure" do
-      let(:filled_template) { "filled tosca template content" }
-      let(:mock_im_client) { instance_double(InfrastructureManager::Client) }
       let(:failed_im_response) do
         { success: false, error: "No VMI obtained from Sites to system 'front'", status_code: 400 }
       end
 
       before do
-        allow(DeployableService::ToscaTemplateFiller).to receive(:call).with(project_item).and_return(filled_template)
-        allow(InfrastructureManager::Client).to receive(:new).with(nil, "IISAS-FedCloud").and_return(mock_im_client)
         allow(mock_im_client).to receive(:create_infrastructure).with(filled_template).and_return(failed_im_response)
-        allow(Rails.logger).to receive(:info)
-        allow(Rails.logger).to receive(:error)
+      end
+
+      it "creates an Infrastructure record" do
+        expect { subject.perform(project_item) }.to change(Infrastructure, :count).by(1)
+      end
+
+      it "marks infrastructure as failed" do
+        subject.perform(project_item)
+
+        infrastructure = Infrastructure.last
+        expect(infrastructure.state).to eq("failed")
+        expect(infrastructure.last_error).to include("No VMI obtained")
       end
 
       it "updates project item status to rejected" do
@@ -83,16 +180,13 @@ RSpec.describe DeployableService::DeploymentJob, type: :job do
 
         project_item.reload
         expect(project_item.status_type).to eq("rejected")
-        expect(project_item.status).to include(
-          "Deployment failed - Infrastructure Manager did not return a deployment address"
-        )
+        expect(project_item.status).to include("Deployment failed")
       end
 
       it "logs the IM API error" do
         subject.perform(project_item)
 
-        expect(Rails.logger).to have_received(:error).with("Deployment failed for ProjectItem #{project_item.id}")
-        expect(Rails.logger).to have_received(:error).with("IM deployment failed: #{failed_im_response[:error]}")
+        expect(Rails.logger).to have_received(:error).with(/IM deployment failed/)
       end
 
       it "does not update deployment_link" do
@@ -103,10 +197,44 @@ RSpec.describe DeployableService::DeploymentJob, type: :job do
       end
     end
 
-    context "when an exception occurs" do
+    context "when IM returns no deployment URI" do
+      let(:no_uri_response) { { success: true, data: {} } }
+
+      before do
+        allow(mock_im_client).to receive(:create_infrastructure).with(filled_template).and_return(no_uri_response)
+      end
+
+      it "marks infrastructure as failed" do
+        subject.perform(project_item)
+
+        infrastructure = Infrastructure.last
+        expect(infrastructure.state).to eq("failed")
+        expect(infrastructure.last_error).to include("No deployment URI")
+      end
+
+      it "updates project item status to rejected" do
+        subject.perform(project_item)
+
+        project_item.reload
+        expect(project_item.status_type).to eq("rejected")
+      end
+    end
+
+    context "when an exception occurs during template filling" do
       before do
         allow(DeployableService::ToscaTemplateFiller).to receive(:call).and_raise(StandardError, "Template error")
-        allow(Rails.logger).to receive(:error)
+      end
+
+      it "creates an Infrastructure record first" do
+        expect { subject.perform(project_item) }.to change(Infrastructure, :count).by(1)
+      end
+
+      it "marks infrastructure as failed" do
+        subject.perform(project_item)
+
+        infrastructure = Infrastructure.last
+        expect(infrastructure.state).to eq("failed")
+        expect(infrastructure.last_error).to eq("Template error")
       end
 
       it "logs the error" do
@@ -130,22 +258,20 @@ RSpec.describe DeployableService::DeploymentJob, type: :job do
   describe "private methods" do
     describe "#extract_deployment_uri" do
       it "extracts URI from hash response" do
-        response_data = { "uri" => "https://deploy.sandbox.eosc-beyond.eu/infrastructures/inf-12345" }
+        response_data = { "uri" => deployment_uri }
         result = subject.send(:extract_deployment_uri, response_data)
 
-        expect(result).to eq("https://deploy.sandbox.eosc-beyond.eu/infrastructures/inf-12345")
+        expect(result).to eq(deployment_uri)
       end
 
       it "extracts URI from string response containing http" do
-        response_data = "https://deploy.sandbox.eosc-beyond.eu/infrastructures/inf-12345"
-        result = subject.send(:extract_deployment_uri, response_data)
+        result = subject.send(:extract_deployment_uri, deployment_uri)
 
-        expect(result).to eq("https://deploy.sandbox.eosc-beyond.eu/infrastructures/inf-12345")
+        expect(result).to eq(deployment_uri)
       end
 
       it "returns nil for non-URI string" do
-        response_data = "inf-12345"
-        result = subject.send(:extract_deployment_uri, response_data)
+        result = subject.send(:extract_deployment_uri, "inf-12345")
 
         expect(result).to be_nil
       end
@@ -155,6 +281,48 @@ RSpec.describe DeployableService::DeploymentJob, type: :job do
 
         expect(result).to be_nil
       end
+    end
+
+    describe "#extract_infrastructure_id" do
+      it "extracts ID from standard IM URI" do
+        uri = "https://deploy.sandbox.eosc-beyond.eu/infrastructures/inf-12345"
+        result = subject.send(:extract_infrastructure_id, uri)
+
+        expect(result).to eq("inf-12345")
+      end
+
+      it "extracts ID from URI with im-dev prefix" do
+        uri = "https://deploy.sandbox.eosc-beyond.eu/im-dev/infrastructures/abc-789"
+        result = subject.send(:extract_infrastructure_id, uri)
+
+        expect(result).to eq("abc-789")
+      end
+
+      it "extracts UUID-style ID" do
+        uuid = "cc2f148a-9f5e-11f0-9a72-2b7a5255cf3a"
+        uri = "https://deploy.sandbox.eosc-beyond.eu/infrastructures/#{uuid}"
+        result = subject.send(:extract_infrastructure_id, uri)
+
+        expect(result).to eq(uuid)
+      end
+
+      it "returns nil for nil input" do
+        result = subject.send(:extract_infrastructure_id, nil)
+
+        expect(result).to be_nil
+      end
+
+      it "returns nil for URI without infrastructures path" do
+        result = subject.send(:extract_infrastructure_id, "https://example.com/other/path")
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "job configuration" do
+    it "uses the default queue" do
+      expect(described_class.new.queue_name).to eq("default")
     end
   end
 end

--- a/spec/jobs/infrastructure/destroy_job_spec.rb
+++ b/spec/jobs/infrastructure/destroy_job_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Infrastructure::DestroyJob, type: :job do
+  let(:provider) { create(:provider) }
+  let(:deployable_service) { create(:deployable_service, resource_organisation: provider) }
+  let(:service_category) { create(:service_category) }
+  let(:offer) { create(:offer, service: nil, deployable_service: deployable_service, offer_category: service_category) }
+  let(:project) { create(:project) }
+  let(:project_item) { create(:project_item, offer: offer, project: project) }
+
+  let(:infrastructure) do
+    Infrastructure.create!(
+      project_item: project_item,
+      im_base_url: "https://deploy.sandbox.eosc-beyond.eu",
+      cloud_site: "IISAS-FedCloud",
+      state: "running",
+      im_infrastructure_id: "infra-123"
+    )
+  end
+
+  let(:im_client) { instance_double(InfrastructureManager::Client) }
+
+  before { allow(InfrastructureManager::Client).to receive(:new).and_return(im_client) }
+
+  describe "#perform" do
+    context "when destroy succeeds" do
+      before { allow(im_client).to receive(:destroy_infrastructure).and_return({ success: true }) }
+
+      it "marks infrastructure as destroyed" do
+        described_class.perform_now(infrastructure.id)
+
+        expect(infrastructure.reload.state).to eq("destroyed")
+      end
+
+      it "updates project_item status to closed" do
+        described_class.perform_now(infrastructure.id)
+
+        project_item.reload
+        expect(project_item.status).to eq("Infrastructure has been destroyed")
+        expect(project_item.status_type).to eq("closed")
+      end
+
+      it "logs success message" do
+        expect(Rails.logger).to receive(:info).with(/Destroying Infrastructure/)
+        expect(Rails.logger).to receive(:info).with(/destroyed successfully/)
+
+        described_class.perform_now(infrastructure.id)
+      end
+    end
+
+    context "when destroy fails" do
+      before do
+        allow(im_client).to receive(:destroy_infrastructure).and_return({ success: false, error: "Permission denied" })
+      end
+
+      it "marks infrastructure as failed with error message" do
+        described_class.perform_now(infrastructure.id)
+
+        infrastructure.reload
+        expect(infrastructure.state).to eq("failed")
+        expect(infrastructure.last_error).to include("Permission denied")
+      end
+
+      it "updates project_item status to rejected" do
+        described_class.perform_now(infrastructure.id)
+
+        project_item.reload
+        expect(project_item.status).to include("Failed to destroy")
+        expect(project_item.status_type).to eq("rejected")
+      end
+
+      it "logs error message" do
+        expect(Rails.logger).to receive(:info).with(/Destroying Infrastructure/)
+        expect(Rails.logger).to receive(:error).with(/Failed to destroy/)
+
+        described_class.perform_now(infrastructure.id)
+      end
+    end
+
+    context "when infrastructure cannot be destroyed" do
+      it "does nothing if infrastructure not found" do
+        expect(im_client).not_to receive(:destroy_infrastructure)
+        described_class.perform_now(-1)
+      end
+
+      it "does nothing if infrastructure is already destroyed" do
+        infrastructure.update_columns(state: "destroyed")
+
+        expect(im_client).not_to receive(:destroy_infrastructure)
+        described_class.perform_now(infrastructure.id)
+      end
+
+      it "does nothing if infrastructure is pending (no im_infrastructure_id)" do
+        infrastructure.update_columns(state: "pending", im_infrastructure_id: nil)
+
+        expect(im_client).not_to receive(:destroy_infrastructure)
+        described_class.perform_now(infrastructure.id)
+      end
+    end
+
+    context "when exception occurs" do
+      it "marks infrastructure as failed with exception message" do
+        allow(im_client).to receive(:destroy_infrastructure).and_raise(StandardError, "Network error")
+
+        expect(Rails.logger).to receive(:info).with(/Destroying Infrastructure/)
+        expect(Rails.logger).to receive(:error).with(/Destroy job failed/)
+
+        described_class.perform_now(infrastructure.id)
+
+        infrastructure.reload
+        expect(infrastructure.state).to eq("failed")
+        expect(infrastructure.last_error).to eq("Network error")
+      end
+    end
+  end
+
+  describe "destroyable states" do
+    %w[creating configured running failed].each do |state_name|
+      it "destroys infrastructure in '#{state_name}' state" do
+        infrastructure.update_columns(state: state_name)
+        allow(im_client).to receive(:destroy_infrastructure).and_return({ success: true })
+
+        described_class.perform_now(infrastructure.id)
+
+        expect(infrastructure.reload.state).to eq("destroyed")
+      end
+    end
+  end
+
+  describe "job configuration" do
+    it "uses the default queue" do
+      expect(described_class.new.queue_name).to eq("default")
+    end
+  end
+end

--- a/spec/jobs/infrastructure/state_polling_job_spec.rb
+++ b/spec/jobs/infrastructure/state_polling_job_spec.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Infrastructure::StatePollingJob, type: :job do
+  let(:provider) { create(:provider) }
+  let(:deployable_service) { create(:deployable_service, resource_organisation: provider) }
+  let(:service_category) { create(:service_category) }
+  let(:offer) { create(:offer, service: nil, deployable_service: deployable_service, offer_category: service_category) }
+  let(:project) { create(:project) }
+  let(:project_item) { create(:project_item, offer: offer, project: project) }
+
+  let(:infrastructure) do
+    Infrastructure.create!(
+      project_item: project_item,
+      im_base_url: "https://deploy.sandbox.eosc-beyond.eu",
+      cloud_site: "IISAS-FedCloud",
+      state: "creating",
+      im_infrastructure_id: "infra-123"
+    )
+  end
+
+  let(:im_client) { instance_double(InfrastructureManager::Client) }
+
+  before { allow(InfrastructureManager::Client).to receive(:new).and_return(im_client) }
+
+  describe "#perform" do
+    context "with infrastructure_id argument (single polling)" do
+      it "polls the specific infrastructure" do
+        allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "running" } })
+        allow(im_client).to receive(:get_outputs).and_return({ success: true, data: { "outputs" => {} } })
+
+        described_class.perform_now(infrastructure.id)
+
+        expect(infrastructure.reload.state).to eq("running")
+      end
+
+      it "does nothing if infrastructure not found" do
+        expect(im_client).not_to receive(:get_state)
+        described_class.perform_now(-1)
+      end
+
+      it "does nothing if infrastructure has no im_infrastructure_id" do
+        infrastructure.update_columns(im_infrastructure_id: nil)
+
+        expect(im_client).not_to receive(:get_state)
+        described_class.perform_now(infrastructure.id)
+      end
+
+      it "does nothing if infrastructure is destroyed" do
+        infrastructure.update_columns(state: "destroyed")
+
+        expect(im_client).not_to receive(:get_state)
+        described_class.perform_now(infrastructure.id)
+      end
+
+      it "does nothing if infrastructure is failed" do
+        infrastructure.update_columns(state: "failed")
+
+        expect(im_client).not_to receive(:get_state)
+        described_class.perform_now(infrastructure.id)
+      end
+    end
+
+    context "without infrastructure_id argument (poll all pending)" do
+      it "polls all pending infrastructures" do
+        # Create another project_item for the second infrastructure
+        project_item2 = create(:project_item, offer: offer, project: project)
+        infra2 =
+          Infrastructure.create!(
+            project_item: project_item2,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "running",
+            im_infrastructure_id: "infra-456",
+            last_state_check_at: 2.minutes.ago
+          )
+
+        # Set infrastructure to also need polling
+        infrastructure.update_columns(last_state_check_at: 2.minutes.ago)
+
+        allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "running" } })
+        allow(im_client).to receive(:get_outputs).and_return({ success: true, data: { "outputs" => {} } })
+
+        described_class.perform_now
+
+        expect(infrastructure.reload.state).to eq("running")
+        expect(infra2.reload.state).to eq("running")
+      end
+
+      it "skips infrastructures without im_infrastructure_id" do
+        infrastructure.update_columns(im_infrastructure_id: nil, last_state_check_at: 2.minutes.ago)
+
+        expect(im_client).not_to receive(:get_state)
+        described_class.perform_now
+      end
+
+      it "continues polling other infrastructures when one fails" do
+        project_item2 = create(:project_item, offer: offer, project: project)
+        infra2 =
+          Infrastructure.create!(
+            project_item: project_item2,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "running",
+            im_infrastructure_id: "infra-456",
+            last_state_check_at: 2.minutes.ago
+          )
+        infrastructure.update_columns(last_state_check_at: 2.minutes.ago)
+
+        # First call raises, second succeeds
+        call_count = 0
+        allow(im_client).to receive(:get_state) do
+          call_count += 1
+          if call_count == 1
+            raise StandardError, "Connection failed"
+          else
+            { success: true, data: { "state" => "running" } }
+          end
+        end
+        allow(im_client).to receive(:get_outputs).and_return({ success: true, data: { "outputs" => {} } })
+
+        expect(Rails.logger).to receive(:error).with(/Failed to poll Infrastructure/)
+
+        described_class.perform_now
+
+        # Both should have updated last_state_check_at
+        expect(infrastructure.reload.last_state_check_at).to be_present
+        expect(infra2.reload.last_state_check_at).to be_present
+      end
+    end
+  end
+
+  describe "state updates" do
+    before { infrastructure.update_columns(last_state_check_at: 2.minutes.ago) }
+
+    it "updates state from IM response" do
+      allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "configured" } })
+
+      described_class.perform_now(infrastructure.id)
+
+      expect(infrastructure.reload.state).to eq("configured")
+    end
+
+    it "handles failed state from IM" do
+      allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "failed" } })
+
+      described_class.perform_now(infrastructure.id)
+
+      expect(infrastructure.reload.state).to eq("failed")
+      expect(infrastructure.last_error).to include("failed")
+    end
+
+    it "logs warning when get_state fails" do
+      allow(im_client).to receive(:get_state).and_return({ success: false, error: "Connection timeout" })
+
+      expect(Rails.logger).to receive(:warn).with(/Could not get state/)
+
+      described_class.perform_now(infrastructure.id)
+
+      # State should remain unchanged
+      expect(infrastructure.reload.state).to eq("creating")
+    end
+  end
+
+  describe "output fetching" do
+    before { infrastructure.update_columns(last_state_check_at: 2.minutes.ago) }
+
+    it "fetches outputs when infrastructure is running" do
+      allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "running" } })
+      allow(im_client).to receive(:get_outputs).and_return(
+        { success: true, data: { "outputs" => { "jupyterhub_url" => "https://jupyter.example.com" } } }
+      )
+
+      described_class.perform_now(infrastructure.id)
+
+      expect(infrastructure.reload.outputs).to eq({ "jupyterhub_url" => "https://jupyter.example.com" })
+    end
+
+    it "skips output fetch if outputs already have jupyterhub_url" do
+      infrastructure.update_columns(outputs: { "jupyterhub_url" => "https://existing.com" })
+      allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "running" } })
+
+      expect(im_client).not_to receive(:get_outputs)
+
+      described_class.perform_now(infrastructure.id)
+    end
+
+    it "updates project_item deployment_link when jupyterhub_url is found" do
+      allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "running" } })
+      allow(im_client).to receive(:get_outputs).and_return(
+        { success: true, data: { "outputs" => { "jupyterhub_url" => "https://jupyter.example.com" } } }
+      )
+
+      described_class.perform_now(infrastructure.id)
+
+      expect(project_item.reload.deployment_link).to eq("https://jupyter.example.com")
+      expect(project_item.status).to include("Deployment ready")
+    end
+
+    it "does not update project_item if deployment_link matches" do
+      project_item.update!(deployment_link: "https://jupyter.example.com")
+      allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "running" } })
+      allow(im_client).to receive(:get_outputs).and_return(
+        { success: true, data: { "outputs" => { "jupyterhub_url" => "https://jupyter.example.com" } } }
+      )
+
+      expect(project_item).not_to receive(:update!)
+
+      described_class.perform_now(infrastructure.id)
+    end
+
+    it "handles empty outputs gracefully" do
+      allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "running" } })
+      allow(im_client).to receive(:get_outputs).and_return({ success: true, data: { "outputs" => {} } })
+
+      described_class.perform_now(infrastructure.id)
+
+      expect(infrastructure.reload.outputs).to eq({})
+    end
+
+    it "handles get_outputs failure gracefully" do
+      allow(im_client).to receive(:get_state).and_return({ success: true, data: { "state" => "running" } })
+      allow(im_client).to receive(:get_outputs).and_return({ success: false, error: "Failed" })
+
+      # Should not raise
+      described_class.perform_now(infrastructure.id)
+
+      expect(infrastructure.reload.state).to eq("running")
+    end
+  end
+
+  describe "job configuration" do
+    it "uses the default queue" do
+      expect(described_class.new.queue_name).to eq("default")
+    end
+  end
+end

--- a/spec/models/concerns/orderable_resource_interface_spec.rb
+++ b/spec/models/concerns/orderable_resource_interface_spec.rb
@@ -1,0 +1,357 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "OrderableResource interface compatibility", type: :model do
+  # This spec ensures that both Service and DeployableService implement
+  # a compatible interface. This is critical for the ordering wizard,
+  # offer associations, and views that need to work with both types.
+  #
+  # These tests should pass BEFORE and AFTER the OrderableResource
+  # concern refactoring.
+
+  let(:provider) { create(:provider) }
+  let(:catalogue) { create(:catalogue) }
+  let(:service_category) { create(:service_category) }
+
+  shared_examples "orderable resource interface" do |resource_class|
+    let(:resource) do
+      if resource_class == Service
+        # Pass providers: [provider] to override factory sequence
+        create(
+          :service,
+          resource_organisation: provider,
+          providers: [provider],
+          catalogue: catalogue,
+          status: :published
+        )
+      else
+        create(:deployable_service, resource_organisation: provider, catalogue: catalogue, status: :published)
+      end
+    end
+
+    describe "#{resource_class} - required attributes" do
+      it "responds to name" do
+        expect(resource).to respond_to(:name)
+        expect(resource.name).to be_a(String)
+      end
+
+      it "responds to description" do
+        expect(resource).to respond_to(:description)
+        expect(resource.description).to be_a(String)
+      end
+
+      it "responds to tagline" do
+        expect(resource).to respond_to(:tagline)
+        expect(resource.tagline).to be_a(String)
+      end
+
+      it "responds to slug" do
+        expect(resource).to respond_to(:slug)
+        expect(resource.slug).to be_a(String)
+      end
+
+      it "responds to status" do
+        expect(resource).to respond_to(:status)
+        expect(resource.status).to be_present
+      end
+
+      it "responds to order_type" do
+        expect(resource).to respond_to(:order_type)
+        expect(resource.order_type).to be_present
+      end
+
+      it "responds to abbreviation" do
+        expect(resource).to respond_to(:abbreviation)
+      end
+    end
+
+    describe "#{resource_class} - required associations" do
+      it "responds to offers" do
+        expect(resource).to respond_to(:offers)
+        expect(resource.offers).to respond_to(:to_a)
+      end
+
+      it "responds to bundles" do
+        expect(resource).to respond_to(:bundles)
+      end
+
+      it "responds to resource_organisation" do
+        expect(resource).to respond_to(:resource_organisation)
+        expect(resource.resource_organisation).to eq(provider)
+      end
+
+      it "responds to catalogue" do
+        expect(resource).to respond_to(:catalogue)
+      end
+
+      it "responds to providers and includes resource_organisation" do
+        expect(resource).to respond_to(:providers)
+        # NOTE: Service returns CollectionProxy, DeployableService returns Array
+        # Both should be enumerable and include the provider
+        expect(resource.providers.to_a).to include(provider)
+      end
+
+      it "responds to scientific_domains" do
+        expect(resource).to respond_to(:scientific_domains)
+      end
+    end
+
+    describe "#{resource_class} - count methods" do
+      it "responds to offers_count" do
+        expect(resource).to respond_to(:offers_count)
+        expect(resource.offers_count).to be_a(Integer)
+      end
+
+      it "responds to bundles_count" do
+        expect(resource).to respond_to(:bundles_count)
+        expect(resource.bundles_count).to be_a(Integer)
+      end
+    end
+
+    describe "#{resource_class} - predicate methods" do
+      it "responds to offers?" do
+        expect(resource).to respond_to(:offers?)
+        expect(resource.offers?).to be_in([true, false])
+      end
+
+      it "responds to bundles?" do
+        expect(resource).to respond_to(:bundles?)
+        expect(resource.bundles?).to be_in([true, false])
+      end
+
+      it "responds to published?" do
+        expect(resource).to respond_to(:published?)
+        expect(resource.published?).to eq(true) # We created with status: :published
+      end
+
+      it "responds to suspended?" do
+        expect(resource).to respond_to(:suspended?)
+        expect(resource.suspended?).to eq(false)
+      end
+
+      it "responds to draft?" do
+        expect(resource).to respond_to(:draft?)
+        expect(resource.draft?).to eq(false)
+      end
+
+      it "responds to deleted?" do
+        expect(resource).to respond_to(:deleted?)
+        expect(resource.deleted?).to eq(false)
+      end
+    end
+
+    describe "#{resource_class} - ownership" do
+      let(:other_user) { create(:user) }
+
+      it "responds to owned_by?" do
+        expect(resource).to respond_to(:owned_by?)
+      end
+
+      it "returns false for non-administrator" do
+        expect(resource.owned_by?(other_user)).to eq(false)
+      end
+
+      it "handles nil user gracefully" do
+        # NOTE: Service and DeployableService handle nil differently
+        # DeployableService: returns false
+        # Service: raises error (bug to fix in refactoring)
+        if resource_class == DeployableService
+          expect(resource.owned_by?(nil)).to eq(false)
+        else
+          # Service currently raises error on nil - this is a known inconsistency
+          expect { resource.owned_by?(nil) }.to raise_error(NoMethodError)
+        end
+      end
+
+      # NOTE: Testing positive ownership case is complex due to different
+      # ownership mechanisms (Service: owners/service_user_relationships,
+      # DeployableService: data_administrators on resource_organisation).
+      # This is tested in the individual model specs.
+    end
+
+    describe "#{resource_class} - search links" do
+      it "responds to organisation_search_link" do
+        expect(resource).to respond_to(:organisation_search_link)
+      end
+
+      it "responds to provider_search_link" do
+        expect(resource).to respond_to(:provider_search_link)
+      end
+
+      it "responds to node_search_link" do
+        expect(resource).to respond_to(:node_search_link)
+      end
+    end
+
+    describe "#{resource_class} - URL helpers" do
+      it "responds to to_param" do
+        expect(resource).to respond_to(:to_param)
+        expect(resource.to_param).to be_present
+      end
+    end
+
+    describe "#{resource_class} - offers association with scopes" do
+      # Create a fresh resource without factory-generated offers
+      let(:clean_resource) do
+        if resource_class == Service
+          create(:service, resource_organisation: provider, catalogue: catalogue, status: :published, offers: [])
+        else
+          create(:deployable_service, resource_organisation: provider, catalogue: catalogue, status: :published)
+        end
+      end
+
+      let!(:published_offer) do
+        if resource_class == Service
+          create(
+            :offer,
+            service: clean_resource,
+            deployable_service: nil,
+            offer_category: service_category,
+            status: :published,
+            bundle_exclusive: false
+          )
+        else
+          create(
+            :offer,
+            service: nil,
+            deployable_service: clean_resource,
+            offer_category: service_category,
+            status: :published,
+            bundle_exclusive: false
+          )
+        end
+      end
+
+      let!(:draft_offer) do
+        if resource_class == Service
+          create(
+            :offer,
+            service: clean_resource,
+            deployable_service: nil,
+            offer_category: service_category,
+            status: :draft
+          )
+        else
+          create(
+            :offer,
+            service: nil,
+            deployable_service: clean_resource,
+            offer_category: service_category,
+            status: :draft
+          )
+        end
+      end
+
+      it "includes offers in the association" do
+        clean_resource.reload
+        expect(clean_resource.offers).to include(published_offer)
+        expect(clean_resource.offers).to include(draft_offer)
+      end
+
+      it "offers respond to inclusive scope" do
+        expect(clean_resource.offers).to respond_to(:inclusive)
+      end
+
+      it "inclusive scope returns only published non-exclusive offers" do
+        inclusive = clean_resource.offers.inclusive
+        expect(inclusive).to include(published_offer)
+        expect(inclusive).not_to include(draft_offer)
+      end
+
+      it "offers respond to accessible scope" do
+        expect(clean_resource.offers).to respond_to(:accessible)
+      end
+
+      it "offers respond to active scope" do
+        expect(clean_resource.offers).to respond_to(:active)
+      end
+    end
+
+    describe "#{resource_class} - wizard compatibility" do
+      it "can be used with ProjectItem::Wizard" do
+        wizard = nil
+        expect { wizard = ProjectItem::Wizard.new(resource) }.not_to raise_error
+        expect(wizard).to be_a(ProjectItem::Wizard)
+      end
+
+      it "wizard can create steps" do
+        wizard = ProjectItem::Wizard.new(resource)
+        expect { wizard.step(:choose_offer, {}) }.not_to raise_error
+        expect { wizard.step(:information, {}) }.not_to raise_error
+        expect { wizard.step(:configuration, {}) }.not_to raise_error
+        expect { wizard.step(:summary, {}) }.not_to raise_error
+      end
+    end
+
+    describe "#{resource_class} - view compatibility methods" do
+      # Methods commonly accessed in views
+      it "responds to rating" do
+        expect(resource).to respond_to(:rating)
+      end
+
+      it "responds to popularity_ratio" do
+        expect(resource).to respond_to(:popularity_ratio)
+      end
+
+      it "responds to service_opinion_count" do
+        expect(resource).to respond_to(:service_opinion_count)
+      end
+
+      it "responds to horizontal" do
+        expect(resource).to respond_to(:horizontal)
+      end
+
+      it "responds to public_contacts" do
+        expect(resource).to respond_to(:public_contacts)
+      end
+
+      it "responds to main_contact" do
+        expect(resource).to respond_to(:main_contact)
+      end
+
+      it "responds to categories" do
+        expect(resource).to respond_to(:categories)
+      end
+
+      it "responds to target_users" do
+        expect(resource).to respond_to(:target_users)
+      end
+
+      it "responds to geographical_availabilities" do
+        expect(resource).to respond_to(:geographical_availabilities)
+      end
+    end
+  end
+
+  describe "Service" do
+    include_examples "orderable resource interface", Service
+  end
+
+  describe "DeployableService" do
+    include_examples "orderable resource interface", DeployableService
+  end
+
+  describe "cross-type consistency" do
+    let(:service) { create(:service, resource_organisation: provider, providers: [provider], status: :published) }
+    let(:deployable_service) { create(:deployable_service, resource_organisation: provider, status: :published) }
+
+    it "both return providers including resource_organisation" do
+      # Both should include the provider in their providers list
+      # Note: Service.providers returns CollectionProxy, DS returns Array
+      expect(service.providers.to_a).to include(provider)
+      expect(deployable_service.providers.to_a).to include(provider)
+    end
+
+    it "both have consistent status methods" do
+      expect(service.published?).to eq(deployable_service.published?)
+      expect(service.draft?).to eq(deployable_service.draft?)
+    end
+
+    it "both work with policy scope" do
+      # Ensure policies work with both types
+      expect { Pundit.policy_scope(nil, Service) }.not_to raise_error
+      expect { Pundit.policy_scope(nil, DeployableService) }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/concerns/orderable_resource_spec.rb
+++ b/spec/models/concerns/orderable_resource_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrderableResource, type: :model do
+  # Test the concern through DeployableService which includes it
+  let(:provider) { create(:provider) }
+  let(:catalogue) { create(:catalogue) }
+
+  describe "included scopes" do
+    let!(:published_ds) do
+      create(:deployable_service, resource_organisation: provider, catalogue: catalogue, status: :published)
+    end
+    let!(:draft_ds) do
+      create(:deployable_service, resource_organisation: provider, catalogue: catalogue, status: :draft)
+    end
+    let!(:suspended_ds) do
+      create(:deployable_service, resource_organisation: provider, catalogue: catalogue, status: :suspended)
+    end
+    let!(:deleted_ds) do
+      create(:deployable_service, resource_organisation: provider, catalogue: catalogue, status: :deleted)
+    end
+
+    describe ".visible" do
+      it "includes published and unverified resources" do
+        expect(DeployableService.visible).to include(published_ds)
+      end
+
+      it "excludes draft resources" do
+        expect(DeployableService.visible).not_to include(draft_ds)
+      end
+
+      it "excludes deleted resources" do
+        expect(DeployableService.visible).not_to include(deleted_ds)
+      end
+    end
+
+    describe ".active" do
+      it "includes published resources" do
+        expect(DeployableService.active).to include(published_ds)
+      end
+
+      it "excludes draft resources" do
+        expect(DeployableService.active).not_to include(draft_ds)
+      end
+
+      it "excludes suspended resources" do
+        expect(DeployableService.active).not_to include(suspended_ds)
+      end
+
+      it "excludes deleted resources" do
+        expect(DeployableService.active).not_to include(deleted_ds)
+      end
+    end
+  end
+
+  describe "shared method implementations" do
+    let(:deployable_service) { create(:deployable_service, resource_organisation: provider, status: :published) }
+
+    describe "#offers?" do
+      context "when resource has offers" do
+        let(:service_category) { create(:service_category) }
+
+        before do
+          create(:offer, service: nil, deployable_service: deployable_service, offer_category: service_category)
+        end
+
+        it "returns true" do
+          expect(deployable_service.reload.offers?).to be true
+        end
+      end
+
+      context "when resource has no offers" do
+        it "returns false" do
+          expect(deployable_service.offers?).to be false
+        end
+      end
+    end
+
+    describe "#bundles?" do
+      context "when resource has no bundles" do
+        it "returns false" do
+          expect(deployable_service.bundles?).to be false
+        end
+      end
+    end
+
+    describe "#suspended?" do
+      it "returns true when status is suspended" do
+        deployable_service.status = "suspended"
+        expect(deployable_service.suspended?).to be true
+      end
+
+      it "returns false when status is not suspended" do
+        expect(deployable_service.suspended?).to be false
+      end
+    end
+
+    describe "#deleted?" do
+      it "returns true when status is deleted" do
+        deployable_service.status = "deleted"
+        expect(deployable_service.deleted?).to be true
+      end
+
+      it "returns false when status is not deleted" do
+        expect(deployable_service.deleted?).to be false
+      end
+    end
+
+    describe "#draft?" do
+      it "returns true when status is draft" do
+        deployable_service.status = "draft"
+        expect(deployable_service.draft?).to be true
+      end
+
+      it "returns false when status is not draft" do
+        expect(deployable_service.draft?).to be false
+      end
+    end
+
+    describe "#published?" do
+      it "returns true when status is published" do
+        expect(deployable_service.published?).to be true
+      end
+
+      it "returns false when status is not published" do
+        deployable_service.status = "draft"
+        expect(deployable_service.published?).to be false
+      end
+    end
+  end
+
+  describe "search link methods" do
+    let(:deployable_service) { create(:deployable_service, resource_organisation: provider, status: :published) }
+
+    context "when external search is enabled" do
+      let(:search_base_url) { "https://search.example.com" }
+
+      before do
+        allow(Mp::Application.config).to receive(:enable_external_search).and_return(true)
+        allow(Mp::Application.config).to receive(:search_service_base_url).and_return(search_base_url)
+      end
+
+      describe "#organisation_search_link" do
+        it "returns external search URL with resource_organisation filter" do
+          result = deployable_service.organisation_search_link("Test Provider")
+          expect(result).to eq("#{search_base_url}/search/service?q=*&fq=resource_organisation:(%22Test Provider%22)")
+        end
+      end
+
+      describe "#node_search_link" do
+        it "returns external search URL with node filter" do
+          result = deployable_service.node_search_link("Test Node")
+          expect(result).to eq("#{search_base_url}/search/service?q=*&fq=node:(%22Test Node%22)")
+        end
+      end
+
+      describe "#provider_search_link" do
+        it "returns external search URL with providers filter" do
+          result = deployable_service.provider_search_link("Test Provider")
+          expect(result).to eq("#{search_base_url}/search/service?q=*&fq=providers:(%22Test Provider%22)")
+        end
+      end
+    end
+
+    context "when external search is disabled" do
+      before { allow(Mp::Application.config).to receive(:enable_external_search).and_return(false) }
+
+      describe "#organisation_search_link" do
+        it "returns the default path" do
+          result = deployable_service.organisation_search_link("Test Provider", "/fallback/path")
+          expect(result).to eq("/fallback/path")
+        end
+
+        it "returns nil if no default path provided" do
+          result = deployable_service.organisation_search_link("Test Provider")
+          expect(result).to be_nil
+        end
+      end
+
+      describe "#node_search_link" do
+        it "returns the default path" do
+          result = deployable_service.node_search_link("Test Node", "/node/path")
+          expect(result).to eq("/node/path")
+        end
+      end
+
+      describe "#provider_search_link" do
+        it "returns the default path" do
+          result = deployable_service.provider_search_link("Test Provider", "/provider/path")
+          expect(result).to eq("/provider/path")
+        end
+      end
+    end
+  end
+
+  describe "REQUIRED_METHODS constant" do
+    it "defines the methods that implementing classes must provide" do
+      expect(OrderableResource::REQUIRED_METHODS).to include(:name)
+      expect(OrderableResource::REQUIRED_METHODS).to include(:description)
+      expect(OrderableResource::REQUIRED_METHODS).to include(:offers)
+      expect(OrderableResource::REQUIRED_METHODS).to include(:resource_organisation)
+      expect(OrderableResource::REQUIRED_METHODS).to include(:owned_by?)
+    end
+  end
+end

--- a/spec/models/deployable_service_spec.rb
+++ b/spec/models/deployable_service_spec.rb
@@ -398,25 +398,9 @@ RSpec.describe DeployableService, backend: true do
       end
     end
 
-    describe "method_missing behavior" do
-      it "handles boolean methods with false return" do
-        expect(deployable_service.non_existent_method?).to be false
-      end
-
-      it "handles count methods with 0 return" do
-        expect(deployable_service.non_existent_count).to eq(0)
-      end
-
-      it "handles plural methods by returning empty collection" do
-        # This should return an empty collection for plural methods
-        expect { deployable_service.non_existent_items }.not_to raise_error
-        expect(deployable_service.non_existent_items).to eq([])
-      end
-
-      it "raises NoMethodError for unhandled methods" do
-        expect { deployable_service.completely_unknown_method }.to raise_error(NoMethodError)
-      end
-    end
+    # NOTE: method_missing behavior was intentionally removed in Phase 4 refactoring
+    # DeployableService now uses explicit methods via OrderableResource concern
+    # instead of duck-typing catch-all patterns
 
     describe "#offers_count" do
       it "returns 0 when no offers" do

--- a/spec/models/infrastructure_spec.rb
+++ b/spec/models/infrastructure_spec.rb
@@ -1,0 +1,339 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Infrastructure, type: :model do
+  let(:provider) { create(:provider) }
+  let(:deployable_service) { create(:deployable_service, resource_organisation: provider) }
+  let(:service_category) { create(:service_category) }
+  let(:offer) { create(:offer, service: nil, deployable_service: deployable_service, offer_category: service_category) }
+  let(:project) { create(:project) }
+  let(:project_item) { create(:project_item, offer: offer, project: project) }
+
+  let(:infrastructure) do
+    Infrastructure.create!(
+      project_item: project_item,
+      im_base_url: "https://deploy.sandbox.eosc-beyond.eu",
+      cloud_site: "IISAS-FedCloud",
+      state: "pending"
+    )
+  end
+
+  # Helper to create additional project items for scope tests
+  def create_project_item_for_infra
+    create(:project_item, offer: offer, project: project)
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(infrastructure).to be_valid
+    end
+
+    it "requires project_item" do
+      infra = Infrastructure.new(im_base_url: "https://example.com", cloud_site: "test", state: "pending")
+      expect(infra).not_to be_valid
+      expect(infra.errors[:project_item]).to be_present
+    end
+
+    it "requires im_base_url" do
+      infra = Infrastructure.new(project_item: project_item, cloud_site: "test", state: "pending")
+      expect(infra).not_to be_valid
+      expect(infra.errors[:im_base_url]).to include("can't be blank")
+    end
+
+    it "requires cloud_site" do
+      infra = Infrastructure.new(project_item: project_item, im_base_url: "https://example.com", state: "pending")
+      expect(infra).not_to be_valid
+      expect(infra.errors[:cloud_site]).to include("can't be blank")
+    end
+
+    it "requires state to be a valid value" do
+      infra =
+        Infrastructure.new(
+          project_item: project_item,
+          im_base_url: "https://example.com",
+          cloud_site: "test",
+          state: "invalid_state"
+        )
+      expect(infra).not_to be_valid
+      expect(infra.errors[:state]).to be_present
+    end
+
+    it "allows all valid states" do
+      Infrastructure::STATES.each do |valid_state|
+        infra =
+          Infrastructure.new(
+            project_item: project_item,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: valid_state
+          )
+        expect(infra).to be_valid, "Expected state '#{valid_state}' to be valid"
+      end
+    end
+
+    it "enforces uniqueness of im_infrastructure_id" do
+      infrastructure.update!(im_infrastructure_id: "unique-id-123")
+
+      project_item2 = create(:project_item, offer: offer, project: project)
+      duplicate =
+        Infrastructure.new(
+          project_item: project_item2,
+          im_base_url: "https://example.com",
+          cloud_site: "test",
+          state: "pending",
+          im_infrastructure_id: "unique-id-123"
+        )
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:im_infrastructure_id]).to be_present
+    end
+
+    it "allows nil im_infrastructure_id" do
+      expect(infrastructure.im_infrastructure_id).to be_nil
+      expect(infrastructure).to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "belongs to project_item" do
+      expect(infrastructure.project_item).to eq(project_item)
+    end
+
+    it "can access deployable_service through project_item" do
+      expect(infrastructure.deployable_service).to eq(deployable_service)
+    end
+  end
+
+  describe "scopes" do
+    describe ".active" do
+      it "excludes destroyed and failed infrastructures, includes others" do
+        pending_infra = infrastructure
+        running_infra =
+          Infrastructure.create!(
+            project_item: create_project_item_for_infra,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "running"
+          )
+
+        # Check active scope
+        active_ids = Infrastructure.active.pluck(:id)
+        expect(active_ids).to include(pending_infra.id, running_infra.id)
+
+        # Now mark one as destroyed and one as failed
+        running_infra.update_column(:state, "destroyed")
+        pending_infra.update_column(:state, "failed")
+
+        # Re-check - they should be excluded now
+        active_ids = Infrastructure.active.pluck(:id)
+        expect(active_ids).not_to include(running_infra.id)
+        expect(active_ids).not_to include(pending_infra.id)
+      end
+    end
+
+    describe ".pending_state_check" do
+      it "includes active infrastructures needing state check" do
+        old_check =
+          Infrastructure.create!(
+            project_item: create_project_item_for_infra,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "running",
+            last_state_check_at: 2.minutes.ago
+          )
+        never_checked = infrastructure # has nil last_state_check_at
+
+        pending_ids = Infrastructure.pending_state_check.pluck(:id)
+        expect(pending_ids).to include(old_check.id, never_checked.id)
+      end
+
+      it "excludes recently checked infrastructures" do
+        recently_checked =
+          Infrastructure.create!(
+            project_item: create_project_item_for_infra,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "running",
+            last_state_check_at: 30.seconds.ago
+          )
+
+        expect(Infrastructure.pending_state_check.pluck(:id)).not_to include(recently_checked.id)
+      end
+
+      it "excludes destroyed infrastructures" do
+        destroyed =
+          Infrastructure.create!(
+            project_item: create_project_item_for_infra,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "running",
+            last_state_check_at: 2.minutes.ago
+          )
+        destroyed.update_column(:state, "destroyed")
+
+        expect(Infrastructure.pending_state_check.pluck(:id)).not_to include(destroyed.id)
+      end
+    end
+  end
+
+  describe "state predicates" do
+    Infrastructure::STATES.each do |state_name|
+      describe "##{state_name}?" do
+        it "returns true when state is #{state_name}" do
+          infrastructure.state = state_name
+          expect(infrastructure.send("#{state_name}?")).to be true
+        end
+
+        it "returns false when state is not #{state_name}" do
+          other_state = (Infrastructure::STATES - [state_name]).first
+          infrastructure.state = other_state
+          expect(infrastructure.send("#{state_name}?")).to be false
+        end
+      end
+    end
+  end
+
+  describe "state transition methods" do
+    describe "#mark_created!" do
+      it "sets im_infrastructure_id and state to creating" do
+        infrastructure.mark_created!("infra-123")
+        expect(infrastructure.im_infrastructure_id).to eq("infra-123")
+        expect(infrastructure.state).to eq("creating")
+        expect(infrastructure.last_state_check_at).to be_present
+      end
+    end
+
+    describe "#mark_configured!" do
+      it "sets state to configured" do
+        infrastructure.mark_configured!
+        expect(infrastructure.state).to eq("configured")
+        expect(infrastructure.last_state_check_at).to be_present
+      end
+    end
+
+    describe "#mark_running!" do
+      it "sets state to running with outputs" do
+        outputs = { "jupyterhub_url" => "https://example.com/jupyter" }
+        infrastructure.mark_running!(outputs)
+        expect(infrastructure.state).to eq("running")
+        expect(infrastructure.outputs).to eq(outputs)
+        expect(infrastructure.last_error).to be_nil
+      end
+
+      it "clears last_error when marking running" do
+        infrastructure.update!(last_error: "previous error")
+        infrastructure.mark_running!
+        expect(infrastructure.last_error).to be_nil
+      end
+    end
+
+    describe "#mark_failed!" do
+      it "sets state to failed with error message" do
+        infrastructure.mark_failed!("Something went wrong")
+        expect(infrastructure.state).to eq("failed")
+        expect(infrastructure.last_error).to eq("Something went wrong")
+      end
+
+      it "increments retry_count" do
+        expect { infrastructure.mark_failed!("error") }.to change { infrastructure.retry_count }.by(1)
+      end
+    end
+
+    describe "#mark_destroyed!" do
+      it "sets state to destroyed" do
+        infrastructure.update_columns(im_infrastructure_id: "infra-123", state: "running")
+        infrastructure.mark_destroyed!
+        expect(infrastructure.reload.state).to eq("destroyed")
+        expect(infrastructure.last_state_check_at).to be_present
+      end
+    end
+  end
+
+  describe "#update_state_from_im!" do
+    it "maps 'pending' to creating" do
+      infrastructure.update_state_from_im!("pending")
+      expect(infrastructure.state).to eq("creating")
+    end
+
+    it "maps 'configured' to configured" do
+      infrastructure.update_state_from_im!("configured")
+      expect(infrastructure.state).to eq("configured")
+    end
+
+    it "maps 'running' to running" do
+      infrastructure.update_state_from_im!("running")
+      expect(infrastructure.state).to eq("running")
+    end
+
+    it "maps 'stopped' to running (infrastructure still exists)" do
+      infrastructure.update_state_from_im!("stopped")
+      expect(infrastructure.state).to eq("running")
+    end
+
+    it "maps 'failed' to failed with error" do
+      infrastructure.update_state_from_im!("failed")
+      expect(infrastructure.state).to eq("failed")
+      expect(infrastructure.last_error).to include("failed")
+    end
+
+    it "handles case-insensitive states" do
+      infrastructure.update_state_from_im!("RUNNING")
+      expect(infrastructure.state).to eq("running")
+    end
+
+    it "handles unknown states gracefully" do
+      expect(Rails.logger).to receive(:warn).with(/Unknown IM state/)
+      infrastructure.update_state_from_im!("unknown_state")
+      expect(infrastructure.last_state_check_at).to be_present
+    end
+  end
+
+  describe "#can_destroy?" do
+    it "returns true for running infrastructure with im_infrastructure_id" do
+      infrastructure.update!(state: "running", im_infrastructure_id: "infra-123")
+      expect(infrastructure.can_destroy?).to be true
+    end
+
+    it "returns true for failed infrastructure with im_infrastructure_id" do
+      infrastructure.update!(state: "failed", im_infrastructure_id: "infra-123")
+      expect(infrastructure.can_destroy?).to be true
+    end
+
+    it "returns false for destroyed infrastructure" do
+      infrastructure.update_columns(state: "destroyed", im_infrastructure_id: "infra-123")
+      expect(infrastructure.can_destroy?).to be false
+    end
+
+    it "returns false without im_infrastructure_id" do
+      infrastructure.update!(state: "running", im_infrastructure_id: nil)
+      expect(infrastructure.can_destroy?).to be false
+    end
+
+    it "returns false for pending infrastructure" do
+      infrastructure.update!(state: "pending", im_infrastructure_id: "infra-123")
+      expect(infrastructure.can_destroy?).to be false
+    end
+  end
+
+  describe "#deployment_url" do
+    it "returns jupyterhub_url from outputs" do
+      infrastructure.update!(outputs: { "jupyterhub_url" => "https://jupyter.example.com" })
+      expect(infrastructure.deployment_url).to eq("https://jupyter.example.com")
+    end
+
+    it "falls back to public_url" do
+      infrastructure.update!(outputs: { "public_url" => "https://public.example.com" })
+      expect(infrastructure.deployment_url).to eq("https://public.example.com")
+    end
+
+    it "falls back to endpoint" do
+      infrastructure.update!(outputs: { "endpoint" => "https://endpoint.example.com" })
+      expect(infrastructure.deployment_url).to eq("https://endpoint.example.com")
+    end
+
+    it "returns nil when no URL outputs" do
+      infrastructure.update!(outputs: {})
+      expect(infrastructure.deployment_url).to be_nil
+    end
+  end
+end

--- a/spec/models/offer_parent_service_spec.rb
+++ b/spec/models/offer_parent_service_spec.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Offer parent service compatibility", type: :model do
+  # This spec ensures that Offer works correctly with both Service
+  # and DeployableService as parent. This is critical for the polymorphic
+  # refactoring - these tests should pass before and after.
+
+  let(:provider) { create(:provider) }
+  let(:service_category) { create(:service_category) }
+
+  describe "Offer with Service parent" do
+    # Create service without factory-generated offers
+    let(:service) { create(:service, resource_organisation: provider, status: :published, offers: []) }
+    let(:offer) do
+      create(
+        :offer,
+        service: service,
+        deployable_service: nil,
+        offer_category: service_category,
+        status: :published,
+        bundle_exclusive: false
+      )
+    end
+
+    describe "parent_service accessor" do
+      it "returns the service" do
+        expect(offer.parent_service).to eq(service)
+      end
+
+      it "returns service via service accessor" do
+        expect(offer.service).to eq(service)
+      end
+
+      it "returns nil via deployable_service accessor" do
+        expect(offer.deployable_service).to be_nil
+      end
+    end
+
+    describe "association from parent" do
+      it "is included in service.offers" do
+        offer # trigger creation
+        service.reload
+        expect(service.offers).to include(offer)
+      end
+
+      it "increments service offers_count" do
+        offer # trigger creation
+        expect(service.reload.offers_count).to be >= 1
+      end
+    end
+
+    describe "scopes" do
+      it "is included in Offer.inclusive" do
+        expect(Offer.inclusive).to include(offer)
+      end
+
+      it "is included in Offer.accessible" do
+        expect(Offer.accessible).to include(offer)
+      end
+
+      it "is excluded from inclusive when service is draft" do
+        service.update!(status: :draft)
+        expect(Offer.inclusive).not_to include(offer)
+      end
+
+      it "is excluded from inclusive when bundle_exclusive" do
+        offer.update!(bundle_exclusive: true)
+        expect(Offer.inclusive).not_to include(offer)
+      end
+    end
+
+    describe "order_type validation" do
+      it "validates order_type matches service" do
+        # First published offer should match service order_type
+        expect(offer).to be_valid
+      end
+    end
+  end
+
+  describe "Offer with DeployableService parent" do
+    let(:deployable_service) { create(:deployable_service, resource_organisation: provider, status: :published) }
+    let(:offer) do
+      create(
+        :offer,
+        service: nil,
+        deployable_service: deployable_service,
+        offer_category: service_category,
+        status: :published,
+        bundle_exclusive: false
+      )
+    end
+
+    describe "parent_service accessor" do
+      it "returns the deployable_service" do
+        expect(offer.parent_service).to eq(deployable_service)
+      end
+
+      it "returns nil via service accessor" do
+        expect(offer.service).to be_nil
+      end
+
+      it "returns deployable_service via deployable_service accessor" do
+        expect(offer.deployable_service).to eq(deployable_service)
+      end
+    end
+
+    describe "association from parent" do
+      it "is included in deployable_service.offers" do
+        expect(deployable_service.offers).to include(offer)
+      end
+    end
+
+    describe "scopes" do
+      it "is included in Offer.inclusive" do
+        expect(Offer.inclusive).to include(offer)
+      end
+
+      it "is included in Offer.accessible" do
+        expect(Offer.accessible).to include(offer)
+      end
+
+      it "is excluded from inclusive when deployable_service is draft" do
+        deployable_service.update!(status: :draft)
+        expect(Offer.inclusive).not_to include(offer)
+      end
+    end
+  end
+
+  describe "validation: orderable must be present" do
+    let(:service) { create(:service, resource_organisation: provider) }
+    let(:deployable_service) { create(:deployable_service, resource_organisation: provider) }
+
+    it "is invalid without any orderable" do
+      offer = build(:offer, service: nil, deployable_service: nil, offer_category: service_category)
+      expect(offer).not_to be_valid
+      expect(offer.errors[:base]).to include("Must belong to either service or deployable service")
+    end
+
+    it "is valid with service as orderable" do
+      offer = build(:offer, service: service, offer_category: service_category)
+      expect(offer).to be_valid
+      expect(offer.orderable).to eq(service)
+    end
+
+    it "is valid with deployable_service as orderable" do
+      offer = build(:offer, deployable_service: deployable_service, offer_category: service_category)
+      expect(offer).to be_valid
+      expect(offer.orderable).to eq(deployable_service)
+    end
+
+    it "uses service when both are provided (service takes precedence)" do
+      # With polymorphic association, only one orderable can be set
+      # Factory gives precedence to service when both are provided
+      offer = build(:offer, service: service, deployable_service: deployable_service, offer_category: service_category)
+      expect(offer).to be_valid
+      expect(offer.orderable).to eq(service)
+    end
+  end
+
+  describe "ProjectItem creation" do
+    let(:user) { create(:user) }
+    let(:project) { create(:project, user: user) }
+
+    context "with Service offer" do
+      let(:service) { create(:service, resource_organisation: provider, status: :published) }
+      let(:offer) do
+        create(:offer, service: service, deployable_service: nil, offer_category: service_category, status: :published)
+      end
+
+      it "creates project item successfully" do
+        project_item = create(:project_item, offer: offer, project: project)
+        expect(project_item).to be_persisted
+      end
+
+      it "project_item.service returns the service" do
+        project_item = create(:project_item, offer: offer, project: project)
+        expect(project_item.service).to eq(service)
+      end
+
+      it "project_item.offer.parent_service returns the service" do
+        project_item = create(:project_item, offer: offer, project: project)
+        expect(project_item.offer.parent_service).to eq(service)
+      end
+    end
+
+    context "with DeployableService offer" do
+      let(:deployable_service) { create(:deployable_service, resource_organisation: provider, status: :published) }
+      let(:offer) do
+        create(
+          :offer,
+          service: nil,
+          deployable_service: deployable_service,
+          offer_category: service_category,
+          status: :published
+        )
+      end
+
+      it "creates project item successfully" do
+        project_item = create(:project_item, offer: offer, project: project)
+        expect(project_item).to be_persisted
+      end
+
+      it "project_item.service returns the deployable_service" do
+        project_item = create(:project_item, offer: offer, project: project)
+        expect(project_item.service).to eq(deployable_service)
+      end
+
+      it "project_item.offer.parent_service returns the deployable_service" do
+        project_item = create(:project_item, offer: offer, project: project)
+        expect(project_item.offer.parent_service).to eq(deployable_service)
+      end
+    end
+  end
+
+  describe "mixed offers in same query" do
+    let(:service) { create(:service, resource_organisation: provider, status: :published) }
+    let(:deployable_service) { create(:deployable_service, resource_organisation: provider, status: :published) }
+
+    let!(:service_offer) do
+      create(
+        :offer,
+        service: service,
+        deployable_service: nil,
+        offer_category: service_category,
+        status: :published,
+        bundle_exclusive: false
+      )
+    end
+
+    let!(:ds_offer) do
+      create(
+        :offer,
+        service: nil,
+        deployable_service: deployable_service,
+        offer_category: service_category,
+        status: :published,
+        bundle_exclusive: false
+      )
+    end
+
+    it "Offer.inclusive includes both types" do
+      inclusive = Offer.inclusive
+      expect(inclusive).to include(service_offer)
+      expect(inclusive).to include(ds_offer)
+    end
+
+    it "Offer.accessible includes both types" do
+      accessible = Offer.accessible
+      expect(accessible).to include(service_offer)
+      expect(accessible).to include(ds_offer)
+    end
+
+    it "each offer has correct parent_service" do
+      expect(service_offer.parent_service).to eq(service)
+      expect(ds_offer.parent_service).to eq(deployable_service)
+    end
+
+    it "Offer.all includes both types" do
+      expect(Offer.all).to include(service_offer)
+      expect(Offer.all).to include(ds_offer)
+    end
+  end
+
+  describe "counter cache behavior" do
+    context "for Service" do
+      let(:service) { create(:service, resource_organisation: provider, status: :published, offers_count: 0) }
+
+      it "increments offers_count when published offer created" do
+        expect do
+          create(
+            :offer,
+            service: service,
+            deployable_service: nil,
+            offer_category: service_category,
+            status: :published
+          )
+        end.to change { service.reload.offers_count }.by(1)
+      end
+    end
+
+    context "for DeployableService" do
+      let(:deployable_service) { create(:deployable_service, resource_organisation: provider, status: :published) }
+
+      it "offers_count reflects actual offers" do
+        create(
+          :offer,
+          service: nil,
+          deployable_service: deployable_service,
+          offer_category: service_category,
+          status: :published
+        )
+        # DeployableService calculates offers_count dynamically
+        expect(deployable_service.offers_count).to eq(1)
+      end
+    end
+  end
+
+  describe "policy compatibility" do
+    let(:user) { create(:user) }
+    let(:service) { create(:service, resource_organisation: provider, status: :published) }
+    let(:deployable_service) { create(:deployable_service, resource_organisation: provider, status: :published) }
+
+    let(:service_offer) do
+      create(:offer, service: service, deployable_service: nil, offer_category: service_category, status: :published)
+    end
+
+    let(:ds_offer) do
+      create(
+        :offer,
+        service: nil,
+        deployable_service: deployable_service,
+        offer_category: service_category,
+        status: :published
+      )
+    end
+
+    it "OfferPolicy works with service offer" do
+      expect { Pundit.policy(user, service_offer) }.not_to raise_error
+    end
+
+    it "OfferPolicy works with deployable_service offer" do
+      expect { Pundit.policy(user, ds_offer) }.not_to raise_error
+    end
+  end
+end

--- a/spec/policies/project_item_policy_spec.rb
+++ b/spec/policies/project_item_policy_spec.rb
@@ -28,4 +28,80 @@ RSpec.describe ProjectItemPolicy, backend: true do
       expect(subject).to_not permit(user, build(:project_item))
     end
   end
+
+  permissions :destroy_infrastructure? do
+    let(:provider) { create(:provider) }
+    let(:deployable_service) { create(:deployable_service, resource_organisation: provider) }
+    let(:service_category) { create(:service_category) }
+    let(:offer) do
+      create(:offer, service: nil, deployable_service: deployable_service, offer_category: service_category)
+    end
+    let(:project) { create(:project, user: user) }
+    let(:project_item) { create(:project_item, offer: offer, project: project) }
+
+    context "with destroyable infrastructure" do
+      let!(:infrastructure) do
+        Infrastructure.create!(
+          project_item: project_item,
+          im_base_url: "https://example.com",
+          cloud_site: "test",
+          state: "running",
+          im_infrastructure_id: "infra-123"
+        )
+      end
+
+      it "grants access to project owner" do
+        expect(subject).to permit(user, project_item)
+      end
+
+      it "denies access to non-owner" do
+        other_user = create(:user)
+        expect(subject).not_to permit(other_user, project_item)
+      end
+
+      it "denies access to nil user" do
+        expect(subject).not_to permit(nil, project_item)
+      end
+    end
+
+    context "without infrastructure" do
+      it "denies access even to project owner" do
+        expect(subject).not_to permit(user, project_item)
+      end
+    end
+
+    context "with non-destroyable infrastructure" do
+      let!(:infrastructure) do
+        Infrastructure.create!(
+          project_item: project_item,
+          im_base_url: "https://example.com",
+          cloud_site: "test",
+          state: "pending"
+        )
+      end
+
+      it "denies access when infrastructure cannot be destroyed" do
+        expect(subject).not_to permit(user, project_item)
+      end
+    end
+
+    context "with already destroyed infrastructure" do
+      let!(:infrastructure) do
+        infra =
+          Infrastructure.create!(
+            project_item: project_item,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "running",
+            im_infrastructure_id: "infra-123"
+          )
+        infra.update_columns(state: "destroyed")
+        infra
+      end
+
+      it "denies access for destroyed infrastructure" do
+        expect(subject).not_to permit(user, project_item)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/ess/offers_controller_spec.rb
+++ b/spec/requests/api/v1/ess/offers_controller_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe Api::V1::Ess::OffersController, swagger_doc: "v1/ess_swagger.json
 
         let!(:manager) { create(:user, roles: [:coordinator]) }
         let!(:offers) { create_list(:offer, 2) }
-        let!(:second_offer) { create(:offer, service_id: offers.first.service_id) }
+        let!(:second_offer) { create(:offer, orderable: offers.first.orderable) }
         let!(:draft_service) { create(:service, status: :draft) }
-        let!(:published_offer_draft_service) { create(:offer, service: draft_service) }
-        let!(:draft) { create(:offer, service_id: offers.second.service_id, status: :draft) }
+        let!(:published_offer_draft_service) { create(:offer, orderable: draft_service) }
+        let!(:draft) { create(:offer, orderable: offers.second.orderable, status: :draft) }
         let!(:deleted) { create(:offer, status: :deleted) }
 
         let(:"X-User-Token") { manager.authentication_token }
@@ -44,8 +44,8 @@ RSpec.describe Api::V1::Ess::OffersController, swagger_doc: "v1/ess_swagger.json
         let!(:regular_user) { create(:user) }
         let!(:manager) { create(:user, roles: [:coordinator]) }
         let!(:offers) { create_list(:offer, 3) }
-        let!(:second_offer) { create(:offer, service_id: offers.first.service_id) }
-        let!(:draft) { create(:offer, service_id: offers.second.service_id, status: :draft) }
+        let!(:second_offer) { create(:offer, orderable: offers.first.orderable) }
+        let!(:draft) { create(:offer, orderable: offers.second.orderable, status: :draft) }
         let!(:deleted) { create(:offer, status: :deleted) }
 
         let(:"X-User-Token") { regular_user.authentication_token }

--- a/spec/requests/projects/services/infrastructures_controller_spec.rb
+++ b/spec/requests/projects/services/infrastructures_controller_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Projects::Services::InfrastructuresController, type: :request do
+  let(:user) { create(:user) }
+  let(:project) { create(:project, user: user) }
+  let(:provider) { create(:provider) }
+  let(:deployable_service) { create(:deployable_service, resource_organisation: provider) }
+  let(:service_category) { create(:service_category) }
+  let(:offer) { create(:offer, service: nil, deployable_service: deployable_service, offer_category: service_category) }
+  let(:project_item) { create(:project_item, offer: offer, project: project) }
+
+  describe "DELETE /projects/:project_id/services/:service_id/infrastructure" do
+    context "when user is not logged in" do
+      it "redirects to login" do
+        delete project_service_infrastructure_path(project, project_item)
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "when user is logged in" do
+      before { login_as(user) }
+
+      context "with destroyable infrastructure" do
+        let!(:infrastructure) do
+          Infrastructure.create!(
+            project_item: project_item,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "running",
+            im_infrastructure_id: "infra-123"
+          )
+        end
+
+        it "enqueues the destroy job" do
+          expect { delete project_service_infrastructure_path(project, project_item) }.to have_enqueued_job(
+            Infrastructure::DestroyJob
+          ).with(infrastructure.id)
+        end
+
+        it "redirects to project service page" do
+          delete project_service_infrastructure_path(project, project_item)
+          expect(response).to redirect_to(project_service_path(project, project_item))
+        end
+
+        it "sets a success flash message" do
+          delete project_service_infrastructure_path(project, project_item)
+          expect(flash[:notice]).to include("destruction has been initiated")
+        end
+      end
+
+      context "without infrastructure" do
+        it "redirects to root with alert (not authorized)" do
+          delete project_service_infrastructure_path(project, project_item)
+          expect(response).to redirect_to(root_path(anchor: ""))
+          expect(flash[:alert]).to be_present
+        end
+
+        it "does not enqueue any job" do
+          expect { delete project_service_infrastructure_path(project, project_item) }.not_to have_enqueued_job(
+            Infrastructure::DestroyJob
+          )
+        end
+      end
+
+      context "with non-destroyable infrastructure" do
+        let!(:infrastructure) do
+          Infrastructure.create!(
+            project_item: project_item,
+            im_base_url: "https://example.com",
+            cloud_site: "test",
+            state: "pending"
+          )
+        end
+
+        it "redirects to root with alert (not authorized)" do
+          delete project_service_infrastructure_path(project, project_item)
+          expect(response).to redirect_to(root_path(anchor: ""))
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
+
+    context "when user is not the project owner" do
+      let(:other_user) { create(:user) }
+
+      before { login_as(other_user) }
+
+      let!(:infrastructure) do
+        Infrastructure.create!(
+          project_item: project_item,
+          im_base_url: "https://example.com",
+          cloud_site: "test",
+          state: "running",
+          im_infrastructure_id: "infra-123"
+        )
+      end
+
+      it "redirects to root with alert (not authorized)" do
+        delete project_service_infrastructure_path(project, project_item)
+        expect(response).to redirect_to(root_path(anchor: ""))
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+end

--- a/swagger/v1/ess/offer/offer_read.json
+++ b/swagger/v1/ess/offer/offer_read.json
@@ -30,6 +30,10 @@
     "service_id": {
       "type": "integer"
     },
+    "orderable_type": {
+      "type": "string",
+      "enum": ["Service", "DeployableService"]
+    },
     "status": {
       "type": "string",
       "enum": ["published", "draft", "deleted"]


### PR DESCRIPTION
Refactor Offer model to use polymorphic association for Service and DeployableService, and add infrastructure lifecycle management for deployable service deployments.

Polymorphic Orderable
---------------------
- Replace service_id and deployable_service_id columns with polymorphic orderable_type/orderable_id on offers table
- Add parent_service method as unified accessor for both types
- Add backward-compatible service/deployable_service accessors
- Create reusable join scopes: join_service, join_orderable, with_published_orderable and SQL constants for external use
- Update all policies, controllers, and serializers to use new scopes

OrderableResource Concern
-------------------------
- Extract shared interface for Service and DeployableService
- Define required methods: name, description, offers, owned_by?, etc.
- Add common scopes: visible, active

Infrastructure Tracking
-----------------------
- Add Infrastructure model with state machine (pending -> creating -> configured -> running -> failed/destroyed)
- Add InfrastructureManager::Client for IM API integration with token caching and refresh
- Add DeploymentJob for creating infrastructures
- Add StatePollingJob for monitoring infrastructure state
- Add DestroyJob and UI endpoint for infrastructure teardown
- Extract IM configuration to config/deployable_services.yml

Database Migrations
-------------------
- 20251213211539_make_offer_orderable_polymorphic
- 20251214080854_create_infrastructures
- 20251214143117_remove_deprecated_offer_columns
