### PR TITLE
fix:[#3531] Fix deployable services synchronization

### DIFF
--- a/app/services/deployable_service/pc_create_or_update.rb
+++ b/app/services/deployable_service/pc_create_or_update.rb
@@ -84,8 +84,8 @@ class DeployableService::PcCreateOrUpdate
       deployable_service.status = "errored"
       deployable_service.save(validate: false)
     end
+    DeployableServiceSource::Create.call(deployable_service)
 
-    deployable_service.save!(validate: false)
     deployable_service
   end
 end

--- a/app/services/deployable_service_source/create.rb
+++ b/app/services/deployable_service_source/create.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class DeployableServiceSource::Create < ApplicationService
+  def initialize(deployable_service, source_type = "eosc_registry")
+    super()
+    @deployable_service = deployable_service
+    @source_type = source_type
+  end
+
+  def call
+    new_source =
+      DeployableServiceSource.create(
+        deployable_service_id: @deployable_service.id,
+        source_type: @source_type,
+        eid: @deployable_service.pid,
+        errored: @deployable_service.errors.to_hash
+      )
+    @deployable_service.update(upstream_id: new_source.id)
+  end
+end

--- a/spec/factories/jms_deployable_service.rb
+++ b/spec/factories/jms_deployable_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :jms_deployable_service, class: Hash do
+    skip_create
+    transient do
+      eid { "deployable.service.1" }
+      name { "Test Deployable Service" }
+      provider_eid { "test.provider" }
+    end
+
+    initialize_with do
+      next(
+        {
+          "id" => eid,
+          "name" => name,
+          "acronym" => "TDS",
+          "description" => "A test deployable service for testing purposes",
+          "tagline" => "Test tagline",
+          "url" => "https://test.example.com",
+          "node" => "node-sandbox",
+          "version" => "1.0.0",
+          "softwareLicense" => "MIT",
+          "resourceOrganisation" => provider_eid,
+          "catalogueId" => nil,
+          "creators" => ["Test Creator"],
+          "tags" => %w[test deployable],
+          "scientificDomains" => [],
+          "lastUpdate" => "2024-01-01"
+        }
+      )
+    end
+  end
+end

--- a/spec/services/deployable_service/pc_create_or_update_spec.rb
+++ b/spec/services/deployable_service/pc_create_or_update_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeployableService::PcCreateOrUpdate, backend: true do
+  let(:provider_eid) { "test.provider" }
+  let!(:provider) { create(:provider, name: "Test Provider") }
+  let!(:provider_source) do
+    create(:provider_source, source_type: "eosc_registry", eid: provider_eid, provider: provider)
+  end
+
+  describe "#call" do
+    context "when creating a new deployable service" do
+      let(:jms_deployable_service) { build(:jms_deployable_service, provider_eid: provider_eid) }
+
+      it "creates a deployable service with a source" do
+        expect { described_class.new(jms_deployable_service, true).call }.to change(DeployableService, :count).by(
+          1
+        ).and change(DeployableServiceSource, :count).by(1)
+      end
+
+      it "sets the upstream_id on the deployable service" do
+        result = described_class.new(jms_deployable_service, true).call
+
+        expect(result.upstream_id).to be_present
+        expect(result.sources.first).to be_present
+        expect(result.sources.first.eid).to eq(jms_deployable_service["id"])
+      end
+
+      it "sets the source_type to eosc_registry" do
+        result = described_class.new(jms_deployable_service, true).call
+
+        expect(result.sources.first.source_type).to eq("eosc_registry")
+      end
+    end
+
+    context "when updating an existing deployable service" do
+      let!(:existing_ds) { create(:deployable_service, pid: "deployable.service.1", name: "Old Name") }
+      let!(:existing_source) do
+        create(:deployable_service_source, deployable_service: existing_ds, eid: "deployable.service.1")
+      end
+      let(:jms_deployable_service) do
+        build(:jms_deployable_service, eid: "deployable.service.1", name: "New Name", provider_eid: provider_eid)
+      end
+
+      before { existing_ds.update!(upstream_id: existing_source.id) }
+
+      it "updates the existing deployable service" do
+        expect { described_class.new(jms_deployable_service, true).call }.not_to change(DeployableService, :count)
+
+        existing_ds.reload
+        expect(existing_ds.name).to eq("New Name")
+      end
+
+      it "does not create a new source" do
+        expect { described_class.new(jms_deployable_service, true).call }.not_to change(DeployableServiceSource, :count)
+      end
+    end
+
+    context "when deployable service is inactive" do
+      let(:jms_deployable_service) { build(:jms_deployable_service, provider_eid: provider_eid) }
+
+      it "creates with draft status" do
+        result = described_class.new(jms_deployable_service, false).call
+
+        expect(result.status).to eq("draft")
+      end
+    end
+  end
+end

--- a/spec/services/deployable_service_source/create_spec.rb
+++ b/spec/services/deployable_service_source/create_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeployableServiceSource::Create, backend: true do
+  describe "#call" do
+    let(:deployable_service) { create(:deployable_service, pid: "test.deployable.service") }
+
+    it "creates a source for the deployable service" do
+      expect { described_class.new(deployable_service).call }.to change(DeployableServiceSource, :count).by(1)
+    end
+
+    it "sets the eid from the deployable service pid" do
+      described_class.new(deployable_service).call
+
+      source = deployable_service.sources.first
+      expect(source.eid).to eq("test.deployable.service")
+    end
+
+    it "sets the source_type to eosc_registry by default" do
+      described_class.new(deployable_service).call
+
+      source = deployable_service.sources.first
+      expect(source.source_type).to eq("eosc_registry")
+    end
+
+    it "sets the upstream_id on the deployable service" do
+      described_class.new(deployable_service).call
+
+      deployable_service.reload
+      expect(deployable_service.upstream_id).to eq(deployable_service.sources.first.id)
+    end
+  end
+end


### PR DESCRIPTION
Create DeployableServiceSource when syncing new DeployableServices from Provider Catalog, mirroring the pattern used by Service sync.