### PR TITLE
fix: repair dev:prime seed task crashing on fresh setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,14 @@ you can add new records by editing `db/data.yml`.
 It is important to remember that if some record
 is a parent for another, it must be written above its child.
 
+`dev:prime` saves records that are synced to Elasticsearch via Searchkick
+(`Service`, `Offer`, `Bundle`, `Provider`), so their indices must already
+exist beforehand, otherwise the task aborts partway through with
+`Searchkick::ImportError: index_not_found_exception`. Make sure Elasticsearch
+is running (see [docker compose](#docker-compose)), then run:
+
 ```shell
+./bin/rails searchkick:reindex:all
 ./bin/rails dev:prime
 ```
 

--- a/app/models/catalogue.rb
+++ b/app/models/catalogue.rb
@@ -90,7 +90,7 @@ class Catalogue < ApplicationRecord
   end
 
   def affiliations=(value)
-    super(value.compact_blank)
+    super(value&.compact_blank)
   end
 
   def hosting_legal_entity

--- a/db/data.yml
+++ b/db/data.yml
@@ -1128,6 +1128,7 @@ providers:
     country_alpha2: "PL"
     image_base_64: *provider_default_logo
 
+target_users:
   Researchers:
     name: &researchers "Researchers"
     description: "Someone who conducts scientific research, i.e., an organized and systematic investigation by using scientific methods."

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -116,6 +116,8 @@ namespace :dev do
   end
 
   def create_target_users(target_users_hash)
+    return unless target_users_hash
+
     puts "Generating target groups:"
     target_users_hash.each_value do |hash|
       parent = TargetUser.find_by(name: hash["parent"])


### PR DESCRIPTION
## Summary
- `db/data.yml` was missing its `target_users:` top-level key, leaving that block nested under `providers:`; `create_providers` then tried to build a provider out of each target-user entry and crashed on the missing `multimedia` key.
- `Catalogue#affiliations=` called `value.compact_blank` without a nil guard, unlike its sibling `participating_countries=`, so catalogues without affiliations in the seed data raised `NoMethodError`.
- `create_target_users` didn't guard against a missing `target_users` hash, unlike the other seed methods in the same file.
- Documented in the README that `dev:prime` requires Elasticsearch indices to exist beforehand (`searchkick:reindex:all`), since it saves Searchkick-backed records and otherwise aborts with `Searchkick::ImportError` partway through.

## Test plan
- [x] `bundle exec rails db:drop db:create db:migrate`
- [x] `bundle exec rails searchkick:reindex:all`
- [x] `bundle exec rails dev:prime` completes end-to-end with `Done!`
- [x] Verified record counts (58 services, 45 providers, 78 offers, 24 target users) and that all are synced to their Elasticsearch indices